### PR TITLE
deprecate scala_test suites

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,6 +277,7 @@ scala_test(name, srcs, suites, deps, data, main_class, resources, scalacopts, jv
 using the `scalatest` library. It may depend on `scala_library`,
 `scala_macro_library` and `java_library` rules.
 
-A `scala_test` requires a `suites` attribute, specifying the fully qualified
-(canonical) names of the test suites to run. In a future version, we might
-investigate lifting this requirement.
+A `scala_test` by default runs all tests in a given target.
+For backwards compatiblity it accepts a `suites` attribute which
+is ignored due to the ease with which that field is not correctly
+populated and tests are not run.

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -145,12 +145,6 @@ cd $0.runfiles
       output=ctx.outputs.executable,
       content=content)
 
-def _args_for_suites(suites):
-  args = ["-o"]
-  for suite in suites:
-    args.extend(["-s", suite])
-  return args
-
 def _write_test_launcher(ctx, jars):
   if len(ctx.attr.suites) != 0:
     print("suites attribute is deprecated. All scalatest test suites are run")

--- a/test/BUILD
+++ b/test/BUILD
@@ -38,10 +38,6 @@ scala_test(
     name = "HelloLibTest",
     size = "small",  # Not a macro, can pass test-specific attributes.
     srcs = ["HelloLibTest.scala"],
-    suites = [
-        "scala.test.ScalaSuite",
-        "scala.test.JavaSuite",
-    ],
     deps = [
         ":HelloLib",
     ],


### PR DESCRIPTION
In using the scala rules for a short time, we have already seen several instances of people forgetting to update the suites attribute.

This changes to always run all tests in the target, print the timing for each test in the target (in the standard out) as well as full stack traces of errors.

what do you think @dinowernli 