### PR TITLE
printing the output of failed sh_test run with line breaks

### DIFF
--- a/test_run.sh
+++ b/test_run.sh
@@ -102,7 +102,7 @@ function run_test() {
   if [ $RESPONSE_CODE -eq 0 ]; then
     echo -e "${GREEN} Test $TEST_ARG successful ($DURATION sec) $NC"
   else
-    echo $RES
+    echo "$RES"
     echo -e "${RED} Test $TEST_ARG failed $NC ($DURATION sec) $NC"
     exit $RESPONSE_CODE
   fi


### PR DESCRIPTION
sh_test don't print the each test run output unless it fails.
If it fails - it prints the output without line breaks, which makes it really hard to understand whats going on.

This tiny addition will fix it and make sure the output will be printed with line breaks