### PR TITLE
Fixed #214 - resources_strip_prefix now works for nosrc jar

### DIFF
--- a/test/src/main/scala/scala/test/resources/strip/BUILD
+++ b/test/src/main/scala/scala/test/resources/strip/BUILD
@@ -1,0 +1,15 @@
+load("//scala:scala.bzl", "scala_library","scala_specs2_junit_test")
+
+scala_library(
+   name = "noSrcsWithResources",
+   resource_strip_prefix="test/src/main/scala/scala/test/resources/strip",
+   resources  = ["nosrc_jar_resource.txt"]
+)
+
+scala_specs2_junit_test(
+    name = "resouceStripPrefixTest",
+    srcs = ["ResourceStripPrefixTest.scala"],
+    deps = [":noSrcsWithResources"],
+    size = "small",
+    suffixes = ["Test"],
+)

--- a/test/src/main/scala/scala/test/resources/strip/ResourceStripPrefixTest.scala
+++ b/test/src/main/scala/scala/test/resources/strip/ResourceStripPrefixTest.scala
@@ -1,0 +1,14 @@
+package scala.test.resources.strip
+
+import org.specs2.mutable.SpecificationWithJUnit
+
+class ResourceStripPrefixTest extends SpecificationWithJUnit {
+
+  "resource_strip_prefix" should {
+    "strip the prefix on nosrc jar" in {
+      val resource = getClass.getResourceAsStream("/nosrc_jar_resource.txt")
+      resource must not beNull
+    }
+  }
+
+}

--- a/test/src/main/scala/scala/test/resources/strip/nosrc_jar_resource.txt
+++ b/test/src/main/scala/scala/test/resources/strip/nosrc_jar_resource.txt
@@ -1,0 +1,1 @@
+I am a text resource!

--- a/test_expect_failure/mismatching_resource_strip_prefix/BUILD
+++ b/test_expect_failure/mismatching_resource_strip_prefix/BUILD
@@ -1,0 +1,7 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+   name = "noSrcsJarWithWrongStripPrefix",
+   resource_strip_prefix="wrong_prefix",
+   resources = ["resource.txt"]
+)

--- a/test_expect_failure/mismatching_resource_strip_prefix/resource.txt
+++ b/test_expect_failure/mismatching_resource_strip_prefix/resource.txt
@@ -1,0 +1,1 @@
+some resource :-)

--- a/test_run.sh
+++ b/test_run.sh
@@ -257,6 +257,17 @@ scala_library_jar_without_srcs_must_include_filegroup_resources(){
   test_resources "noSrcsWithFilegroupResources"
 }
 
+scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix() {
+  set +e
+  bazel build test_expect_failure/wrong_resource_strip_prefix:noSrcsJarWithWrongStripPrefix
+  if [ $? -eq 0 ]; then
+    echo "'bazel build of scala_library with invalid resource_strip_prefix should have failed."
+    exit 1
+  fi
+  set -e
+  exit 0
+}
+
 scala_test_test_filters() {
     # test package wildcard (both)
     local output=$(bazel test \
@@ -344,6 +355,7 @@ $runner multiple_junit_suffixes
 $runner multiple_junit_prefixes
 $runner test_scala_junit_test_can_fail
 $runner junit_generates_xml_logs
+$runner scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix
 $runner multiple_junit_patterns
 $runner test_junit_test_must_have_prefix_or_suffix
 $runner test_junit_test_errors_when_no_tests_found


### PR DESCRIPTION
Noted that the function `_adjust_resources_path` was used for both nosrc jar and the scalac worker.

Because this issue does not happen for scalac worker, I had to rename the function `_adjust_resources_path` to `_adjust_resources_path_by_general_rules` and then create another function for the nosrc jar - that calls the original function only if `resource_strip_prefix` is missing.

The test simply checks that after filtering all lines with "strip" from `jar tf` output, we can still find the resource file.