### PR TITLE
Transitive dependencies for JMH benchmarks

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -78,7 +78,7 @@ def _scala_generate_benchmark(ctx):
   ctx.action(
       outputs = [ctx.outputs.benchmark_list, ctx.outputs.compiler_hints, ctx.outputs.src_jar],
       inputs = [class_jar] + classpath,
-      executable = list(ctx.attr._generator.files)[0],
+      executable = ctx.executable._generator,
       arguments = [f.path for f in [class_jar, ctx.outputs.src_jar] + classpath],
       progress_message = "Generating benchmark code for %s" % ctx.label,
   )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -118,7 +118,6 @@ def scala_benchmark_jmh(**kw):
   )
 
   codegen = name + "_codegen"
-  src_jar = "%s_jmh.srcjar" % name
   benchmark_list = "resources/META-INF/BenchmarkList"
   compiler_hints = "resources/META-INF/CompilerHints"
 

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -82,9 +82,6 @@ def _scala_generate_benchmark(ctx):
       arguments = [f.path for f in [class_jar, ctx.outputs.src_jar] + classpath],
       progress_message = "Generating benchmark code for %s" % ctx.label,
   )
-  return struct(
-      files=set([ctx.outputs.src_jar])
-  )
 
 scala_generate_benchmark = rule(
     implementation = _scala_generate_benchmark,

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -110,6 +110,8 @@ def scala_benchmark_jmh(**kw):
           "//external:io_bazel_rules_scala/dependency/jmh/jmh_core",
       ],
       scalacopts = scalacopts,
+      resources = kw.get("resources", []),
+      resource_jars = kw.get("resource_jars", []),
       visibility = ["//visibility:public"],
   )
 

--- a/src/scala/io/bazel/rules_scala/jmh_support/BUILD
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BUILD
@@ -10,6 +10,7 @@ scala_library(
       "//external:io_bazel_rules_scala/dependency/jmh/org_ows2_asm_asm",      
       "//src/scala:scala_compiler",
       "//src/java/io/bazel/rulesscala/io_utils",
+      "//src/java/io/bazel/rulesscala/jar",
   ],
   visibility = ["//visibility:public"],
 )

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -10,7 +10,11 @@ import org.openjdk.jmh.generators.asm.ASMGeneratorSource
 import org.openjdk.jmh.runner.{ Runner, RunnerException }
 import org.openjdk.jmh.runner.options.{ Options, OptionsBuilder }
 
+import java.net.URI
+import scala.collection.JavaConverters._
 import java.nio.file.{Files, FileSystems, Path}
