### PR TITLE
Add support for JMH benchmarks

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -9,6 +9,9 @@ twitter_scrooge()
 load("//tut_rule:tut.bzl", "tut_repositories")
 tut_repositories()
 
+load("//jmh:jmh.bzl", "jmh_repositories")
+jmh_repositories()
+
 # test adding a scala jar:
 maven_jar(
   name = "com_twitter__scalding_date",

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -1,0 +1,123 @@
+load("//scala:scala.bzl", "scala_binary", "scala_library")
+
+def jmh_repositories():
+  native.maven_jar(
+      name = "io_bazel_rules_scala_org_openjdk_jmh_jmh_core",
+      artifact = "org.openjdk.jmh:jmh-core:1.17.4",
+      sha1 = "126d989b196070a8b3653b5389e602a48fe6bb2f",
+  )
+  native.bind(
+      name = 'io_bazel_rules_scala/dependency/jmh/jmh_core',
+      actual = '@io_bazel_rules_scala_org_openjdk_jmh_jmh_core//jar',
+  )
+  native.maven_jar(
+      name = "io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_asm",
+      artifact = "org.openjdk.jmh:jmh-generator-asm:1.17.4",
+      sha1 = "c85c3d8cfa194872b260e89770d41e2084ce2cb6",
+  )
+  native.bind(
+      name = 'io_bazel_rules_scala/dependency/jmh/jmh_generator_asm',
+      actual = '@io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_asm//jar',
+  )
+  native.maven_jar(
+       name = "io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_reflection",
+       artifact = "org.openjdk.jmh:jmh-generator-reflection:1.17.4",
+       sha1 = "f75a7823c9fcf03feed6d74aa44ea61fc70a8439",
+  )
+  native.bind(
+       name = 'io_bazel_rules_scala/dependency/jmh/jmh_generator_reflection',
+       actual = '@io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_reflection//jar',
+  )
+  native.maven_jar(
+      name = "io_bazel_rules_scala_org_ows2_asm_asm",
+      artifact = "org.ow2.asm:asm:5.0.4",
+      sha1 = "0da08b8cce7bbf903602a25a3a163ae252435795",
+  )
+  native.bind(
+      name = "io_bazel_rules_scala/dependency/jmh/org_ows2_asm_asm",
+      actual = '@io_bazel_rules_scala_org_ows2_asm_asm//jar',
+  )
+  native.maven_jar(
+      name = "io_bazel_rules_scala_net_sf_jopt_simple_jopt_simple",
+      artifact = "net.sf.jopt-simple:jopt-simple:5.0.3",
+      sha1 = "cdd846cfc4e0f7eefafc02c0f5dce32b9303aa2a",
+  )
+  native.bind(
+      name = "io_bazel_rules_scala/dependency/jmh/net_sf_jopt_simple_jopt_simple",
+      actual = '@io_bazel_rules_scala_net_sf_jopt_simple_jopt_simple//jar',
+  )
+  native.maven_jar(
+      name = "io_bazel_rules_scala_org_apache_commons_commons_math3",
+      artifact = "org.apache.commons:commons-math3:3.6.1",
+      sha1 = "e4ba98f1d4b3c80ec46392f25e094a6a2e58fcbf",
+  )
+  native.bind(
+      name = "io_bazel_rules_scala/dependency/jmh/org_apache_commons_commons_math3",
+      actual = '@io_bazel_rules_scala_org_apache_commons_commons_math3//jar',
+  )
+
+
+def scala_benchmark_jmh(**kw):
+  name = kw["name"]
+  deps = kw.get("deps", [])
+  srcs = kw["srcs"]
+  lib = "%s_generator" % name
+  scalacopts = kw.get("scalacopts", [])
+  scala_library(
+      name = lib,
+      srcs = srcs,
+      deps = deps + [
+          "//external:io_bazel_rules_scala/dependency/jmh/jmh_core",
+      ],
+      scalacopts = scalacopts,
+      visibility = ["//visibility:public"],
+  )
+  tool = "__jmh_benchmark_generator"
+  scala_binary(
+    name = tool,
+    main_class = "io.bazel.rules_scala.jmh_support.BenchmarkGenerator",
+    deps = [
+      "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator_lib"
+    ],
+  )
+
+  codegen = name + "_codegen"
+  src_jar = "%s_jmh.srcjar" % name
+  benchmark_list = "resources/META-INF/BenchmarkList"
+  compiler_hints = "resources/META-INF/CompilerHints"
+  native.genrule(
+      name = codegen,
+      srcs = [lib],
+      outs = [src_jar, benchmark_list, compiler_hints],
+      tools = [tool, "@local_jdk//:jar"],
+      cmd = """
+pushd `dirname $(location {lib})`
+jar -xf `basename $(location {lib})`
+popd
+./$(location {tool}) $(location {lib}) $(@D)
+pushd $(@D)/sources
+jar -cf ../{name}_jmh.srcjar ./**/*
+popd
+""".format(tool=tool, lib=lib, name=name),
+  )
+
+  compiled_lib = name + "_compiled_benchmark_lib"
+  scala_library(
+      name = compiled_lib,
+      srcs = [src_jar],
+      deps = deps + [
+          "//external:io_bazel_rules_scala/dependency/jmh/jmh_core",
+          lib,
+          codegen,
+      ],
+      resources = [benchmark_list, compiler_hints],
+  )
+  scala_binary(
+     name = name,
+     deps = [
+         "//external:io_bazel_rules_scala/dependency/jmh/net_sf_jopt_simple_jopt_simple",
+         "//external:io_bazel_rules_scala/dependency/jmh/org_apache_commons_commons_math3",
+         compiled_lib,
+    ],
+     main_class = "org.openjdk.jmh.Main"
+  )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -63,6 +63,8 @@ def scala_benchmark_jmh(**kw):
   srcs = kw["srcs"]
   lib = "%s_generator" % name
   scalacopts = kw.get("scalacopts", [])
+  main_class = kw.get("main_class", "org.openjdk.jmh.Main")
+
   scala_library(
       name = lib,
       srcs = srcs,
@@ -138,5 +140,5 @@ popd
          "//external:io_bazel_rules_scala/dependency/jmh/org_apache_commons_commons_math3",
          compiled_lib,
     ],
-     main_class = "org.openjdk.jmh.Main"
+     main_class = main_class,
   )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -91,6 +91,8 @@ def scala_benchmark_jmh(**kw):
       outs = [src_jar, benchmark_list, compiler_hints],
       tools = [
           jmh_benchmark_generator_tool,
+          # Without the JDK, local_jdk//:jar complains of failing to find
+          # a Java SE Runtime Environment.
           jdk_tool,
           jar_creator_tool,
           jar_tool,

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -74,14 +74,7 @@ def scala_benchmark_jmh(**kw):
       scalacopts = scalacopts,
       visibility = ["//visibility:public"],
   )
