### PR TITLE
Java only sources

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -187,3 +187,9 @@ scala_binary(
     main_class = "scala.test.MixJavaScalaLibBinary",
     deps = ["MixJavaScalaLib"],
 )
+
+scala_library(
+    name = "SupportJavaOnlySourcesToEaseJavaScalaInterop",
+    srcs = glob(["src/main/scala/scala/test/only_java/*.java"]),
+    jvm_flags = ["-Xms1G", "-Xmx4G"],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -188,8 +188,8 @@ scala_binary(
     deps = ["MixJavaScalaLib"],
 )
 
-scala_library(
-    name = "SupportJavaOnlySourcesToEaseJavaScalaInterop",
-    srcs = glob(["src/main/scala/scala/test/only_java/*.java"]),
-    jvm_flags = ["-Xms1G", "-Xmx4G"],
+scala_binary(
+    name = "JavaOnlySources",
+    srcs = ["src/main/scala/scala/test/only_java/Alpha.java"],
+    main_class = "scala.test.Alpha",
 )

--- a/test/src/main/scala/scala/test/only_java/Alpha.java
+++ b/test/src/main/scala/scala/test/only_java/Alpha.java
@@ -1,3 +1,6 @@
 package scala.test;
 public class Alpha {
+	public static void main(String[] args) {
+		return; //we just want this to be compiled and run
+	}
 }

--- a/test/src/main/scala/scala/test/only_java/Alpha.java
+++ b/test/src/main/scala/scala/test/only_java/Alpha.java
@@ -1,0 +1,3 @@
+package scala.test;
+public class Alpha {
+}

--- a/test_run.sh
+++ b/test_run.sh
@@ -102,4 +102,5 @@ run_test xmllint_test
 run_test test_build_is_identical
 run_test test_transitive_deps
 run_test test_repl
+run_test bazel run test:JavaOnlySources
 


### PR DESCRIPTION
Added an already passing test-target which shows support of targets with java only sources.
I think it has value even if it's already passing since at least currently this is a feature we want to support (until #970 in bazel itself is resolved) and I'd be calmer if there was any regression check for it.
Do you think an actual test is needed?