+
+import io.bazel.rulesscala.jar.JarCreator
 
 
 /**
@@ -22,24 +26,44 @@ import java.nio.file.{Files, FileSystems, Path}
  * https://github.com/tixxit/sbt-benchmark/blob/master/src/main/scala/net/tixxit/sbt/benchmark/BenchmarkPlugin.scala
  */
 object BenchmarkGenerator {
-  case class JmhGeneratedSources(sources: Seq[Path], resources: Seq[Path])
+
+  case class BenchmarkGeneratorArgs(
+    inputJar: Path,
+    resultSourceJar: Path,
+    classPath: List[Path]
+  ) {
+    val resultResourceDirectory: Path = resultSourceJar.getParent.resolve("resources")
+  }
 
   def main(argv: Array[String]): Unit = {
-    val classPath = System.getProperty("java.class.path").split(':').map {s =>
-      FileSystems.getDefault.getPath(s)
+    val args = parseArgs(argv)
+    if (!args.resultResourceDirectory.toFile.isDirectory) {
+      args.resultResourceDirectory.toFile.mkdirs()
+    }
+    generateJmhBenchmark(
+      args.resultSourceJar,
+      args.resultResourceDirectory,
+      args.inputJar,
+      args.classPath
+    )
+  }
+
+  private def parseArgs(argv: Array[String]): BenchmarkGeneratorArgs = {
+    if (argv.length < 2) {
+      System.err.println(
+        "Usage: BenchmarkGenerator INPUT_JAR RESULT_JAR [CLASSPATH_ELEMENT] [CLASSPATH_ELEMENT...]"
+      )
+      System.exit(1)
     }
     val fs = FileSystems.getDefault
 
-    val outDir = fs.getPath(argv(1))
-    val srcDir = outDir.resolve("sources")
-    if (!srcDir.toFile.isDirectory) { srcDir.toFile.mkdirs() }
-    val resourceDir = outDir.resolve("resources")
-    if (!resourceDir.toFile.isDirectory) { resourceDir.toFile.mkdirs() }
+    val inputJar = fs.getPath(argv(0))
+    val resultSourceJar = fs.getPath(argv(1))
+    val classPath = argv.slice(2, argv.length).map { s => fs.getPath(s) }.toList
 
-    val generated = generateJmhBenchmark(
-      srcDir,
-      resourceDir,
-      List(fs.getPath(argv(0)).getParent),
+    BenchmarkGeneratorArgs(
+      inputJar,
+      resultSourceJar,
       classPath
     )
   }
@@ -51,7 +75,7 @@ object BenchmarkGenerator {
 
   private def listFilesRecursively(root: Path)(pred: Path => Boolean): List[Path] = {
     def loop(fs0: List[Path], files: List[Path]): List[Path] = fs0 match {
-      case f :: fs if f.toFile.isDirectory => loop(fs ++ listFiles(f), files)
+      case f :: fs if Files.isDirectory(f) => loop(fs ++ listFiles(f), files)
       case f :: fs if pred(f) => loop(fs, f :: files)
       case _ :: fs => loop(fs, files)
       case Nil => files.reverse
@@ -60,10 +84,15 @@ object BenchmarkGenerator {
     loop(root :: Nil, Nil)
   }
 
-  private def collectClasses(root: Path): List[Path] =
-    listFilesRecursively(root) { path =>
-      path.getFileName.toString.endsWith(".class")
+  private def collectClassesFromJar(root: Path): List[Path] = {
+    val uri = new URI("jar:file", null, root.toFile.getAbsolutePath, null)
+    val fs = FileSystems.newFileSystem(uri, Map.empty[String, String].asJava)
+    fs.getRootDirectories.asScala.toList.flatMap { rootDir =>
+      listFilesRecursively(rootDir) { (path: Path) =>
+        path.getFileName.toString.endsWith(".class")
+      }
     }
+  }
 
   private def createDirectories(p: Path): Unit = {
     def missingParents(path: Path): List[Path] = {
@@ -109,17 +138,23 @@ object BenchmarkGenerator {
       f(tempDir)
     } finally {
       listFilesRecursively(tempDir)(_ => true).reverse.foreach {file =>
-        log(s"would delete $file")
+        Files.delete(file)
       }
     }
   }
 
+  private def constructJar(output: Path, fileDir: Path): Unit = {
+    val creator = new JarCreator(output.toAbsolutePath.toFile.toString)
+    creator.addDirectory(fileDir.toFile)
+    creator.execute
+  }
+
   private def generateJmhBenchmark(
-    sourceDir: Path,
+    sourceJarOut: Path,
     resourceDir: Path,
-    benchmarkClasspath: Seq[Path],
-    fullClasspath: Seq[Path]
-  ): JmhGeneratedSources = {
+    benchmarkJarPath: Path,
+    classpath: List[Path]
+  ): Unit = {
     withTempDirectory { tempDir =>
       val tmpResourceDir = tempDir.resolve("resources")
       val tmpSourceDir = tempDir.resolve("sources")
@@ -127,13 +162,14 @@ object BenchmarkGenerator {
       tmpResourceDir.toFile.mkdir()
       tmpSourceDir.toFile.mkdir()
 
-      withClassLoader(benchmarkClasspath ++ fullClasspath) {
+      withClassLoader(benchmarkJarPath :: classpath) {
         val source = new ASMGeneratorSource
         val destination = new FileSystemDestination(tmpResourceDir.toFile, tmpSourceDir.toFile)
         val generator = new JMHGenerator
 
-        val classes = benchmarkClasspath.flatMap(f => collectClasses(f)).map(_.toFile)
-        source.processClasses(classes.asJava)
+        collectClassesFromJar(benchmarkJarPath).foreach { path =>
+          source.processClass(Files.newInputStream(path))
+        }
         generator.generate(source, destination)
         generator.complete(source, destination)
         if (destination.hasErrors) {
@@ -143,8 +179,8 @@ object BenchmarkGenerator {
           }
         }
       }
-
-      JmhGeneratedSources(move(tmpSourceDir, sourceDir), move(tmpResourceDir, resourceDir))
+      constructJar(sourceJarOut, tmpSourceDir)
+      move(tmpResourceDir, resourceDir)
     }
   }
 

--- a/test/jmh/AddNumbers.scala
+++ b/test/jmh/AddNumbers.scala
@@ -1,0 +1,7 @@
+package foo
+
+object AddNumbers {
+  def addUntil1000: Int = {
+    (0 until 1000).reduce(_ + _)
+  }
+}

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,6 +1,6 @@
 load("//jmh:jmh.bzl", "scala_library", "scala_benchmark_jmh")
 
-native.java_library(
+java_library(
     name = "java_type",
     srcs = ["JavaType.java"],
     visibility = ["//visibility:public"],

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,6 +1,27 @@
-load("//jmh:jmh.bzl", "scala_benchmark_jmh")
+load("//jmh:jmh.bzl", "scala_library", "scala_benchmark_jmh")
+
+native.java_library(
+    name = "java_type",
+    srcs = ["JavaType.java"],
+    visibility = ["//visibility:public"],
+)
+
+scala_library(
+    name = "scala_type",
+    srcs = ["ScalaType.scala"],
+    visibility = ["//visibility:public"],
+)
+
+scala_library(
+    name = "add_numbers",
+    srcs = ["AddNumbers.scala"],
+    deps = [":scala_type", ":java_type"],
+    exports = [":scala_type", ":java_type"],
+    visibility = ["//visibility:public"],
+)
 
 scala_benchmark_jmh(
     name = "test_benchmark",
     srcs = ["TestBenchmark.scala"],
+    deps = [":add_numbers"],
 )

--- a/test/jmh/JavaType.java
+++ b/test/jmh/JavaType.java
@@ -1,0 +1,5 @@
+package foo;
+
+public class JavaType {
+    public int i = 0;
+}

--- a/test/jmh/ScalaType.scala
+++ b/test/jmh/ScalaType.scala
@@ -1,0 +1,3 @@
+package foo
+
+case class ScalaType(n : Int)

--- a/test/jmh/TestBenchmark.scala
+++ b/test/jmh/TestBenchmark.scala
@@ -1,10 +1,15 @@
 package foo
 
-import org.openjdk.jmh.annotations.Benchmark
+import org.openjdk.jmh.annotations.{Benchmark, Scope, State}
 
 class TestBenchmark {
-  @Benchmark
-  def sumIntegersBenchmark: Int = {
-    (0 until 1000).reduce(_ + _)
+  @State(Scope.Benchmark)
+  class BenchmarkState {
+    val myScalaType = ScalaType(100)
+    val myJavaType = new JavaType
   }
+
+  @Benchmark
+  def sumIntegersBenchmark: Int =
+    AddNumbers.addUntil1000
 }


### PR DESCRIPTION
### Summary

This PR properly gathers the dependencies for JMH benchmark generation. It uses a Skylark rule to assemble the runtime dependencies for the compiled library for which JMH will generate benchmark code. We need the runtime dependencies (rather than the `ijar` compile-only dependencies) since JMH's generators actually need to loaded classes depended upon.

### Motivation

We were failing to build benchmarks with dependencies on targets exported from the benchmarks' dependencies.

### Testing

Added some Java and Scala dependencies to test target for JMH benchmarks.

r? @johnynek 