-  jmh_benchmark_generator_tool = "__jmh_benchmark_generator"
-  scala_binary(
-    name = jmh_benchmark_generator_tool,
-    main_class = "io.bazel.rules_scala.jmh_support.BenchmarkGenerator",
-    deps = [
-      "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator_lib"
-    ],
-  )
+  jmh_benchmark_generator_tool = "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator"
 
   codegen = name + "_codegen"
   src_jar = "%s_jmh.srcjar" % name

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -74,9 +74,9 @@ def scala_benchmark_jmh(**kw):
       scalacopts = scalacopts,
       visibility = ["//visibility:public"],
   )
-  tool = "__jmh_benchmark_generator"
+  jmh_benchmark_generator_tool = "__jmh_benchmark_generator"
   scala_binary(
-    name = tool,
+    name = jmh_benchmark_generator_tool,
     main_class = "io.bazel.rules_scala.jmh_support.BenchmarkGenerator",
     deps = [
       "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator_lib"
@@ -98,7 +98,12 @@ def scala_benchmark_jmh(**kw):
       name = codegen,
       srcs = [lib, binary_deploy_jar],
       outs = [src_jar, benchmark_list, compiler_hints],
-      tools = [tool, java_tool, jar_tool, jdk_tool],
+      tools = [
+          jmh_benchmark_generator_tool,
+          java_tool,
+          jar_tool,
+          jdk_tool,
+      ],
       cmd = """
 BINARY_DEPLOY_JAR=`pwd`/$(location {binary_deploy_jar})
 JAVA=`pwd`/$(location {java_tool})
@@ -108,12 +113,12 @@ pushd `dirname $(location {lib})`
 $$JAR -xf `basename $(location {lib})`
 popd
 
-./$(location {tool}) $(location {lib}) $(@D)
+./$(location {jmh_benchmark_generator_tool}) $(location {lib}) $(@D)
 pushd $(@D)/sources
 $$JAVA -jar $$BINARY_DEPLOY_JAR ../{name}_jmh.srcjar ./
 popd
 """.format(
-      tool=tool,
+      jmh_benchmark_generator_tool=jmh_benchmark_generator_tool,
       binary_deploy_jar=binary_deploy_jar,
       java_tool=java_tool,
       jar_tool=jar_tool,

--- a/src/scala/io/bazel/rules_scala/jmh_support/BUILD
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BUILD
@@ -1,0 +1,22 @@
+load("//scala:scala.bzl", "scala_binary", "scala_library")
+
+scala_library(
+  name = "benchmark_generator_lib",
+  srcs = ["BenchmarkGenerator.scala"],
+  deps = [
+      "//external:io_bazel_rules_scala/dependency/jmh/jmh_core",
+      "//external:io_bazel_rules_scala/dependency/jmh/jmh_generator_asm",
+      "//external:io_bazel_rules_scala/dependency/jmh/jmh_generator_reflection",
+      "//external:io_bazel_rules_scala/dependency/jmh/org_ows2_asm_asm",      
+      "//src/scala:scala_compiler",
+      "//src/java/io/bazel/rulesscala/io_utils",
+  ],
+  visibility = ["//visibility:public"],
+)
+
+scala_binary(
+  name = "benchmark_generator",
+  main_class = "io.bazel.rules_scala.jmh_support.BenchmarkGenerator",
+  deps = [":benchmark_generator_lib"],
+  visibility = ["//visibility:public"],
+)

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -1,0 +1,146 @@
+package io.bazel.rules_scala.jmh_support
+
+import java.net.URLClassLoader
+
+import scala.annotation.tailrec
+import scala.collection.JavaConverters._
+
+import org.openjdk.jmh.generators.core.{ BenchmarkGenerator => JMHGenerator, FileSystemDestination }
+import org.openjdk.jmh.generators.asm.ASMGeneratorSource
+import org.openjdk.jmh.runner.{ Runner, RunnerException }
+import org.openjdk.jmh.runner.options.{ Options, OptionsBuilder }
+
+import java.nio.file.{Files, FileSystems, Path}
+
+
+object BenchmarkGenerator {
+  case class JmhGeneratedSources(sources: Seq[Path], resources: Seq[Path])
+
+  def main(argv: Array[String]): Unit = {
+    val classPath = System.getProperty("java.class.path").split(':').map {s =>
+      FileSystems.getDefault.getPath(s)
+    }
+    val fs = FileSystems.getDefault
+
+    val outDir = fs.getPath(argv(1))
+    val srcDir = outDir.resolve("sources")
+    if (!srcDir.toFile.isDirectory) { srcDir.toFile.mkdirs() }
+    val resourceDir = outDir.resolve("resources")
+    if (!resourceDir.toFile.isDirectory) { resourceDir.toFile.mkdirs() }
+
+    val generated = generateJmhBenchmark(
+      srcDir,
+      resourceDir,
+      List(fs.getPath(argv(0)).getParent),
+      classPath
+    )
+  }
+
+  private def listFiles(dir: Path): List[Path] = {
+    val stream = Files.newDirectoryStream(dir)
+    stream.asScala.toList
+  }
+
+  private def listFilesRecursively(root: Path)(pred: Path => Boolean): List[Path] = {
+    def loop(fs0: List[Path], files: List[Path]): List[Path] = fs0 match {
+      case f :: fs if f.toFile.isDirectory => loop(fs ++ listFiles(f), files)
+      case f :: fs if pred(f) => loop(fs, f :: files)
+      case _ :: fs => loop(fs, files)
+      case Nil => files.reverse
+    }
+
+    loop(root :: Nil, Nil)
+  }
+
+  private def collectClasses(root: Path): List[Path] =
+    listFilesRecursively(root) { path =>
+      path.getFileName.toString.endsWith(".class")
+    }
+
+  private def createDirectories(p: Path): Unit = {
+    def missingParents(path: Path): List[Path] = {
+      if (path == null || path.toFile.exists() || path.toFile.isDirectory) {
+        Nil
+      } else {
+        path :: missingParents(path.getParent)
+      }
+    }
+    missingParents(p.getParent).reverse.foreach { d =>
+      if (!d.toFile.mkdir()) {
+        sys.error(s"Failed to create directory $d")
+      }
+    }
+  }
+
+  private def move(from: Path, to: Path): List[Path] =
+    listFilesRecursively(from)(_ => true).map { src =>
+      val tail = from.relativize(src)
+      val dest = to.resolve(tail)
+      createDirectories(dest)
+      Files.move(src, dest)
+      dest
+    }
+
+  // Courtesy of Doug Tangren (https://groups.google.com/forum/#!topic/simple-build-tool/CYeLHcJjHyA)
+  private def withClassLoader[A](cp: Seq[Path])(f: => A): A = {
+    val originalLoader = Thread.currentThread.getContextClassLoader
+    val jmhLoader = classOf[JMHGenerator].getClassLoader
+    val classLoader = new URLClassLoader(cp.map(_.toUri.toURL).toArray, jmhLoader)
+    try {
+      Thread.currentThread.setContextClassLoader(classLoader)
+      f
+    } finally {
+      Thread.currentThread.setContextClassLoader(originalLoader)
+    }
+  }
+
+  private def withTempDirectory[A](f: Path => A): A = {
+    val baseDir = System.getProperty("java.io.tmpdir")
+    val tempDir = Files.createTempDirectory("jmh_benchmark_generator")
+    try {
+      f(tempDir)
+    } finally {
+      listFilesRecursively(tempDir)(_ => true).reverse.foreach {file =>
+        log(s"would delete $file")
+      }
+    }
+  }
+
+  private def generateJmhBenchmark(
+    sourceDir: Path,
+    resourceDir: Path,
+    benchmarkClasspath: Seq[Path],
+    fullClasspath: Seq[Path]
+  ): JmhGeneratedSources = {
+    withTempDirectory { tempDir =>
+      val tmpResourceDir = tempDir.resolve("resources")
+      val tmpSourceDir = tempDir.resolve("sources")
+
+      tmpResourceDir.toFile.mkdir()
+      tmpSourceDir.toFile.mkdir()
+
+      withClassLoader(benchmarkClasspath ++ fullClasspath) {
+        val source = new ASMGeneratorSource
+        val destination = new FileSystemDestination(tmpResourceDir.toFile, tmpSourceDir.toFile)
+        val generator = new JMHGenerator
+
+        val classes = benchmarkClasspath.flatMap(f => collectClasses(f)).map(_.toFile)
+        source.processClasses(classes.asJava)
+        generator.generate(source, destination)
+        generator.complete(source, destination)
+        if (destination.hasErrors) {
+          log("JMH Benchmark generator failed")
+          for (e <- destination.getErrors.asScala) {
+            log(e.toString)
+          }
+        }
+      }
+
+      JmhGeneratedSources(move(tmpSourceDir, sourceDir), move(tmpResourceDir, resourceDir))
+    }
+  }
+
+  private def log(str: String): Unit = {
+    System.err.println(s"JMH benchmark generation: $str")
+  }
+}

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -13,6 +13,14 @@ import org.openjdk.jmh.runner.options.{ Options, OptionsBuilder }
 import java.nio.file.{Files, FileSystems, Path}
 
 
+/**
+ * Wrapper around JMH generator code to find JMH benchmarks and emit generated
+ * code for running them.
+ *
+ * This implementation is derived from Thomas Switzer's excellent `sbt` plugin,
+ * `sbt-benchmark`. His original implementation may be found here:
+ * https://github.com/tixxit/sbt-benchmark/blob/master/src/main/scala/net/tixxit/sbt/benchmark/BenchmarkPlugin.scala
+ */
 object BenchmarkGenerator {
   case class JmhGeneratedSources(sources: Seq[Path], resources: Seq[Path])
 

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,0 +1,6 @@
+load("//jmh:jmh.bzl", "scala_benchmark_jmh")
+
+scala_benchmark_jmh(
+    name = "test_benchmark",
+    srcs = ["TestBenchmark.scala"],
+)

--- a/test/jmh/TestBenchmark.scala
+++ b/test/jmh/TestBenchmark.scala
@@ -1,0 +1,10 @@
+package foo
+
+import org.openjdk.jmh.annotations.Benchmark
+
+class TestBenchmark {
+  @Benchmark
+  def sumIntegersBenchmark: Int = {
+    (0 until 1000).reduce(_ + _)
+  }
+}

--- a/test_run.sh
+++ b/test_run.sh
@@ -78,6 +78,15 @@ test_repl() {
   echo "import scala.test._; MoreScalaLibBinary.main(Array())" | bazel-bin/test/MoreScalaLibBinaryRepl | grep "More Hello"
 }
 
+test_benchmark_jmh() {
+  RES=$(bazel run -- test/jmh:test_benchmark -i1 -f1 -wi 1)
+  RESPONSE_CODE=$?
+  if [[ $RES != *Result*Benchmark* ]]; then
+    echo "Benchmark did not produce expected output:\n$RES"
+    exit 1
+  fi
+  exit $RESPONSE_CODE
+}
 NC='\033[0m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
@@ -119,4 +128,5 @@ run_test test_transitive_deps
 run_test test_scala_library_suite
 run_test test_repl
 run_test bazel run test:JavaOnlySources
+run_test test_benchmark_jmh
 


### PR DESCRIPTION
### Summary

This PR adds crude support for JMH benchmarks with a `scala_benchmark_jmh` target. To do this, it also allows compilation of Java sources in source JARs.

The meat of the logic to generate JMH benchmark code was cargo-culted from @tixxit's excellent SBT plug-in for JMH benchmarks:

https://github.com/tixxit/sbt-benchmark/blob/master/src/main/scala/net/tixxit/sbt/benchmark/BenchmarkPlugin.scala

### Motivation
- https://github.com/bazelbuild/rules_scala/issues/157
- https://github.com/bazelbuild/rules_scala/issues/150

### Testing
Added a very simple JMH benchmark under `tests/jmh`.

### TODO

- [x] Generate JARs without updating timestamps.
- [x] (likely) want to split this PR into two, one per issue.

r? @johnynek 