### PR TITLE
Unified use of collect_jar and binary_common, other cleanups

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -192,6 +192,10 @@ scala_repl(
     name = "MoreScalaLibBinaryRepl",
     deps = [":MoreScalaLibBinary"])
 
+scala_repl(
+    name = "ReplWithSources",
+    srcs = ["A.scala"])
+
 scala_library(
   name = "jar_export",
   exports = ["@com_twitter__scalding_date//jar"]

--- a/test_run.sh
+++ b/test_run.sh
@@ -88,6 +88,7 @@ test_repl() {
   echo "import scala.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl | grep "bar" &&
   echo "import scala.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl | grep "A hui hou" &&
   echo "import scala.test._; MoreScalaLibBinary.main(Array())" | bazel-bin/test/MoreScalaLibBinaryRepl | grep "More Hello"
+  echo "import scala.test._; A.main(Array())" | bazel-bin/test/ReplWithSources | grep "4 8 15"
 }
 
 test_benchmark_jmh() {

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -59,12 +59,13 @@ find {out}_tmp -exec touch -t 198001010000 {{}} \;
 rm -rf {out}_tmp"""
 
   cmd = cmd.format(out=ctx.outputs.libarchive.path,
-                   jar=ctx.file._jar.path)
+                   jar=ctx.executable._jar.path)
 
+  # We need _jdk to even run _jar. Depending on _jar is not enough with sandbox
   ctx.action(
     inputs = ctx.files.srcs +
-      ctx.files._jar +
-      ctx.files._jdk, #  We need _jdk to even run _jar. Depending on _jar is not enough with sandbox
+      ctx.files._jdk +
+      [ctx.executable._jar],
     outputs = [ctx.outputs.libarchive],
     command = cmd,
     progress_message = "making thrift archive %s" % ctx.label,
@@ -123,7 +124,7 @@ thrift_library = rule(
       # created by this is created in such a way that absolute imports work...
       "absolute_prefix": attr.string(default='', mandatory=False),
       "absolute_prefixes": attr.string_list(),
-      "_jar": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:jar"), single_file=True, allow_files=True),
+      "_jar": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:jar"), allow_files=True),
       "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
   },
   outputs={"libarchive": "lib%{name}.jar"},


### PR DESCRIPTION
Many places were directly using file or files on various jars when
building up the classpaths. This was not resilient to later changing
those jars to being true java targets (and thus having runtime
dependencies).

Also, there was significant redundancy in the various scala rules each
analyzing their deps and runtime_deps to build up the compile and
runtime jar lists.

A new function _collect_jars_from_common_ctx has been created to reduce
this redundancy. This function looks at ctx.attr.deps and
ctx.attr.runtime_deps to build up compiletime and runtime jars. It also
assumes an automatic dependency on scala-reflect and scala-library.
(This allows eliminating weirdness where both those jars were being
separately added to the compiletime and runtime classpath.) All these
collections are via _collect_jars, rather than files, and thus should be
resilient to later changing the jar sources to true java targets that
have other runtime dependencies. Note that _collect_jars has a failsafe
to look at files when given a non-java target anyway.

Note that the function has parameters for extra_deps and
extra_runtime_deps. This is used by scala_test and scala_junit_test to
implicitly include testing library dependencies and scala_repl to
implicitly include the necessary scala-compiler dependency (since that
holds the main_class runner).

Finally, scala_repl now uses scala_binary_common rather than setting up
its own scala provider, etc. Beforehand, scala_repl was using
commot_attrs, which stipulate srcs and so forth to compile but the
implementation was never actually invoking the compile. Now, scala_repl
just uses _scala_binary_common like scala_binary, scala_test, etc. Added
a test that a REPL with sources actually compiles and can use them.

This did require 'outputs' and generation of a deploy_jar for scala_repl
(since scala_binary_common references them).

Other cleanups or important notes:
The ClassPath of the written manifest is now blank (previously had the
scala-library in it). The restructuring adds the scala-library to the
rjars before passing them to the deploy_jar builder. Thus, scala-library
should end up placed in the deploy jar anyway.

As example of need to consider transitive dependencies for these files,
scalatest_reporter actually requires scala_xml. However, when added as
just a file, would not end up adding scala_xml. Now, using collect_jar
that xml addition happens automatically.

IMPORTANT NOTE: Also for scala_test, CANNOT directly depend on
_scalatest using _collect_jar. _scalatest points to an http_jar, which
runs ijar and exposes that result as the compiletime jar. However,
scalatest defines and exposes macros and so this falls apart. Ideally,
the scalatest label would be retargeted to something like
scala_macro_library, which exposes the right compiletime jars, runtime
jars and providers. (Reverting back to http_file would work but cause
other issues so the stopgap was to mnaually inject the runtime jars as
the compiletime jars. Since no actual dependencies in current scalatest
import, this ends up looking identical as before.)

Further note for future reference that http_jar runs ijar because it is
roughly equivalent to http_file followed by java_import (and java_import
runs ijar).

Remove the various requirements that single_file = true since using
_collect_jar means don't need reliance on file.

Removed scalacompiler from the compiletime class path for compilation of
a scala target. It was not being added to the runtime classpath so this
could have led to code compiling but then failing to load the proper
classes at runtime.

In thrift.bzl, use executable to refer to jar instead of file.