### PR TITLE
Adding a simple resource_strip_prefix option

### DIFF
--- a/.bazelrc.travis
+++ b/.bazelrc.travis
@@ -4,6 +4,9 @@ startup --host_jvm_args=-Xms2500m
 startup --batch
 test --ram_utilization_factor=10
 
+# Just making sure that we don't OOM with parallel builds
+build --local_resources 2048,.5,1.0
+
 # This is so we understand failures better
 build --verbose_failures
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,8 @@ to your command line, or to enable by default for building/testing add it to you
 ## scala\_library / scala\_macro_library
 
 ```python
-scala_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, scalacopts, jvm_flags)
-scala_macro_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, scalacopts, jvm_flags)
+scala_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags)
+scala_macro_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags)
 ```
 
 `scala_library` generates a `.jar` file from `.scala` source files. This rule
@@ -151,6 +151,17 @@ In order to make a java rule use this jar file, use the `java_import` rule.
       </td>
     </tr>
     <tr>
+      <td><code>resource_strip_prefix</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>
+          The path prefix to strip from Java resources. If specified,
+          this path prefix is stripped from every file in the `resources` attribute.
+          It is an error for a resource file not to be under this directory.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>scalacopts</code></td>
       <td>
         <p><code>List of strings; optional</code></p>
@@ -182,7 +193,7 @@ In order to make a java rule use this jar file, use the `java_import` rule.
 ## scala_binary
 
 ```python
-scala_binary(name, srcs, deps, runtime_deps, data, main_class, resources, scalacopts, jvm_flags)
+scala_binary(name, srcs, deps, runtime_deps, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags)
 ```
 
 `scala_binary` generates a Scala executable. It may depend on `scala_library`, `scala_macro_library`
@@ -258,6 +269,17 @@ A `scala_binary` requires a `main_class` attribute.
       </td>
     </tr>
     <tr>
+      <td><code>resource_strip_prefix</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>
+          The path prefix to strip from Java resources. If specified,
+          this path prefix is stripped from every file in the `resources` attribute.
+          It is an error for a resource file not to be under this directory.
+        </p>
+      </td>
+    </tr>
+    <tr>
       <td><code>scalacopts</code></td>
       <td>
         <p><code>List of strings; optional</code></p>
@@ -289,7 +311,7 @@ A `scala_binary` requires a `main_class` attribute.
 ## scala_test
 
 ```python
-scala_test(name, srcs, suites, deps, data, main_class, resources, scalacopts, jvm_flags)
+scala_test(name, srcs, suites, deps, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags)
 ```
 
 `scala_test` generates a Scala executable which runs unit test suites written

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -157,6 +157,7 @@ Plugins: {plugin_arg}
 PrintCompileTime: {print_compile_time}
 ResourceDests: {resource_dest}
 ResourceSrcs: {resource_src}
