### PR TITLE
improve the deploy jar creation

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -233,9 +233,18 @@ def _compile_or_empty(ctx, jars, srcjars, buildijar):
     return struct(ijar=ijar, class_jar=ctx.outputs.jar)
 
 def _build_deployable(ctx, jars):
+  # the _jar_bin program we call below expects one optional argument:
   # -m is the argument to pass a manifest to our jar creation code
-  # the next argument is the manifest itself, then the target jars
-  # finally the list of jars to merge
+  # the next argument is the path manifest itself
+  # the manifest is set up by methods that call this function (see usages
+  # of _build_deployable and note that they always first call write_manifest).
+  # that is what creates the manifest content
+  #
+  # following the manifest argument and the manifest, the next argument is
+  # the output path for the target jar
+  #
+  # finally all the rest of the arguments are jars to be flattened into one
+  # fat jar
   args = ["-m", ctx.outputs.manifest.path, ctx.outputs.deploy_jar.path]
   args.extend([j.path for j in jars])
   ctx.action(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -233,10 +233,13 @@ def _compile_or_empty(ctx, jars, srcjars, buildijar):
     return struct(ijar=ijar, class_jar=ctx.outputs.jar)
 
 def _build_deployable(ctx, jars):
+  # -m is the argument to pass a manifest to our jar creation code
+  # the next argument is the manifest itself, then the target jars
+  # finally the list of jars to merge
   args = ["-m", ctx.outputs.manifest.path, ctx.outputs.deploy_jar.path]
   args.extend([j.path for j in jars])
   ctx.action(
-      inputs=list(jars) + ctx.files._jdk + ctx.files._jar + [ctx.outputs.manifest],
+      inputs=list(jars) + [ctx.outputs.manifest],
       outputs=[ctx.outputs.deploy_jar],
       executable=ctx.executable._jar_bin,
       mnemonic="ScalaDeployJar",

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -233,25 +233,15 @@ def _compile_or_empty(ctx, jars, srcjars, buildijar):
     return struct(ijar=ijar, class_jar=ctx.outputs.jar)
 
 def _build_deployable(ctx, jars):
-  cmd = "rm -rf {out}_tmp\n"
-  cmd += "mkdir -p {out}_tmp\n"
-  for jar in jars:
-    cmd += "unzip -o {jar} -d {{out}}_tmp >/dev/null\n".format(jar=jar.path)
-  cmd += "{java} -jar {jar} -m {manifest} {out} {out}_tmp\n"
-  cmd += "rm -rf {out}_tmp\n"
-
-  cmd = cmd.format(
-      out=ctx.outputs.deploy_jar.path,
-      jar=_get_jar_path(ctx.files._jar),
-      java=ctx.file._java.path,
-      manifest=ctx.outputs.manifest.path)
+  args = ["-m", ctx.outputs.manifest.path, ctx.outputs.deploy_jar.path]
+  args.extend([j.path for j in jars])
   ctx.action(
       inputs=list(jars) + ctx.files._jdk + ctx.files._jar + [ctx.outputs.manifest],
       outputs=[ctx.outputs.deploy_jar],
-      command=cmd,
+      executable=ctx.executable._jar_bin,
       mnemonic="ScalaDeployJar",
       progress_message="scala deployable %s" % ctx.label,
-      arguments=[])
+      arguments=args)
 
 def write_manifest(ctx):
   # TODO(bazel-team): I don't think this classpath is what you want
@@ -471,6 +461,7 @@ _implicit_deps = {
   "_java": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:java"), single_file=True, allow_files=True),
   "_javac": attr.label(executable=True, default=Label("@bazel_tools//tools/jdk:javac"), single_file=True, allow_files=True),
   "_jar": attr.label(executable=True, default=Label("//src/java/io/bazel/rulesscala/jar:jar_deploy.jar"), allow_files=True),
+  "_jar_bin": attr.label(executable=True, default=Label("//src/java/io/bazel/rulesscala/jar")),
   "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
 }
 

--- a/src/java/io/bazel/rulesscala/jar/JarCreator.java
+++ b/src/java/io/bazel/rulesscala/jar/JarCreator.java
@@ -66,12 +66,12 @@ public class JarCreator extends JarHelper {
    *
    * @param directory the directory to add to the jar
    */
-  public void addDirectory(String directory) {
-    addDirectory(null, new File(directory));
+  public void addDirectory(File directory) {
+    addDirectory(null, directory);
   }
 
-  public void addZip(String name) {
-    jarEntries.put(name, (new File(name)).getAbsolutePath());
+  public void addZip(String name, File file) {
+    jarEntries.put(name, file.getAbsolutePath());
   }
   /**
    * Adds the contents of a directory to the Jar file. All files below this
@@ -193,11 +193,12 @@ public class JarCreator extends JarHelper {
     createJar.setManifestFile(manifestFile);
     for (int i = (idx+1); i < args.length; i++) {
       String thisName = args[i];
-      if (JarHelper.isJar(thisName)) {
-        createJar.addZip(thisName);
+      File f = new File(thisName);
+      if (JarHelper.isJar(thisName, f)) {
+        createJar.addZip(thisName, f);
       }
       else {
-        createJar.addDirectory(thisName);
+        createJar.addDirectory(f);
       }
     }
     createJar.setCompression(true);

--- a/src/java/io/bazel/rulesscala/jar/JarCreator.java
+++ b/src/java/io/bazel/rulesscala/jar/JarCreator.java
@@ -70,8 +70,8 @@ public class JarCreator extends JarHelper {
     addDirectory(null, directory);
   }
 
-  public void addZip(String name, File file) {
-    jarEntries.put(name, file.getAbsolutePath());
+  public void addJar(File file) {
+    jarEntries.put(file.getAbsolutePath(), file.getAbsolutePath());
   }
   /**
    * Adds the contents of a directory to the Jar file. All files below this
@@ -194,8 +194,8 @@ public class JarCreator extends JarHelper {
     for (int i = (idx+1); i < args.length; i++) {
       String thisName = args[i];
       File f = new File(thisName);
-      if (JarHelper.isJar(thisName, f)) {
-        createJar.addZip(thisName, f);
+      if (JarHelper.isJar(f)) {
+        createJar.addJar(f);
       }
       else {
         createJar.addDirectory(f);

--- a/src/java/io/bazel/rulesscala/jar/JarCreator.java
+++ b/src/java/io/bazel/rulesscala/jar/JarCreator.java
@@ -70,6 +70,9 @@ public class JarCreator extends JarHelper {
     addDirectory(null, new File(directory));
   }
 
+  public void addZip(String name) {
+    jarEntries.put(name, (new File(name)).getAbsolutePath());
+  }
   /**
    * Adds the contents of a directory to the Jar file. All files below this
    * directory will be added to the Jar file using the prefix and the name
@@ -189,7 +192,13 @@ public class JarCreator extends JarHelper {
     JarCreator createJar = new JarCreator(output);
     createJar.setManifestFile(manifestFile);
     for (int i = (idx+1); i < args.length; i++) {
-      createJar.addDirectory(args[i]);
+      String thisName = args[i];
+      if (JarHelper.isJar(thisName)) {
+        createJar.addZip(thisName);
+      }
+      else {
+        createJar.addDirectory(thisName);
+      }
     }
     createJar.setCompression(true);
     createJar.setNormalize(true);

--- a/src/java/io/bazel/rulesscala/jar/JarHelper.java
+++ b/src/java/io/bazel/rulesscala/jar/JarHelper.java
@@ -64,8 +64,8 @@ public class JarHelper {
     jarFile = filename;
   }
 
-  public static boolean isJar(String name, File file) {
-    return name.endsWith(".jar") && (file.isFile());
+  public static boolean isJar(File file) {
+    return file.getName().endsWith(".jar") && (file.isFile());
   }
 
   /**
@@ -223,7 +223,7 @@ public class JarHelper {
           System.err.println("adding " + file);
         }
         // Create a new entry
-        if (JarHelper.isJar(name, file)) {
+        if (JarHelper.isJar(file)) {
           JarFile nameJf = new JarFile(file);
           copyJar(nameJf, names, out);
         }

--- a/src/java/io/bazel/rulesscala/jar/JarHelper.java
+++ b/src/java/io/bazel/rulesscala/jar/JarHelper.java
@@ -64,8 +64,8 @@ public class JarHelper {
     jarFile = filename;
   }
 
-  public static boolean isJar(String name) {
-    return name.endsWith(".jar") && ((new File(name)).isFile());
+  public static boolean isJar(String name, File file) {
+    return name.endsWith(".jar") && (file.isFile());
   }
 
   /**
@@ -223,7 +223,7 @@ public class JarHelper {
           System.err.println("adding " + file);
         }
         // Create a new entry
-        if (JarHelper.isJar(name)) {
+        if (JarHelper.isJar(name, file)) {
           JarFile nameJf = new JarFile(file);
           copyJar(nameJf, names, out);
         }


### PR DESCRIPTION
This does not pass the zip contents through the file system and makes deploy jar creation part a executable action. It should be both faster, but also safer for creation of deploy jars on linux systems (such as Docker or with encrypted home directories) that often have limited file lengths that might be violated by jars.

review? @ianoc @ittaiz ?