### PR TITLE
Fix the behavior of the jvm_flags param to support multiple params 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bazel-*
+*.swp
+*.idea

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -175,7 +175,7 @@ SourceJars: {srcjars}
         javac_path=ctx.file._javac.path,
         java_files=",".join([f.path for f in java_srcs]),
         #  these are the flags passed to javac, which needs them prefixed by -J
-        jvm_flags=" ".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
+        jvm_flags=",".join(["-J" + flag for flag in ctx.attr.jvm_flags]),
         resource_src=",".join([f.path for f in ctx.files.resources]),
         resource_dest=",".join(
           [_adjust_resources_path(f.path)[1] for f in ctx.files.resources]

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -20,7 +20,7 @@ public class CompileOptions {
   final public String[] javaFiles;
   final public String javacPath;
   final public String javacOpts;
-  final public String jvmFlags;
+  final public String[] jvmFlags;
   final public Map<String, String> resourceFiles;
 
   public CompileOptions(List<String> args) {
@@ -38,7 +38,7 @@ public class CompileOptions {
     javaFiles = getCommaList(argMap, "JavaFiles");
     javacPath = getOrEmpty(argMap, "JavacPath");
     javacOpts = getOrEmpty(argMap, "JavacOpts");
-    jvmFlags = getOrEmpty(argMap, "JvmFlags");
+    jvmFlags = getCommaList(argMap, "JvmFlags");
 
     sourceJars = getCommaList(argMap, "SourceJars");
     iJarEnabled = booleanGetOrFalse(argMap, "EnableIjar");

--- a/test/BUILD
+++ b/test/BUILD
@@ -155,6 +155,7 @@ scala_library(
     name = "MixJavaScalaLib",
     srcs = glob(["src/main/scala/scala/test/mix_java_scala/*.scala"]) +
            glob(["src/main/scala/scala/test/mix_java_scala/*.java"]),
+    jvm_flags = ["-Xms1G", "-Xmx4G"],
 )
 #needed to test java sources are compiled
 scala_binary(


### PR DESCRIPTION
... by making the param a list rather than a string.

Drive-by:
* Add a few bits and pieces to .gitignore.
* Add a repro-case to test/BUILD which validates the fix.
* Use a list of arguments rather than a string to invoke javac.

Addresses: https://github.com/bazelbuild/rules_scala/issues/99

@petemounce @johnynek @damienmg 