### PR TITLE
Change the scala compiler download to https

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -320,7 +320,7 @@ def scala_repositories():
     name = "scala",
     strip_prefix = "scala-2.11.7",
     sha256 = "ffe4196f13ee98a66cf54baffb0940d29432b2bd820bd0781a8316eec22926d0",
-    url = "http://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz",
+    url = "https://downloads.typesafe.com/scala/2.11.7/scala-2.11.7.tgz",
     build_file_content = SCALA_BUILD_FILE,
   )
   native.http_file(


### PR DESCRIPTION
this started failing today prompting:

https://github.com/bazelbuild/bazel/issues/969

quickfix here.

Review @dinowernli 