### PR TITLE
Fix uses of bind for thrift rules

### DIFF
--- a/src/scala/io/bazel/rules_scala/scrooge_support/BUILD
+++ b/src/scala/io/bazel/rules_scala/scrooge_support/BUILD
@@ -4,9 +4,9 @@ scala_library(
   name = "compiler",
   srcs = ["Compiler.scala"],
   deps = [
-    "@scrooge_generator//jar",
-    "@util_core//jar",
-    "@util_logging//jar",
+    "//external:io_bazel_rules_scala/dependency/thrift/scrooge_generator",
+    "//external:io_bazel_rules_scala/dependency/thrift/util_core",
+    "//external:io_bazel_rules_scala/dependency/thrift/util_logging",
     "//src/scala:parser_combinators",
     ":focused_zip_importer",
   ],
@@ -17,7 +17,7 @@ scala_library(
   name = "focused_zip_importer",
   srcs = ["FocusedZipImporter.scala"],
   deps = [
-    "@scrooge_generator//jar",
+    "//external:io_bazel_rules_scala/dependency/thrift/scrooge_generator",
   ],
   visibility = ["//visibility:public"],
 )

--- a/src/scala/scripts/BUILD
+++ b/src/scala/scripts/BUILD
@@ -4,9 +4,9 @@ scala_library(
   name = "generator_lib",
   srcs = ["TwitterScroogeGenerator.scala"],
   deps = [
-    "@scrooge_generator//jar",
-    "@util_core//jar",
-    "@util_logging//jar",
+    "//external:io_bazel_rules_scala/dependency/thrift/scrooge_generator",
+    "//external:io_bazel_rules_scala/dependency/thrift/util_core",
+    "//external:io_bazel_rules_scala/dependency/thrift/util_logging",
     "//src/scala/io/bazel/rules_scala/scrooge_support:compiler",
     "//src/scala:parser_combinators",
     "//src/java/io/bazel/rulesscala/jar",

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -18,7 +18,6 @@ def twitter_scrooge():
     sha1 = "2203b4df04943f4d52c53b9608cef60c08786ef2",
     server = "twitter_scrooge_maven_server",
   )
-
   native.bind(name = 'io_bazel_rules_scala/dependency/thrift/libthrift', actual = '@libthrift//jar')
 
   native.maven_jar(
@@ -27,7 +26,6 @@ def twitter_scrooge():
     sha1 = "84b86c2e082aba6e0c780b3c76281703b891a2c8",
     server = "twitter_scrooge_maven_server",
   )
-
   native.bind(name = 'io_bazel_rules_scala/dependency/thrift/scrooge_core', actual = '@scrooge_core//jar')
 
   #scrooge-generator related dependencies
@@ -37,18 +35,23 @@ def twitter_scrooge():
     sha1 = "cacf72eedeb5309ca02b2d8325c587198ecaac82",
     server = "twitter_scrooge_maven_server",
   )
+  native.bind(name = 'io_bazel_rules_scala/dependency/thrift/scrooge_generator', actual = '@scrooge_generator//jar')
+
   native.maven_jar(
     name = "util_core",
     artifact = scala_mvn_artifact("com.twitter:util-core:6.33.0"),
     sha1 = "bb49fa66a3ca9b7db8cd764d0b26ce498bbccc83",
     server = "twitter_scrooge_maven_server",
   )
+  native.bind(name = 'io_bazel_rules_scala/dependency/thrift/util_core', actual = '@util_core//jar')
+
   native.maven_jar(
     name = "util_logging",
     artifact = scala_mvn_artifact("com.twitter:util-logging:6.33.0"),
     sha1 = "3d28e46f8ee3b7ad1b98a51b98089fc01c9755dd",
     server = "twitter_scrooge_maven_server",
   )
+  native.bind(name = 'io_bazel_rules_scala/dependency/thrift/util_logging', actual = '@util_logging//jar')
 
 def _collect_transitive_srcs(targets):
   r = set()


### PR DESCRIPTION
We use some binds, but not all. This uses only bind so users can fix the versions they need.