### PR TITLE
forcing utf-8 encoding with javac

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -174,7 +174,7 @@ Files: {files}
 IjarCmdPath: {ijar_cmd_path}
 IjarOutput: {ijar_out}
 JarOutput: {out}
-JavacOpts: {javac_opts}
+JavacOpts: -encoding utf8 {javac_opts}
 JavacPath: {javac_path}
 JavaFiles: {java_files}
 JvmFlags: {jvm_flags}

--- a/test/BUILD
+++ b/test/BUILD
@@ -382,3 +382,9 @@ scala_junit_test(
     print_discovered_classes = True,
     suffixes = ["Test"],
 )
+
+scala_library(
+    name = "filesWithUtf8",
+    srcs = ["src/main/scala/scala/test/utf8/JavaClassWithUtf8.java",
+            "src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala"]
+    )

--- a/test/src/main/scala/scala/test/utf8/JavaClassWithUtf8.java
+++ b/test/src/main/scala/scala/test/utf8/JavaClassWithUtf8.java
@@ -1,6 +1,5 @@
 package scala.test.utf8;
 
 class JavaClassWithUtf8{
-	public static final String CHINESES_STR = "http://www.example.com/真　12花柳芳/bla";
 	public static final String UTF_8_STR = "‡"; 
 }

--- a/test/src/main/scala/scala/test/utf8/JavaClassWithUtf8.java
+++ b/test/src/main/scala/scala/test/utf8/JavaClassWithUtf8.java
@@ -1,0 +1,6 @@
+package scala.test.utf8;
+
+class JavaClassWithUtf8{
+	public static final String CHINESES_STR = "http://www.example.com/真　12花柳芳/bla";
+	public static final String UTF_8_STR = "‡"; 
+}

--- a/test/src/main/scala/scala/test/utf8/JavaClassWithUtf8.java
+++ b/test/src/main/scala/scala/test/utf8/JavaClassWithUtf8.java
@@ -1,5 +1,5 @@
 package scala.test.utf8;
 
-class JavaClassWithUtf8{
+class JavaClassWithUtf8 {
 	public static final String UTF_8_STR = "‡"; 
 }

--- a/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
+++ b/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
@@ -1,5 +1,5 @@
 package scala.test.utf8
 
-class ScalaClassWithUTF8{
-	val Utf8String:String = "‡"
+class ScalaClassWithUtf8 {
+	val Utf8String: String = "‡"
 }

--- a/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
+++ b/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
@@ -1,6 +1,5 @@
 package scala.test.utf8
 
 class ScalaClassWithUTF8{
-	val ChineseString:String = "http://www.example.com/真　12花柳芳/bla"
-	val RandomUtfString = "‡"
+	val RandomUtfString:String = "‡"
 }

--- a/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
+++ b/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
@@ -1,0 +1,6 @@
+package scala.test.utf8
+
+class ScalaClassWithUTF8{
+	val ChineseString:String = "http://www.example.com/真　12花柳芳/bla"
+	val RandomUtfString = "‡"
+}

--- a/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
+++ b/test/src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala
@@ -1,5 +1,5 @@
 package scala.test.utf8
 
 class ScalaClassWithUTF8{
-	val RandomUtfString:String = "‡"
+	val Utf8String:String = "‡"
 }


### PR DESCRIPTION
`java_library` compiles UTF-8 files without special configurations.
On systems where UTF-8 is not the default encoding, `scala_library` fails when compiling java code with UTF-8 characters, showing error: 
```
error: unmappable character for encoding ASCII
```
As part of the effort to be compliant with java_library - I suggest we do the same.