### PR TITLE
Correctly set testonly to test targets

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,5 @@
+package(default_testonly = 1)
+
 load("//scala:scala.bzl",
     "scala_binary",
     "scala_library",


### PR DESCRIPTION
testonly was not enforced in previous version of Bazel but this will
be fixed in the next version of Bazel. Correct it for rules_scala.

Tested with `bazel build ...`

Tracking bug: bazelbuild/bazel#1967