### PR TITLE
travis to work on newer versions and on multiplatforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,41 @@
-addons:
-  apt:
-    sources:
-      - ubuntu-toolchain-r-test
-    packages:
-      - gcc-4.8
-      - g++-4.8
-      - libxml2-utils
-      - wget
-      # Package list from http://bazel.io/docs/install.html
-      - pkg-config
-      - zip
-      - unzip
-      - zlib1g-dev
-jdk:
-  - oraclejdk8
+# trusty beta image has jdk8, gcc4.8.4
+dist: trusty
+sudo: required
+# xcode8 has jdk8
+osx_image: xcode8
+# Not technically required but suppresses 'Ruby' in Job status message.
+language: java
+
+os:
+  - linux
+  - osx
+
+env:
+  - V=HEAD
+  - V=0.4.4
 
 before_install:
-  - wget 'https://github.com/bazelbuild/bazel/releases/download/0.3.2/bazel-0.3.2-installer-linux-x86_64.sh'
-  - sha256sum -c .bazel-installer-linux-x86_64.sh.sha256
-  - chmod +x bazel-0.3.2-installer-linux-x86_64.sh
-  - ./bazel-0.3.2-installer-linux-x86_64.sh --user
-  - mv .bazelrc.travis .bazelrc
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
+      OS=darwin
+    else
+      sysctl kernel.unprivileged_userns_clone=1
+      sudo apt-get update -q 
+      sudo apt-get install libxml2-utils -y
+      OS=linux
+    fi
+    if [[ "${V}" == "HEAD" ]]; then
+      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci"
+      CI_ARTIFACT="`wget -qO- ${CI_BASE} | grep -o 'bazel-[^\"]*-installer.sh' | uniq`"
+      URL="${CI_BASE}/${CI_ARTIFACT}"
+    else
+      URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
+    fi
+    wget -O install.sh "${URL}"
+    chmod +x install.sh
+    ./install.sh --user
+    rm -f install.sh
+  - cat .bazelrc.travis >> .bazelrc
 
 script:
   - bash test_run.sh

--- a/test_run.sh
+++ b/test_run.sh
@@ -84,15 +84,17 @@ RED='\033[0;31m'
 
 function run_test() {
   set +e
+  SECONDS=0
   TEST_ARG=$@
   echo "running test $TEST_ARG"
   RES=$($TEST_ARG 2>&1)
   RESPONSE_CODE=$?
+  DURATION=$SECONDS
   if [ $RESPONSE_CODE -eq 0 ]; then
-    echo -e "${GREEN} Test $TEST_ARG successful $NC"
+    echo -e "${GREEN} Test $TEST_ARG successful ($DURATION sec) $NC"
   else
     echo $RES
-    echo -e "${RED} Test $TEST_ARG failed $NC"
+    echo -e "${RED} Test $TEST_ARG failed $NC ($DURATION sec) $NC"
     exit $RESPONSE_CODE
   fi
 }
@@ -100,6 +102,7 @@ function run_test() {
 xmllint_test() {
   find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null
 }
+
 run_test bazel build test/...
 run_test bazel test test/...
 run_test bazel run test/src/main/scala/scala/test/twitter_scrooge:justscrooges


### PR DESCRIPTION
Previous travis ran only with bazel **0.3.2** and on **linux**.
This update makes sure travis will have 4 permutations:
- versions: **latest** (0.4.4) and **head**.
- platforms: **linux** and **osx**

#Notes:
- The source of this file is from `go_rules` adjusted to this repo
 - I skipped all apt requirements but `libxml2-utils` that failed without it
- Those changes still don't solve issue #76 but will help test solutions to it
- I also added prints on duration of each test that is run by the test_run.sh