### PR TITLE
Add a default output to scala_library

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -317,6 +317,7 @@ def _lib(ctx, non_macro_lib):
       files = list(rjars),
       collect_data = True)
   return struct(
+      files = set([ctx.outputs.jar]),  #  Here is the default output
       scala = scalaattr,
       runfiles=runfiles,
       # This is a free monoid given to the graph for the purpose of


### PR DESCRIPTION
This seems to reduce build time for `bazel build test/...` from 80 seconds to about 55 seconds on my machine. I *think* it is because it is not building the deploy jar for libraries unless needed after this change (or that is my intent). I only see 4 deploy jars created after this change, but 12 without it.

My hope is that `_deploy.jar` becomes an implicit output and is not created unless specifically requested (to the cost of creating deploy jars being quite large).

@smparkes @dinowernli 