### PR TITLE
test discovery filters abstract classes and traits

### DIFF
--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -7,6 +7,7 @@ import java.io.File
 import java.io.FileInputStream
 import java.util.jar.JarInputStream
 import java.util.jar.JarEntry
+import java.lang.reflect.Modifier
 /*
   The test running and discovery mechanism works in the following manner:
     - Bazel rule executes a JVM application to run tests (currently `JUnitCore`) and asks it to run 
@@ -63,6 +64,7 @@ object PrefixSuffixTestDiscoveringSuite {
       .map(dropFileSuffix)
       .map(fileToClassFormat)
       .map(Class.forName)
+      .filter(concreteClasses)
       .toArray
 
   private def matchingEntries(archive: JarInputStream,
@@ -124,5 +126,8 @@ object PrefixSuffixTestDiscoveringSuite {
 
   private def printDiscoveredClasses: Boolean =
     System.getProperty("bazel.discover.classes.print.discovered").toBoolean
+
+  private def concreteClasses(testClass: Class[_]): Boolean =
+    !Modifier.isAbstract(testClass.getModifiers)
 
 }

--- a/test/BUILD
+++ b/test/BUILD
@@ -328,3 +328,11 @@ scala_specs2_junit_test(
     data = ["//src/java/com/google/devtools/build/lib:worker"],
     jvm_flags = ["-Dlocation.expanded=$(location //src/java/com/google/devtools/build/lib:worker)"],
 )
+
+scala_junit_test(
+    name = "JunitFiltersAbstractClassesAndInterfaces",
+    srcs = ["src/main/scala/scala/test/junit/JunitAbstractClassAndInterface.scala"],
+    size = "small",
+    suffixes = ["Test"],
+    print_discovered_classes = True
+)

--- a/test/src/main/scala/scala/test/junit/JunitAbstractClassAndInterface.scala
+++ b/test/src/main/scala/scala/test/junit/JunitAbstractClassAndInterface.scala
@@ -1,0 +1,21 @@
+package scala.test.junit
+
+import org.junit.Test
+
+abstract class SomeAbstractTest {
+  @Test
+  def abstractTest: Unit =
+  	println("abstract")
+} 
+
+trait SomeTraitTest {
+  @Test
+  def traitTest: Unit =
+  	println("trait")
+} 
+
+class SingleTestSoTargetWillNotFailDueToNoTestsTest {
+  @Test
+  def someTest: Unit =
+  	println("passing")
+} 


### PR DESCRIPTION
junit and specs2 fail with when trying to run abstract classes and traits.
We now filter those out.