### PR TITLE
Fix thrift target in sandbox

### DIFF
--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -18,7 +18,7 @@ find {out}_tmp -exec touch -t 198001010000 {{}} \;
 rm -rf {out}_tmp""".format(out=ctx.outputs.libarchive.path,
                            jar=ctx.file._jar.path)
   ctx.action(
-    inputs = ctx.files.srcs,
+    inputs = ctx.files.srcs + ctx.files._jar,
     outputs = [ctx.outputs.libarchive],
     command = cmd,
     progress_message = "making thrift archive %s" % ctx.label,


### PR DESCRIPTION
I had forgotten to make the jar a dependency (via the action's input) of the thrift action, so the sandbox was hiding it.