### PR TITLE
make thrift targets quieter

### DIFF
--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -44,7 +44,7 @@ def _thrift_library_impl(ctx):
 rm -rf {out}_tmp
 mkdir -p {out}_tmp
 {jar} cMf {out}_tmp/tmp.jar $@
-unzip -o {out}_tmp/tmp.jar -d {out}_tmp 2>/dev/null
+unzip -q -o {out}_tmp/tmp.jar -d {out}_tmp 2>/dev/null
 rm -rf {out}_tmp/tmp.jar
 find {out}_tmp -exec touch -t 198001010000 {{}} \;
 """ + jarcmd + """


### PR DESCRIPTION
`unzip` by default prints all the files. This creates a lot of noise for thrift targets.