### PR TITLE
junit filters inner classes

### DIFF
--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -63,6 +63,7 @@ object PrefixSuffixTestDiscoveringSuite {
     matchingEntries(archive, prefixes, suffixes)
       .map(dropFileSuffix)
       .map(fileToClassFormat)
+      .filterNot(innerClasses)
       .map(Class.forName)
       .filter(concreteClasses)
       .toArray
@@ -129,5 +130,8 @@ object PrefixSuffixTestDiscoveringSuite {
 
   private def concreteClasses(testClass: Class[_]): Boolean =
     !Modifier.isAbstract(testClass.getModifiers)
+
+  private def innerClasses(testClassName: String): Boolean =
+    testClassName.contains('$')
 
 }

--- a/test/BUILD
+++ b/test/BUILD
@@ -336,3 +336,11 @@ scala_junit_test(
     suffixes = ["Test"],
     print_discovered_classes = True
 )
+
+scala_junit_test(
+    name = "JunitFiltersInnerClasses",
+    srcs = ["src/main/scala/scala/test/junit/JunitInnerClass.scala"],
+    size = "small",
+    prefixes = ["Test"],
+    print_discovered_classes = True
+)

--- a/test/src/main/scala/scala/test/junit/JunitInnerClass.scala
+++ b/test/src/main/scala/scala/test/junit/JunitInnerClass.scala
@@ -1,0 +1,11 @@
+package scala.test.junit
+
+import org.junit.Test
+
+class TestClass {
+  @Test
+  def someTest: Unit =
+  	println("passing")
+
+  class SomeHelper	
+} 


### PR DESCRIPTION
If you have an inner class in a test with a match on prefix (TestClass for example where the prefix is Test) then the current implementation tries to run it as tests (TestClass$SomeHelper matches the prefix of Test).
Surefire's [behavior](https://github.com/apache/maven-surefire/blob/f841a16e4f85ffc28a39baa3f01454c08092f79d/maven-surefire-common/src/main/java/org/apache/maven/plugin/surefire/AbstractSurefireMojo.java#L747) is to filter out inner classes. 
This PR mimics it.