### PR TITLE
Add disappearing class test

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -73,6 +73,7 @@ def _compile(ctx, jars, buildijar):
       out=ctx.outputs.jar.path,
       ijar_out=ctx.outputs.ijar.path)
   cmd = """
+rm -rf {out}_tmp
 set -e
 mkdir -p {out}_tmp
 env JAVACMD={java} {scalac} {scala_opts} {jvm_flags} -classpath "{jars}" $@ -d {out}_tmp
@@ -80,6 +81,7 @@ env JAVACMD={java} {scalac} {scala_opts} {jvm_flags} -classpath "{jars}" $@ -d {
 find {out}_tmp -exec touch -t 198001010000 {{}} \;
 touch -t 198001010000 {manifest}
 {jar} cmf {manifest} {out} -C {out}_tmp .
+rm -rf {out}_tmp
 """ + ijar_cmd + res_cmd
   cmd = cmd.format(
       java=ctx.file._java.path,

--- a/test/src/main/scala/scala/test/disappearing_class/BUILD
+++ b/test/src/main/scala/scala/test/disappearing_class/BUILD
@@ -1,0 +1,13 @@
+load("//scala:scala.bzl", "scala_binary", "scala_library", "scala_test", "scala_macro_library")
+
+scala_library(
+    name = "uses_class",
+    srcs = ["UsesClass.scala"],
+    deps = [":class_provider"],
+)
+
+
+scala_library(
+    name = "class_provider",
+    srcs = ["ClassProvider.scala"],
+)

--- a/test/src/main/scala/scala/test/disappearing_class/ClassProvider.scala
+++ b/test/src/main/scala/scala/test/disappearing_class/ClassProvider.scala
@@ -1,0 +1,8 @@
+package scala.test
+
+object ClassProvider {
+  def dissappearingClassMethod: String = "testContents"
+}
+
+
+object BackgroundNoise{}

--- a/test/src/main/scala/scala/test/disappearing_class/UsesClass.scala
+++ b/test/src/main/scala/scala/test/disappearing_class/UsesClass.scala
@@ -1,0 +1,5 @@
+package scala.test
+
+object UsesClass {
+  val x = ClassProvider.dissappearingClassMethod
+}

--- a/test_run.sh
+++ b/test_run.sh
@@ -2,6 +2,21 @@
 
 set -e
 
+test_disappearing_class() {
+  git checkout test/src/main/scala/scala/test/disappearing_class/ClassProvider.scala
+  bazel build test/src/main/scala/scala/test/disappearing_class:uses_class
+  echo -e "package scala.test\n\nobject BackgroundNoise{}" > test/src/main/scala/scala/test/disappearing_class/ClassProvider.scala
+  set +e
+  bazel build test/src/main/scala/scala/test/disappearing_class:uses_class
+  RET=$?
+  git checkout test/src/main/scala/scala/test/disappearing_class/ClassProvider.scala
+  if [ $RET -eq 0 ]; then
+    echo "Class caching at play. This should fail"
+    exit 1
+  fi
+  set -e
+}
+
 bazel build test/... \
   && bazel run test:ScalaBinary \
   && bazel run test:ScalaLibBinary \
@@ -9,4 +24,5 @@ bazel build test/... \
   && bazel test test/... \
   && find -L ./bazel-testlogs -iname "*.xml" \
   && (find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null) \
+  && test_disappearing_class \
   && echo "all good"


### PR DESCRIPTION
We came across a case where deleting a class would let the Downstreams using it still compile. This should highlight that bad case