### PR TITLE
Add scala_version function

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,10 @@
 workspace(name = "io_bazel_rules_scala")
 
-load("//scala:scala.bzl", "scala_repositories")
+load("//scala:scala.bzl", "scala_repositories", "scala_mvn_artifact")
 scala_repositories()
+
+# test adding a scala jar:
+maven_jar(
+  name = "com_twitter__scalding_date",
+  artifact = scala_mvn_artifact("com.twitter:scalding-date:0.16.0-RC4")
+)

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -327,6 +327,17 @@ scala_test = rule(
   test=True,
 )
 
+def scala_version():
+  """return the scala version for use in maven coordinates"""
+  return "2.11"
+
+def scala_mvn_artifact(artifact):
+  gav = artifact.split(":")
+  groupid = gav[0]
+  artifactid = gav[1]
+  version = gav[2]
+  return "%s:%s_%s:%s" % (groupid, artifactid, scala_version(), version)
+
 SCALA_BUILD_FILE = """
 # scala.BUILD
 exports_files([
@@ -342,7 +353,7 @@ exports_files([
   "lib/scala-continuations-library_2.11-1.0.2.jar",
   "lib/scala-continuations-plugin_2.11.7-1.0.2.jar",
   "lib/scala-library.jar",
-  "lib/scala-parser-comscala-2.11.7/binators_2.11-1.0.4.jar",
+  "lib/scala-parser-combinators_2.11-1.0.4.jar",
   "lib/scala-reflect.jar",
   "lib/scala-swing_2.11-1.0.2.jar",
   "lib/scala-xml_2.11-1.0.4.jar",

--- a/test/BUILD
+++ b/test/BUILD
@@ -88,3 +88,8 @@ scala_binary(
     main_class = "scala.test.ScalaLibBinary",
     deps = ["ScalaLibResources"],
 )
+
+scala_library(
+  name = "jar_export",
+  exports = ["@com_twitter__scalding_date//jar"]
+)


### PR DESCRIPTION
this is related to #14 

We give a function `scala_version` and a `scala_mvn_artifact` that can be used in name mangling for scala jars. This can help deal with making WORKSPACES less tied to a particular version of scala.