### PR TITLE
Use Bazel mirror to download externals

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -17,3 +17,4 @@ John Sullivan <john.t.sullivan@gmail.com>
 Laurent Le Brun <laurentlb@google.com>
 Nathan Harmata <nharmata@google.com>
 Oscar Boykin <oscar.boykin@gmail.com>
+Justine Alexandra Roberts Tunney <jart@google.com>

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -599,12 +599,12 @@ def scala_repositories():
     name = "scala",
     strip_prefix = "scala-2.11.8",
     sha256 = "87fc86a19d9725edb5fd9866c5ee9424cdb2cd86b767f1bb7d47313e8e391ace",
-    url = "https://downloads.typesafe.com/scala/2.11.8/scala-2.11.8.tgz",
+    url = "http://bazel-mirror.storage.googleapis.com/downloads.typesafe.com/scala/2.11.8/scala-2.11.8.tgz",
     build_file_content = SCALA_BUILD_FILE,
   )
   native.http_file(
     name = "scalatest",
-    url = "https://oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
+    url = "http://bazel-mirror.storage.googleapis.com/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
     sha256 = "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
   )
 

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -7,15 +7,22 @@ load("//scala:scala.bzl",
   "collect_srcjars")
 
 def twitter_scrooge():
+  native.maven_server(
+    name = "twitter_scrooge_maven_server",
+    url = "http://bazel-mirror.storage.googleapis.com/repo1.maven.org/maven2/",
+  )
+
   native.maven_jar(
     name = "libthrift",
     artifact = "org.apache.thrift:libthrift:0.8.0",
     sha1 = "2203b4df04943f4d52c53b9608cef60c08786ef2",
+    server = "twitter_scrooge_maven_server",
   )
   native.maven_jar(
     name = "scrooge_core",
     artifact = scala_mvn_artifact("com.twitter:scrooge-core:4.6.0"),
     sha1 = "84b86c2e082aba6e0c780b3c76281703b891a2c8",
+    server = "twitter_scrooge_maven_server",
   )
 
   #scrooge-generator related dependencies
@@ -23,16 +30,19 @@ def twitter_scrooge():
     name = "scrooge_generator",
     artifact = scala_mvn_artifact("com.twitter:scrooge-generator:4.6.0"),
     sha1 = "cacf72eedeb5309ca02b2d8325c587198ecaac82",
+    server = "twitter_scrooge_maven_server",
   )
   native.maven_jar(
     name = "util_core",
     artifact = scala_mvn_artifact("com.twitter:util-core:6.33.0"),
     sha1 = "bb49fa66a3ca9b7db8cd764d0b26ce498bbccc83",
+    server = "twitter_scrooge_maven_server",
   )
   native.maven_jar(
     name = "util_logging",
     artifact = scala_mvn_artifact("com.twitter:util-logging:6.33.0"),
     sha1 = "3d28e46f8ee3b7ad1b98a51b98089fc01c9755dd",
+    server = "twitter_scrooge_maven_server",
   )
 
 def _collect_transitive_srcs(targets):


### PR DESCRIPTION
I've mirrored your files for guaranteed reliability, courtesy of Google Cloud Storage.

In the future, you can mirror these files too with the following command. Although you need to ask @damienmg for write access to the bucket. Or just email me the URL you want mirrored and I'll happily do it.

```bash
bzmirror() {
  local url="${1:?url}"
  if [[ "${url}" =~ ^([^:]+):([^:]+):([^:]+)$ ]]; then
    url="http://repo1.maven.org/maven2/${BASH_REMATCH[1]//.//}/${BASH_REMATCH[2]}/${BASH_REMATCH[3]}/${BASH_REMATCH[2]}-${BASH_REMATCH[3]}.jar"
  fi
  local dest="gs://bazel-mirror/${url#http*//}"
  local desturl="http://bazel-mirror.storage.googleapis.com/${url#http*//}"
  local name="$(basename "${dest}")"
  wget -O "/tmp/${name}" "${url}" || return 1
  gsutil cp -a public-read "/tmp/${name}" "${dest}" || return 1
  gsutil setmeta -h 'Cache-Control:public, max-age=31536000' "${dest}" || return 1
  curl -I "${desturl}"
  echo
  sha256sum "/tmp/${name}"
  echo "${desturl}"
  rm "/tmp/${name}" || return 1
}
```