### PR TITLE
stabilize travis run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,4 +36,4 @@ before_install:
   - cat .bazelrc.travis >> .bazelrc
 
 script:
-  - bash test_run.sh
+  - bash test_run.sh ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,18 @@ before_install:
       OS=linux
     fi
     if [[ "${V}" == "HEAD" ]]; then
-      URL="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/lastSuccessfulBuild/artifact/output/ci/bazel--installer.sh"
+      # Determine last successful build number. This may change while we are
+      # downloading, so it's important to determine ahead of time, in case
+      # we need to resume the download.
+      CI_BASE="http://ci.bazel.io/job/Bazel/JAVA_VERSION=1.8,PLATFORM_NAME=${OS}-x86_64/"
+      CI_INDEX_URL="${CI_BASE}/lastSuccessfulBuild/"
+      wget -q -O build-index.html "${CI_INDEX_URL}"
+      CI_BUILD=$(grep '<title>' build-index.html | sed -e 's/^.*#\([0-9]*\).*$/\1/')
+      # Determine the artifact name. This is normally, bazel--installer.sh,
+      # but it may be, for example, bazel-0.5rc2-installer.sh before a release.
+      CI_ARTIFACT=$(grep -o 'bazel-[^\"-]*-installer.sh' build-index.html | head -n 1)
+      URL="${CI_BASE}/${CI_BUILD}/artifact/output/ci/${CI_ARTIFACT}"
+      rm build-index.html    
     else
       URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
     fi

--- a/test_run.sh
+++ b/test_run.sh
@@ -100,11 +100,64 @@ test_benchmark_jmh() {
   fi
   exit $RESPONSE_CODE
 }
+
 NC='\033[0m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
+TIMOUT=60
 