+ResourceStripPrefix: {resource_strip_prefix}
 ScalacOpts: {scala_opts}
 SourceJars: {srcjars}
 """.format(
@@ -180,6 +181,7 @@ SourceJars: {srcjars}
         resource_dest=",".join(
           [_adjust_resources_path(f.path)[1] for f in ctx.files.resources]
           ),
+        resource_strip_prefix=ctx.attr.resource_strip_prefix,
         )
     argfile = ctx.new_file(
       ctx.outputs.jar,
@@ -516,6 +518,7 @@ _common_attrs = {
   "runtime_deps": attr.label_list(),
   "data": attr.label_list(allow_files=True, cfg="data"),
   "resources": attr.label_list(allow_files=True),
+  "resource_strip_prefix": attr.string(),
   "scalacopts":attr.string_list(),
   "javacopts":attr.string_list(),
   "jvm_flags": attr.string_list(),

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -22,6 +22,7 @@ public class CompileOptions {
   final public String javacOpts;
   final public String[] jvmFlags;
   final public Map<String, String> resourceFiles;
+  final public String resourceStripPrefix;
 
   public CompileOptions(List<String> args) {
     Map<String, String> argMap = buildArgMap(args);
@@ -51,6 +52,7 @@ public class CompileOptions {
       ijarCmdPath = null;
     }
     resourceFiles = getResources(argMap);
+    resourceStripPrefix = getOrEmpty(argMap, "ResourceStripPrefix");
   }
 
   private static Map<String, String> getResources(Map<String, String> args) {

--- a/src/java/io/bazel/rulesscala/scalac/ScalaCInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalaCInvoker.java
@@ -350,7 +350,10 @@ public class ScalaCInvoker {
     // check if the Resource file is under the specified prefix to strip
     if (!sourcePath.startsWith(resourceStripPrefix)) {
       // Resource File is not under the specified prefix to strip
-      throw new RuntimeException("Resource File is not under the specified prefix to strip");
+      throw new RuntimeException("Resource File "
+        + sourcePath
+        + " is not under the specified strip prefix "
+        + resourceStripPrefix);
     }
     String newResPath = sourcePath.substring(resourceStripPrefix.length());
     return newResPath;

--- a/test/BUILD
+++ b/test/BUILD
@@ -134,6 +134,16 @@ scala_library(
         ],
 )
 
+scala_library(
+    name = "MoreScalaLibResources",
+    srcs = ["src/main/scala/scala/test/MoreScalaLibResources.scala"],
+    resources = [
+        "//test/data:more.txt",
+        "//test/data:foo.txt",
+        ],
+    resource_strip_prefix = "test/",
+)
+
 scala_binary(
     name = "ScalaLibBinary",
     srcs = ["src/main/scala/scala/test/ScalaLibBinary.scala"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -129,8 +129,8 @@ scala_library(
     srcs = ["src/main/scala/scala/test/ScalaLibResources.scala"],
     resources = [
         "//test/data:some.txt",
-        "src/main/resources/scala/test/byes",
-        "src/main/resources/scala/test/hellos",
+        "//test/src/main/resources/scala/test:byes",
+        "//test/src/main/resources/scala/test:hellos",
         ],
 )
 
@@ -140,6 +140,8 @@ scala_library(
     resources = [
         "//test/data:more.txt",
         "//test/data:foo.txt",
+        "//test/src/main/resources/scala/test:more-hellos",
+        "//test/src/main/resources/scala/test:more-byes"
         ],
     resource_strip_prefix = "test/",
 )
@@ -151,9 +153,20 @@ scala_binary(
     deps = ["ScalaLibResources"],
 )
 
+scala_binary(
+    name = "MoreScalaLibBinary",
+    srcs = ["src/main/scala/scala/test/MoreScalaLibBinary.scala"],
+    main_class = "scala.test.MoreScalaLibBinary",
+    deps = ["MoreScalaLibResources"],
+)
+
 scala_repl(
     name = "ScalaLibBinaryRepl",
     deps = [":ScalaLibBinary"])
+
+scala_repl(
+    name = "MoreScalaLibBinaryRepl",
+    deps = [":MoreScalaLibBinary"])
 
 scala_library(
   name = "jar_export",

--- a/test/data/BUILD
+++ b/test/data/BUILD
@@ -1,1 +1,1 @@
-exports_files(["some.txt"])
+exports_files(["some.txt", "more.txt", "foo.txt"])

--- a/test/data/foo.txt
+++ b/test/data/foo.txt
@@ -1,0 +1,1 @@
+this is a test of just random data in some path (not resources)

--- a/test/data/more.txt
+++ b/test/data/more.txt
@@ -1,1 +1,1 @@
-this is a test of just random data in some path (not resources)
+more hellos

--- a/test/data/more.txt
+++ b/test/data/more.txt
@@ -1,0 +1,1 @@
+this is a test of just random data in some path (not resources)

--- a/test/src/main/resources/scala/test/BUILD
+++ b/test/src/main/resources/scala/test/BUILD
@@ -1,0 +1,1 @@
+exports_files(["byes", "hellos", "more-byes", "more-hellos"])

--- a/test/src/main/resources/scala/test/more-byes
+++ b/test/src/main/resources/scala/test/more-byes
@@ -1,0 +1,3 @@
+more see ya
+more later
+A more hui hou

--- a/test/src/main/resources/scala/test/more-hellos
+++ b/test/src/main/resources/scala/test/more-hellos
@@ -1,0 +1,2 @@
+More Hello
+More Bonjour

--- a/test/src/main/scala/scala/test/MoreScalaLibBinary.scala
+++ b/test/src/main/scala/scala/test/MoreScalaLibBinary.scala
@@ -14,16 +14,10 @@
 
 package scala.test
 
-object MoreScalaLibResources {
-  def getGreetings() = get("/src/main/resources/scala/test/more-hellos")
-
-  def getFarewells = get("/src/main/resources/scala/test/more-byes")
-
-  def getData = get("/data/more.txt")
-
-  private def get(s: String): List[String] =
-    scala.io.Source
-      .fromInputStream(getClass.getResourceAsStream(s))
-      .getLines
-      .toList
+object MoreScalaLibBinary {
+  def main(args:Array[String]) {
+    MoreScalaLibResources.getGreetings foreach println
+    MoreScalaLibResources.getFarewells foreach println
+    MoreScalaLibResources.getData foreach println
+  }
 }

--- a/test/src/main/scala/scala/test/MoreScalaLibResources.scala
+++ b/test/src/main/scala/scala/test/MoreScalaLibResources.scala
@@ -1,0 +1,29 @@
+// Copyright 2016 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package scala.test
+
+object MoreScalaLibResources {
+  def getGreetings() = get("more hellos")
+
+  def getFarewells = get("more byes")
+
+  def getData = get("/test/data/more.txt")
+
+  private def get(s: String): List[String] =
+    scala.io.Source
+      .fromInputStream(getClass.getResourceAsStream(s))
+      .getLines
+      .toList
+}

--- a/test_run.sh
+++ b/test_run.sh
@@ -62,7 +62,8 @@ test_transitive_deps() {
 test_repl() {
   echo "import scala.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl | grep "foo java" &&
   echo "import scala.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl | grep "bar" &&
-  echo "import scala.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl | grep "A hui hou"
+  echo "import scala.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl | grep "A hui hou" &&
+  echo "import scala.test._; MoreScalaLibBinary.main(Array())" | bazel-bin/test/MoreScalaLibBinaryRepl | grep "More Hello"
 }
 
 NC='\033[0m'


### PR DESCRIPTION
This will add a `resource_strip_prefix` option like the one in Java. If the `resource_strip_prefix` is defined, we will strip out the prefix from the resource file path and forms the new destination path for the resource files. We will also throw a runtime exception if any of the resource file mentioned in the rule doesn't belongs to the specified path (which is the default behavior in Java rule too)