### PR TITLE
Add support for scalac compiler plugins

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,5 +9,12 @@ twitter_scrooge()
 # test adding a scala jar:
 maven_jar(
   name = "com_twitter__scalding_date",
-  artifact = scala_mvn_artifact("com.twitter:scalding-date:0.16.0-RC4")
+  artifact = scala_mvn_artifact("com.twitter:scalding-date:0.16.0-RC4"),
+  sha1 = "659eb2d42945dea37b310d96af4e12bf83f54d14"
 )
+
+# test of a plugin
+maven_jar(
+  name = "org_psywerx_hairyfotr__linter",
+  artifact = scala_mvn_artifact("org.psywerx.hairyfotr:linter:0.1.13"),
+  sha1 = "e5b3e2753d0817b622c32aedcb888bcf39e275b4")

--- a/test/BUILD
+++ b/test/BUILD
@@ -60,6 +60,7 @@ scala_binary(
 scala_library(
     name = "HelloLib",
     srcs = ["HelloLib.scala"],
+    plugins = ["@org_psywerx_hairyfotr__linter//jar"],
     deps = [
         "OtherJavaLib",
         "OtherLib",

--- a/test/HelloLib.scala
+++ b/test/HelloLib.scala
@@ -15,12 +15,17 @@
 package scala.test
 
 object HelloLib {
+  // This is to check the linter, which will recommend changing this
+  // to just def dumb(x: Int) = x == 3
+  def dumb(x: Int) = if (x == 3) true else false
+
   def printMessage(arg: String) {
     MacroTest.hello(arg == "yo")
     println(getOtherLibMessage(arg))
     println(getOtherJavaLibMessage(arg))
     println(Exported.message)
   }
+
 
   def getOtherLibMessage(arg: String) : String = {
     arg + " " + OtherLib.getMessage()
@@ -30,3 +35,4 @@ object HelloLib {
     arg + " " + OtherJavaLib.getMessage()
   }
 }
+

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -24,7 +24,9 @@ rm -rf {out}_tmp"""
   cmd = cmd.format(out=ctx.outputs.libarchive.path,
                    jar=ctx.file._jar.path)
   ctx.action(
-    inputs = ctx.files.srcs + ctx.files._jar + ctx.files._jdk,
+    inputs = ctx.files.srcs +
+      ctx.files._jar +
+      ctx.files._jdk, #  We need _jdk to even run _jar. Depending on _jar is not enough with sandbox
     outputs = [ctx.outputs.libarchive],
     command = cmd,
     progress_message = "making thrift archive %s" % ctx.label,

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -24,7 +24,7 @@ rm -rf {out}_tmp"""
   cmd = cmd.format(out=ctx.outputs.libarchive.path,
                    jar=ctx.file._jar.path)
   ctx.action(
-    inputs = ctx.files.srcs + ctx.files._jar,
+    inputs = ctx.files.srcs + ctx.files._jar + ctx.files._jdk,
     outputs = [ctx.outputs.libarchive],
     command = cmd,
     progress_message = "making thrift archive %s" % ctx.label,
@@ -83,6 +83,7 @@ thrift_library = rule(
       # created by this is created in such a way that absolute imports work...
       "absolute_prefix": attr.string(default='', mandatory=False),
       "_jar": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:jar"), single_file=True, allow_files=True),
+      "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
   },
   outputs={"libarchive": "lib%{name}.jar"},
 )

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -122,6 +122,7 @@ def _gen_scrooge_srcjar_impl(ctx):
     inputs = list(remote_jars) +
         list(only_transitive_thrift_srcs) +
         list(immediate_thrift_srcs) +
+        ctx.files._jdk + #  We need the jdk to run java actions despite depending on _pluck_scrooge
         [remote_jars_file,
          only_transitive_thrift_srcs_file,
          immediate_thrift_srcs_file],
@@ -194,6 +195,7 @@ scrooge_scala_srcjar = rule(
           executable=True,
           default=Label("//src/scala/scripts:generator"),
           allow_files=True),
+        "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
     },
     outputs={
       "srcjar": "lib%{name}.srcjar",

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -123,7 +123,8 @@ def _gen_scrooge_srcjar_impl(ctx):
         list(only_transitive_thrift_srcs) +
         list(immediate_thrift_srcs) +
         ctx.files._jdk + #  We need the jdk to run java actions despite depending on _pluck_scrooge
-        [remote_jars_file,
+        [ctx.file._java,
+         remote_jars_file,
          only_transitive_thrift_srcs_file,
          immediate_thrift_srcs_file],
     outputs = [ctx.outputs.srcjar],
@@ -196,6 +197,7 @@ scrooge_scala_srcjar = rule(
           default=Label("//src/scala/scripts:generator"),
           allow_files=True),
         "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
+        "_java": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:java"), single_file=True, allow_files=True),
     },
     outputs={
       "srcjar": "lib%{name}.srcjar",

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -122,9 +122,7 @@ def _gen_scrooge_srcjar_impl(ctx):
     inputs = list(remote_jars) +
         list(only_transitive_thrift_srcs) +
         list(immediate_thrift_srcs) +
-        ctx.files._jdk + #  We need the jdk to run java actions despite depending on _pluck_scrooge
-        [ctx.file._java,
-         remote_jars_file,
+        [remote_jars_file,
          only_transitive_thrift_srcs_file,
          immediate_thrift_srcs_file],
     outputs = [ctx.outputs.srcjar],
@@ -196,8 +194,6 @@ scrooge_scala_srcjar = rule(
           executable=True,
           default=Label("//src/scala/scripts:generator"),
           allow_files=True),
-        "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
-        "_java": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:java"), single_file=True, allow_files=True),
     },
     outputs={
       "srcjar": "lib%{name}.srcjar",


### PR DESCRIPTION
This seems to work to add plugins.

Only tested with existing ones, but it *should* work for plugins in the repo as well.

It it not clear to me what the classpath for plugins is (do they need to be fat jars, or does it share a classpath with compilation?)

This seems to work.

review? @smparkes @dinowernli @jcoveney 