-function run_test() {
+run_test_ci() {
+  # spawns the test to new process
+  local TEST_ARG=$@
+  local log_file=output_$$.log
+  echo "running test $TEST_ARG"
+  $TEST_ARG &>$log_file &
+  local test_pid=$!
+  SECONDS=0
+  test_pulse_printer $! $TIMOUT $TEST_ARG &
+  local pulse_printer_pid=$!
+  local result
+
+  {
+    wait $test_pid 2>/dev/null
+    result=$?
+    kill $pulse_printer_pid && wait $pulse_printer_pid 2>/dev/null || true
+  } || return 1
+  
+  DURATION=$SECONDS
+  if [ $result -eq 0 ]; then
+    echo -e "\n${GREEN}Test \"$TEST_ARG\" successful ($DURATION sec) $NC"
+  else
+    echo -e "\nLog:\n"
+    cat $log_file
+    echo -e "\n${RED}Test \"$TEST_ARG\" failed $NC ($DURATION sec) $NC"
+  fi
+  return $result
+}
+
+test_pulse_printer() {
+  # makes sure something is printed to stdout while test is running
+  local test_pid=$1
+  shift
+  local timeout=$1 # in minutes
+  shift
+  local count=0
+
+  # clear the line
+  echo -e "\n"
+
+  while [ $count -lt $timeout ]; do
+    count=$(($count + 1))
+    echo -ne "Still running: \"$@\"\r"
+    sleep 60
+  done
+
+  echo -e "\n${RED}Timeout (${timeout} minutes) reached. Terminating \"$@\"${NC}\n"
+  kill -9 $test_pid
+}
+
+run_test_local() {
+  # runs the tests locally
   set +e
   SECONDS=0
   TEST_ARG=$@
@@ -113,10 +166,11 @@ function run_test() {
   RESPONSE_CODE=$?
   DURATION=$SECONDS
   if [ $RESPONSE_CODE -eq 0 ]; then
-    echo -e "${GREEN} Test $TEST_ARG successful ($DURATION sec) $NC"
+    echo -e "${GREEN} Test \"$TEST_ARG\" successful ($DURATION sec) $NC"
   else
+    echo -e "\nLog:\n"
     echo "$RES"
-    echo -e "${RED} Test $TEST_ARG failed $NC ($DURATION sec) $NC"
+    echo -e "${RED} Test \"$TEST_ARG\" failed $NC ($DURATION sec) $NC"
     exit $RESPONSE_CODE
   fi
 }
@@ -261,33 +315,40 @@ scala_junit_test_test_filter(){
   done
 }
 
-run_test bazel build test/...
-run_test bazel test test/...
-run_test bazel run test/src/main/scala/scala/test/twitter_scrooge:justscrooges
-run_test bazel run test:JavaBinary
-run_test bazel run test:JavaBinary2
-run_test bazel run test:MixJavaScalaLibBinary
-run_test bazel run test:MixJavaScalaSrcjarLibBinary
-run_test bazel run test:ScalaBinary
-run_test bazel run test:ScalaLibBinary
-run_test test_disappearing_class
-run_test find -L ./bazel-testlogs -iname "*.xml"
-run_test xmllint_test
-run_test test_build_is_identical
-run_test test_transitive_deps
-run_test test_scala_library_suite
-run_test test_repl
-run_test bazel run test:JavaOnlySources
-run_test test_benchmark_jmh
-run_test multiple_junit_suffixes
-run_test multiple_junit_prefixes
-run_test test_scala_junit_test_can_fail
-run_test junit_generates_xml_logs
-run_test multiple_junit_patterns
-run_test test_junit_test_must_have_prefix_or_suffix
-run_test test_junit_test_errors_when_no_tests_found
-run_test scala_library_jar_without_srcs_must_include_direct_file_resources
-run_test scala_library_jar_without_srcs_must_include_filegroup_resources
-run_test bazel run test/src/main/scala/scala/test/large_classpath:largeClasspath
-run_test scala_test_test_filters
-run_test scala_junit_test_test_filter
+
+if [ "$1" != "ci" ]; then
+  runner="run_test_local"
+else
+  runner="run_test_ci"
+fi
+
+$runner bazel build test/...
+$runner bazel test test/...
+$runner bazel run test/src/main/scala/scala/test/twitter_scrooge:justscrooges
+$runner bazel run test:JavaBinary
+$runner bazel run test:JavaBinary2
+$runner bazel run test:MixJavaScalaLibBinary
+$runner bazel run test:MixJavaScalaSrcjarLibBinary
+$runner bazel run test:ScalaBinary
+$runner bazel run test:ScalaLibBinary
+$runner test_disappearing_class
+$runner find -L ./bazel-testlogs -iname "*.xml"
+$runner xmllint_test
+$runner test_build_is_identical
+$runner test_transitive_deps
+$runner test_scala_library_suite
+$runner test_repl
+$runner bazel run test:JavaOnlySources
+$runner test_benchmark_jmh
+$runner multiple_junit_suffixes
+$runner multiple_junit_prefixes
+$runner test_scala_junit_test_can_fail
+$runner junit_generates_xml_logs
+$runner multiple_junit_patterns
+$runner test_junit_test_must_have_prefix_or_suffix
+$runner test_junit_test_errors_when_no_tests_found
+$runner scala_library_jar_without_srcs_must_include_direct_file_resources
+$runner scala_library_jar_without_srcs_must_include_filegroup_resources
+$runner bazel run test/src/main/scala/scala/test/large_classpath:largeClasspath
+$runner scala_test_test_filters
+$runner scala_junit_test_test_filter


### PR DESCRIPTION
fixes #221 
travis doesn't like it that our build takes > 30m to finish, especially when we don't print anything to stdout while one of the tests is running.

Hence I created an alternative `run_test` that would run only in CI that would run each test as spawned processes and print to stdout every 1 minutes while the spawned process is running.

**why didn't I just replace the current `run_test`?**
Because locally we don't want our test to spawn new processes (we want to be able to terminate the process tree with Ctrl+C, for instance).