### PR TITLE
Add repl support to binary and test targets

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -368,14 +368,23 @@ def _scala_macro_library_impl(ctx):
 # Common code shared by all scala binary implementations.
 def _scala_binary_common(ctx, cjars, rjars):
   write_manifest(ctx)
-  _compile_or_empty(ctx, cjars, [], False)  # no need to build an ijar for an executable
+  outputs = _compile_or_empty(ctx, cjars, [], False)  # no need to build an ijar for an executable
   _build_deployable(ctx, list(rjars))
 
   runfiles = ctx.runfiles(
       files = list(rjars) + [ctx.outputs.executable] + [ctx.file._java] + ctx.files._jdk,
       collect_data = True)
+
+  jars = _collect_jars(ctx.attr.deps)
+  outputs = struct(ijar=outputs.class_jar, class_jar=outputs.class_jar, deploy_jar=ctx.outputs.deploy_jar)
+  scalaattr = struct(outputs = outputs,
+                     transitive_runtime_deps = rjars,
+                     transitive_compile_exports = set(),
+                     transitive_runtime_exports = set()
+                     )
   return struct(
       files=set([ctx.outputs.executable]),
+      scala = scalaattr,
       runfiles=runfiles)
 
 def _scala_binary_impl(ctx):

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -325,10 +325,10 @@ def _lib(ctx, non_macro_lib):
     rjars += [ctx.file._scalareflect]
 
   _build_deployable(ctx, rjars)
-  outputs = struct(ijar=outputs.ijar, class_jar=outputs.class_jar, deploy_jar=ctx.outputs.deploy_jar)
+  rule_outputs = struct(ijar=outputs.ijar, class_jar=outputs.class_jar, deploy_jar=ctx.outputs.deploy_jar)
 
   texp = _collect_jars(ctx.attr.exports)
-  scalaattr = struct(outputs = outputs,
+  scalaattr = struct(outputs = rule_outputs,
                      transitive_runtime_deps = rjars,
                      transitive_compile_exports = texp.compiletime + cjars,
                      transitive_runtime_exports = texp.runtime
@@ -376,8 +376,8 @@ def _scala_binary_common(ctx, cjars, rjars):
       collect_data = True)
 
   jars = _collect_jars(ctx.attr.deps)
-  outputs = struct(ijar=outputs.class_jar, class_jar=outputs.class_jar, deploy_jar=ctx.outputs.deploy_jar)
-  scalaattr = struct(outputs = outputs,
+  rule_outputs = struct(ijar=outputs.class_jar, class_jar=outputs.class_jar, deploy_jar=ctx.outputs.deploy_jar)
+  scalaattr = struct(outputs = rule_outputs,
                      transitive_runtime_deps = rjars,
                      transitive_compile_exports = set(),
                      transitive_runtime_exports = set()

--- a/test/BUILD
+++ b/test/BUILD
@@ -83,6 +83,10 @@ scala_test(
     ],
 )
 
+scala_repl(
+    name = "HelloLibTestRepl",
+    deps = [":HelloLibTest"])
+
 scala_library(
     name = "a",
     srcs = ["A.scala"]
@@ -153,6 +157,10 @@ scala_binary(
     main_class = "scala.test.ScalaLibBinary",
     deps = ["ScalaLibResources"],
 )
+
+scala_repl(
+    name = "ScalaLibBinaryRepl",
+    deps = [":ScalaLibBinary"])
 
 scala_library(
   name = "jar_export",

--- a/test/HelloLibTest.scala
+++ b/test/HelloLibTest.scala
@@ -16,6 +16,10 @@ package scala.test
 
 import org.scalatest._
 
+object TestUtil {
+  def foo: String = "bar"
+}
+
 class ScalaSuite extends FlatSpec {
   "HelloLib" should "call scala" in {
     assert(HelloLib.getOtherLibMessage("hello").equals("hello scala!"))

--- a/test_run.sh
+++ b/test_run.sh
@@ -26,6 +26,12 @@ test_build_is_identical() {
   diff hash1 hash2
 }
 
+test_repl() {
+  echo "import scala.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl | grep "foo scala" &&
+  echo "import scala.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl | grep "bar" &&
+  echo "import scala.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl | grep "A hui hou"
+}
+
 bazel build test/... \
   && bazel run test:ScalaBinary \
   && bazel run test:ScalaLibBinary \
@@ -37,5 +43,5 @@ bazel build test/... \
   && (find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null) \
   && test_disappearing_class \
   && test_build_is_identical \
-  && echo "import scala.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl | grep "foo scala" \
+  && test_repl \
   && echo "all good"


### PR DESCRIPTION
actually, starting repls for test code and binaries is really useful, so I added support for that as well. This is done by making the binary targets return their deps correctly.