### PR TITLE
Fix scala rules with bazel HEAD

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -306,7 +306,7 @@ def _scala_test_impl(ctx):
 
 def implicit_deps():
   return {
-    "_ijar": attr.label(executable=True, default=Label("//tools/defaults:ijar"), single_file=True, allow_files=True),
+    "_ijar": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:ijar"), single_file=True, allow_files=True),
     "_scalac": attr.label(executable=True, default=Label("@scala//:bin/scalac"), single_file=True, allow_files=True),
     "_scalalib": attr.label(default=Label("@scala//:lib/scala-library.jar"), single_file=True, allow_files=True),
     "_scalaxml": attr.label(default=Label("@scala//:lib/scala-xml_2.11-1.0.4.jar"), single_file=True, allow_files=True),


### PR DESCRIPTION
Bazel HEAD has removed //tools/defaults:ijar, rules should
now depends on @bazel_tools//tools/jdk:ijar.