### PR TITLE
Set failing build to manual

### DIFF
--- a/test_expect_failure/transitive/java_to_scala/BUILD
+++ b/test_expect_failure/transitive/java_to_scala/BUILD
@@ -21,4 +21,5 @@ java_library(
     name = "d",
     srcs = ["D.java"],
     deps = [":c"],
+    tags = ["manual"],
 )

--- a/test_expect_failure/transitive/scala_to_java/BUILD
+++ b/test_expect_failure/transitive/scala_to_java/BUILD
@@ -19,4 +19,5 @@ scala_library(
     name = "d",
     deps = [":c"],
     srcs = ["D.scala"],
+    tags = ["manual"],
 )

--- a/test_expect_failure/transitive/scala_to_scala/BUILD
+++ b/test_expect_failure/transitive/scala_to_scala/BUILD
@@ -19,4 +19,5 @@ scala_library(
     name = "d",
     deps = [":c"],
     srcs = ["D.scala"],
+    tags = ["manual"],
 )

--- a/test_run.sh
+++ b/test_run.sh
@@ -29,21 +29,21 @@ test_build_is_identical() {
 test_transitive_deps() {
   set +e
 
-  bazel build test_expect_failure/transitive/scala_to_scala/...
+  bazel build test_expect_failure/transitive/scala_to_scala:d
   if [ $? -eq 0 ]; then
-    echo "'bazel build test_expect_failure/transitive/scala_to_scala/...' should have failed."
+    echo "'bazel build test_expect_failure/transitive/scala_to_scala:d' should have failed."
     exit 1
   fi
 
-  bazel build test_expect_failure/transitive/java_to_scala/...
+  bazel build test_expect_failure/transitive/java_to_scala:d
   if [ $? -eq 0 ]; then
-    echo "'bazel build test_expect_failure/transitive/java_to_scala/...' should have failed."
+    echo "'bazel build test_expect_failure/transitive/java_to_scala:d' should have failed."
     exit 1
   fi
 
-  bazel build test_expect_failure/transitive/scala_to_java/...
+  bazel build test_expect_failure/transitive/scala_to_java:d
   if [ $? -eq 0 ]; then
-    echo "'bazel build test_transitive_deps/scala_to_java/...' should have failed."
+    echo "'bazel build test_transitive_deps/scala_to_java:d' should have failed."
     exit 1
   fi
 


### PR DESCRIPTION
This prevents from building failing targets with `bazel build //...`.

Fixes #73.