### PR TITLE
Fix for thrift rule issue that manifests with remote repos

### DIFF
--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -23,6 +23,9 @@ rm -rf {out}_tmp"""
 
   cmd = cmd.format(out=ctx.outputs.libarchive.path,
                    jar=ctx.file._jar.path)
+  print(cmd)
+  print([f.path for f in ctx.files.srcs])
+
   ctx.action(
     inputs = ctx.files.srcs +
       ctx.files._jar +


### PR DESCRIPTION
The problem is that the path is not the same when remote as local. The current fix:

1. makes sure that a prefix, if given, is an actual substring of the common prefix.
2. ignores anything *before* the prefix that matches. So it is like the regex `.*prefix(.*)$`.

The above two fixes make this rule usable in both local and remote contexts for me.