### PR TITLE
Updated the readme to say main_class is required for scala_binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ A `scala_binary` requires a `main_class` attribute.
     <tr>
       <td><code>main_class</code></td>
       <td>
-        <p><code>String, optional</code></p>
+        <p><code>String, required</code></p>
         <p>Name of class with main() method to use as an entry point</p>
         <p>
           The value of this attribute is a class name, not a source file. The


### PR DESCRIPTION
Hi,
I might be wrong here but I think the main_class property is required for the scala_binary rule.
The doc also says `A scala_binary requires a main_class attribute.` but the attribute says its optional.
I updated to say It's mandatory.