### PR TITLE
Add a provider for binary targets

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -487,8 +487,15 @@ def _scala_binary_common(ctx, cjars, rjars):
       compile_jars = depset([outputs.class_jar]),
       transitive_runtime_jars = rjars,
   )
+
+  java_provider = java_common.create_provider(
+      compile_time_jars = scalaattr.compile_jars,
+      runtime_jars = scalaattr.transitive_runtime_jars,
+  )
+
   return struct(
       files=set([ctx.outputs.executable]),
+      providers = [java_provider],
       scala = scalaattr,
       runfiles=runfiles)
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -76,6 +76,13 @@ scala_test(
     ],
 )
 
+# test that a library can depend on a test:
+scala_library(
+    name = "lib_to_test",
+    srcs = ["LibToTest.scala"],
+    deps = [":HelloLibTest"],
+    exports = [":HelloLibTest"])
+
 scala_test_suite(
     name = "HelloLibTestSuite",
     size = "small",  # Not a macro, can pass test-specific attributes.
@@ -175,6 +182,13 @@ scala_binary(
     main_class = "scala.test.ResourcesStripScalaBinary",
     deps = ["ResourcesStripScalaLib"],
 )
+
+# test that a library can depend on a binary:
+scala_library(
+    name = "lib_to_bin",
+    srcs = ["LibToBin.scala"],
+    deps = [":ScalaLibBinary"],
+    exports = [":ScalaLibBinary"])
 
 scala_repl(
     name = "ScalaLibBinaryRepl",

--- a/test/BUILD
+++ b/test/BUILD
@@ -80,8 +80,7 @@ scala_test(
 scala_library(
     name = "lib_to_test",
     srcs = ["LibToTest.scala"],
-    deps = [":HelloLibTest"],
-    exports = [":HelloLibTest"])
+    deps = [":HelloLibTest"])
 
 scala_test_suite(
     name = "HelloLibTestSuite",
@@ -187,8 +186,7 @@ scala_binary(
 scala_library(
     name = "lib_to_bin",
     srcs = ["LibToBin.scala"],
-    deps = [":ScalaLibBinary"],
-    exports = [":ScalaLibBinary"])
+    deps = [":ScalaLibBinary"])
 
 scala_repl(
     name = "ScalaLibBinaryRepl",

--- a/test/LibToBin.scala
+++ b/test/LibToBin.scala
@@ -1,0 +1,5 @@
+package scala.test
+
+object LibToBin {
+  def foo = ScalaLibBinary.main(Array("foo"))
+}

--- a/test/LibToTest.scala
+++ b/test/LibToTest.scala
@@ -1,0 +1,5 @@
+package scala.test
+
+object LibToTest {
+  def foo = TestUtil.foo
+}


### PR DESCRIPTION
this being missing caused us some pain.

1) some targets depend on binaries or test. Maybe not awesome, but not sure we really want to make this impossible either.

2) we want tooling we have that deals with hadoop deploys to just use java providers, but scala_binary does not have one, so it fails.

I added two tests that failed before this change.