### PR TITLE
added location expansion with data attribute

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -297,6 +297,10 @@ def _write_launcher(ctx, rjars, main_class, jvm_flags, args, run_before_binary, 
           repo = ctx.workspace_name, spath = f.short_path
       ) for f in rjars])
 
+    location_expanded_jvm_flags = []
+    for jvm_flag in jvm_flags:
+        location_expanded_jvm_flags.append(ctx.expand_location(jvm_flag, ctx.attr.data))
+
     content = """#!/bin/bash
 
 case "$0" in
@@ -323,7 +327,7 @@ exit $BINARY_EXIT_CODE
         classpath = classpath,
         repo = ctx.workspace_name,
         java = ctx.executable._java.short_path,
-        jvm_flags = " ".join(jvm_flags),
+        jvm_flags = " ".join(location_expanded_jvm_flags),
         main_class = main_class,
         args = args,
         run_before_binary = run_before_binary,

--- a/test/BUILD
+++ b/test/BUILD
@@ -301,3 +301,12 @@ sh_test(
     args = ["cat $(location :ScalaBinaryInGenrule)"],
     data = [":ScalaBinaryInGenrule"],
 )
+
+scala_specs2_junit_test(
+    name = "data_location_expansion",
+    srcs = ["src/main/scala/scala/test/location_expansion/LocationExpansionTest.scala"],
+    size = "small",
+    suffixes = ["Test"],
+    data = ["//src/java/com/google/devtools/build/lib:worker"],
+    jvm_flags = ["-Dlocation.expanded=$(location //src/java/com/google/devtools/build/lib:worker)"],
+)

--- a/test/src/main/scala/scala/test/location_expansion/LocationExpansionTest.scala
+++ b/test/src/main/scala/scala/test/location_expansion/LocationExpansionTest.scala
@@ -1,0 +1,14 @@
+package scala.test.location_expansion
+
+import org.specs2.mutable.SpecWithJUnit
+class LocationExpansionTest extends SpecWithJUnit {
+
+  "tests" should {
+    "support location expansion" >> {
+      sys.props.get("location.expanded") must beSome(contain("worker"))
+
+    }
+  }
+  
+
+}


### PR DESCRIPTION
We need $location expansion and that is supported by the java rules.
Not exactly sure why I had to add `ctx.attr.data` explicitly to the `expand_location` since, to me at least, once I add the label in the `data` attribute I think that should be a valid dependency but it's apparently not strict enough for bazel for some reason. I added this [SO](http://stackoverflow.com/questions/43982762/location-expansion-in-bazel) question to try and gather more details on why this works like it does. 