### PR TITLE
Shift from using CLASSPATH env variable to arg

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -319,9 +319,9 @@ if [[ -z "$JAVA_RUNFILES" ]]; then
   fi
 fi
 
-export CLASSPATH={classpath}
+CLASSPATH={classpath}
 {run_before_binary}
-$JAVA_RUNFILES/{repo}/{java} {jvm_flags} {main_class} {args} "$@"
+$JAVA_RUNFILES/{repo}/{java} -classpath "$CLASSPATH" {jvm_flags} {main_class} {args} "$@"
 BINARY_EXIT_CODE=$?
 {run_after_binary}
 exit $BINARY_EXIT_CODE


### PR DESCRIPTION
This changes the launcher script from using export CLASSPATH to using
-classpath argument to the java executable. In theory, this should not
cause any differences but seems to break only tut for some reason.