### PR TITLE
Some small fixes to the scalac infrastructure

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -1,6 +1,5 @@
 package io.bazel.rulesscala.scalac;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -87,7 +86,7 @@ public class CompileOptions {
   private static String[] getCommaList(Map<String, String> m, String k) {
     if(m.containsKey(k)) {
       String v = m.get(k);
-      if (v == "") {
+      if ("".equals(v)) {
         return new String[]{};
       }
       else {

--- a/src/java/io/bazel/rulesscala/scalac/ScalaCInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalaCInvoker.java
@@ -16,7 +16,6 @@ package io.bazel.rulesscala.scalac;
 
 import java.io.PrintStream;
 import io.bazel.rulesscala.worker.GenericWorker;
-import io.bazel.rulesscala.worker.Processor;
 import scala.Console$;
 
 /**


### PR DESCRIPTION
Removing unused imports, variables.

Properly typing the Enumeration meant no longer needed type-cast, which
is nice. Avoids implicit 'inference' of Enumneration<?> by javac which leads to 'fun'.

constParams removal because was dead code.

== is reference equality and .equals is potentially value equality.