### PR TITLE
Add ci.bazel.io build status to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Scala Rules for Bazel
-[![Build Status](https://travis-ci.org/bazelbuild/rules_scala.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_scala)
+[![Build Status](https://travis-ci.org/bazelbuild/rules_scala.svg?branch=master)](https://travis-ci.org/bazelbuild/rules_scala) [![Build Status](http://ci.bazel.io/buildStatus/icon?job=rules_scala)](http://ci.bazel.io/job/rules_scala)
 
 <div class="toc">
   <h2>Rules</h2>


### PR DESCRIPTION
This will currently show as broken because rules scala is failing due to sandboxing since https://github.com/bazelbuild/rules_scala/commit/55156d5fe501c112983deff6e8065eec2b2b366e. Travis CI does not catch those errors.

