### PR TITLE
Add _jdk dependency to binary runfiles and scalac action

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -101,7 +101,8 @@ def _build_nosrc_jar(ctx, buildijar):
     if buildijar:
         outs.extend([ctx.outputs.ijar])
 
-    inputs = ctx.files.resources + [
+    # _jdk added manually since _java doesn't currently setup runfiles
+    inputs = ctx.files.resources + ctx.files._jdk + [
         ctx.outputs.manifest,
         ctx.executable._jar,
         ctx.executable._java,
@@ -207,6 +208,9 @@ SourceJars: {srcjars}
     outs = [ctx.outputs.jar]
     if buildijar:
         outs.extend([ctx.outputs.ijar])
+    # _jdk added manually since _java doesn't currently setup runfiles
+    # _scalac, as a java_binary, should already have it in its runfiles; however,
+    # adding does ensure _java not orphaned if _scalac ever was not a java_binary
     ins = (list(jars) +
            list(dep_srcjars) +
            list(srcjars) +
@@ -215,6 +219,7 @@ SourceJars: {srcjars}
            ctx.files.plugins +
            ctx.files.resources +
            ctx.files.resource_jars +
+           ctx.files._jdk +
            [ctx.outputs.manifest,
             ctx.executable._ijar,
             ctx.executable._java,
@@ -362,7 +367,7 @@ def _collect_jars(targets):
             # see JavaSkylarkApiProvider.java,
             # this is just the compile-time deps
             # this should be improved in bazel 0.1.5 to get outputs.ijar
-            # compile_jars += [target.java.outputs.ijar]
+            # compile_jars += [output.ijar for output in target.java.outputs.jars]
             compile_jars += target.java.transitive_deps
             runtime_jars += target.java.transitive_runtime_deps
             found = True
@@ -444,8 +449,9 @@ def _scala_binary_common(ctx, cjars, rjars):
   outputs = _compile_or_empty(ctx, cjars, [], False)  # no need to build an ijar for an executable
   _build_deployable(ctx, list(rjars))
 
+  # _jdk added manually since _java doesn't currently setup runfiles
   runfiles = ctx.runfiles(
-      files = list(rjars) + [ctx.outputs.executable],
+      files = list(rjars) + [ctx.outputs.executable] + ctx.files._jdk,
       transitive_files = _get_runfiles(ctx.attr._java),
       collect_data = True)
 
@@ -509,8 +515,9 @@ fi
 """,
   )
 
+  # _jdk added manually since _java doesn't currently setup runfiles
   runfiles = ctx.runfiles(
-      files = list(rjars) + [ctx.outputs.executable],
+      files = list(rjars) + [ctx.outputs.executable] + ctx.files._jdk,
       transitive_files = _get_runfiles(ctx.attr._java),
       collect_data = True)
 


### PR DESCRIPTION
The default @local_jdk just imports _java and _javac as raw binaries
without establishing a dependency on/runfiles of _jdk. Thus, all uses of
those should manually add _jdk as a dependency.

In the scalac execution ation that compiles scala, also added _jdk in
case _scalac ever was replaced by a binary that wasn't a java_binary.

Haven't been able to test locally in a hermetic system with the default local_jdk so should wait until CI green before integrating....