### PR TITLE
make scala_test honor --test_filter flag.

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -517,12 +517,12 @@ def _scala_test_impl(ctx):
           "suites attribute is deprecated. All scalatest test suites are run"
         )
     jars = _collect_jars_from_common_ctx(ctx,
-        extra_runtime_deps = [ctx.attr._scalatest_reporter],
+        extra_runtime_deps = [ctx.attr._scalatest_reporter, ctx.attr._scalatest_runner],
     )
     (cjars, rjars) = (jars.compiletime, jars.runtime)
     # _scalatest is an http_jar, so its compile jar is run through ijar
     # however, contains macros, so need to handle separately
-    scalatest_jars = _collect_jars([ctx.attr._scalatest, ctx.attr._scalatest_runner]).runtime
+    scalatest_jars = _collect_jars([ctx.attr._scalatest]).runtime
     cjars += scalatest_jars
     rjars += scalatest_jars
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -522,7 +522,7 @@ def _scala_test_impl(ctx):
     (cjars, rjars) = (jars.compiletime, jars.runtime)
     # _scalatest is an http_jar, so its compile jar is run through ijar
     # however, contains macros, so need to handle separately
-    scalatest_jars = _collect_jars([ctx.attr._scalatest]).runtime
+    scalatest_jars = _collect_jars([ctx.attr._scalatest, ctx.attr._scalatest_runner]).runtime
     cjars += scalatest_jars
     rjars += scalatest_jars
 
@@ -649,9 +649,10 @@ scala_binary = rule(
 scala_test = rule(
   implementation=_scala_test_impl,
   attrs={
-      "main_class": attr.string(default="org.scalatest.tools.Runner"),
+      "main_class": attr.string(default="io.bazel.rulesscala.scala_test.Runner"),
       "suites": attr.string_list(),
       "_scalatest": attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scalatest/scalatest"), allow_files=True),
+      "_scalatest_runner": attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scala_test:runner.jar"), allow_files=True),
       "_scalatest_reporter": attr.label(default=Label("//scala/support:test_reporter")),
       } + _launcher_template + _implicit_deps + _common_attrs,
   outputs={

--- a/src/java/io/bazel/rulesscala/scala_test/BUILD
+++ b/src/java/io/bazel/rulesscala/scala_test/BUILD
@@ -1,9 +1,8 @@
-
 java_binary(
-    name="runner",
+    name = "runner",
     srcs = ["Runner.java"],
+    visibility = ["//visibility:public"],
     deps = [
-         "//external:io_bazel_rules_scala/dependency/scalatest/scalatest"
+        "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
     ],
-        visibility = ["//visibility:public"]
 )

--- a/src/java/io/bazel/rulesscala/scala_test/BUILD
+++ b/src/java/io/bazel/rulesscala/scala_test/BUILD
@@ -1,0 +1,9 @@
+
+java_binary(
+    name="runner",
+    srcs = ["Runner.java"],
+    deps = [
+         "//external:io_bazel_rules_scala/dependency/scalatest/scalatest"
+    ],
+        visibility = ["//visibility:public"]
+)

--- a/src/java/io/bazel/rulesscala/scala_test/Runner.java
+++ b/src/java/io/bazel/rulesscala/scala_test/Runner.java
@@ -1,0 +1,41 @@
+package io.bazel.rulesscala.scala_test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * This exists only as a proxy for scala tests's runner to provide
+ * access to env variables
+ */
+public class Runner {
+    /**
+     * This is the name of the env var set by bazel when a user provides
+     * a `--test_filter` test option
+     */
+    private static final String TESTBRIDGE_TEST_ONLY = "TESTBRIDGE_TEST_ONLY";
+
+    public static void main(String[] args) {
+        org.scalatest.tools.Runner.main(extendArgs(args, System.getenv()));
+    }
+
+    private static String[] extendArgs(String[] args, Map<String, String> env) {
+        return extendFromEnvVar(args, env, TESTBRIDGE_TEST_ONLY, "-s");
+    }
+
+    private static String[] extendFromEnvVar(String[] args, Map<String, String> env, String varName, String flagName) {
+        String value = env.get(varName);
+        if (value == null) {
+            return args;
+        };
+        String[] flag = new String[] {
+            flagName,
+            value
+        };
+        String[] result = new String[args.length + flag.length];
+        System.arraycopy(args, 0, result, 0, args.length);
+        System.arraycopy(flag, 0, result, args.length, flag.length);
+
+        return result;
+    }
+}

--- a/test/BUILD
+++ b/test/BUILD
@@ -99,6 +99,12 @@ scala_test_suite(
     ],
 )
 
+scala_test(
+    name = "TestFilterTests",
+    size = "small",
+    srcs = glob(["TestFilterTest*.scala"]),
+)
+
 scala_repl(
     name = "HelloLibTestRepl",
     deps = [":HelloLibTest"])

--- a/test/TestFilterTestA.scala
+++ b/test/TestFilterTestA.scala
@@ -1,0 +1,11 @@
+package scala.test
+
+import org.scalatest.FunSpec
+
+class TestFilterTestA extends FunSpec {
+  describe("A") {
+    it ("tests a") {
+      assert(true)
+    }
+  }
+}

--- a/test/TestFilterTestB.scala
+++ b/test/TestFilterTestB.scala
@@ -1,0 +1,11 @@
+package scala.test
+
+import org.scalatest.FunSpec
+
+class TestFilterTestB extends FunSpec {
+  describe("B") {
+    it ("tests b") {
+      assert(true)
+    }
+  }
+}

--- a/test_run.sh
+++ b/test_run.sh
@@ -203,6 +203,30 @@ scala_library_jar_without_srcs_must_include_filegroup_resources(){
   test_resources "noSrcsWithFilegroupResources"
 }
 
+scala_test_test_filters() {
+    # test package wildcard (both)
+    local output=$(bazel test \
+                         --cache_test_results=no \
+                         --test_output streamed \
+                         --test_filter scala.test.* \
+                         test:TestFilterTests)
+    if [[ $output != *"tests a"* || $output != *"tests b"* ]]; then
+        echo "Should have contained test output from both test filter test a and b"
+        exit 1
+    fi
+    # test just one
+    local output=$(bazel test \
+                         --cache_test_results=no \
+                         --test_output streamed \
+                         --test_filter scala.test.TestFilterTestA \
+                         test:TestFilterTests)
+    if [[ $output != *"tests a"* || $output == *"tests b"* ]]; then
+        echo "Should have only contained test output from test filter test a"
+        exit 1
+    fi
+}
+
+
 run_test bazel build test/...
 run_test bazel test test/...
 run_test bazel run test/src/main/scala/scala/test/twitter_scrooge:justscrooges
@@ -231,3 +255,4 @@ run_test test_junit_test_errors_when_no_tests_found
 run_test scala_library_jar_without_srcs_must_include_direct_file_resources
 run_test scala_library_jar_without_srcs_must_include_filegroup_resources
 run_test bazel run test/src/main/scala/scala/test/large_classpath:largeClasspath
+run_test scala_test_test_filters


### PR DESCRIPTION
This should address #188, enabling what sbt users are used to with it's `testOnly` feature, with the `--test-filter` option of bazel with `scala_test` rules