### PR TITLE
Catch throwables from type errors

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalaCInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalaCInvoker.java
@@ -207,7 +207,17 @@ public class ScalaCInvoker {
 
       MainClass comp = new MainClass();
       long start = System.currentTimeMillis();
-      comp.process(compilerArgs);
+
+      try {
+        comp.process(compilerArgs);
+      } catch (Throwable ex) {
+        if(ex.toString().contains("scala.reflect.internal.Types$TypeError")){
+          throw new RuntimeException("Build failure with type error", ex);
+        } else {
+          throw ex;
+        }
+      }
+
       long stop = System.currentTimeMillis();
       if (ops.printCompileTime) {
         System.err.println("Compiler runtime: " + (stop - start) + "ms.");


### PR DESCRIPTION
I ran into errors that were killing the standalone workers. Seems the Exception catching we have wasn't picking up these types. Not sure how safe it is to pickup all throwables so i'm just going to focus on the one we know should be captured..