### PR TITLE
scala-lang should be a runtime dependency of any scala_library

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -280,6 +280,7 @@ def _lib(ctx, non_macro_lib):
   rjars += [ctx.outputs.jar]
   rjars += _collect_jars(ctx.attr.runtime_deps).runtime
 
+  rjars += [ctx.file._scalalib, ctx.file._scalareflect]
   if not non_macro_lib:
     #  macros need the scala reflect jar
     rjars += [ctx.file._scalareflect]


### PR DESCRIPTION
That way, a java_binary pulling it in will have scala-lang on the classpath.