### PR TITLE
travis hardcoded to bazel--installer.sh for HEAD

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,9 +25,7 @@ before_install:
       OS=linux
     fi
     if [[ "${V}" == "HEAD" ]]; then
-      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci"
-      CI_ARTIFACT="`wget -qO- ${CI_BASE} | grep -o 'bazel-[^\"]*-installer.sh' | uniq`"
-      URL="${CI_BASE}/${CI_ARTIFACT}"
+      URL="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci/bazel--installer.sh"
     else
       URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
     fi


### PR DESCRIPTION
Around a week ago Bazel build started to output another "without-jdk" installer which causes the travis script to fail. The script tries to do some parsing on the ci.bazel.io output to find the download url and that parsing needs to be changed to handle the new case.
It looks like the parsing was done to be more resilient to output names but on the other hand the output name seems fixed so I've hardcoded that name (bazel--installer.sh).
Let's see if travis will pass for this one