### PR TITLE
Organize implicit dependencies necessary for IDEs.

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -620,6 +620,28 @@ _implicit_deps = {
   "_jdk": attr.label(default=Label("//tools/defaults:jdk"), allow_files=True),
 }
 
+# Single dep to allow IDEs to pickup all the implicit dependencies.
+_resolve_deps = {
+  "_scala_toolchain" : attr.label_list(default=[
+    Label("//external:io_bazel_rules_scala/dependency/scala/scala_library"),
+  ], allow_files=False),
+}
+
+_test_resolve_deps = {
+  "_scala_toolchain" : attr.label_list(default=[
+    Label("//external:io_bazel_rules_scala/dependency/scala/scala_library"),
+    Label("//external:io_bazel_rules_scala/dependency/scalatest/scalatest"),
+  ], allow_files=False),
+}
+
+_junit_resolve_deps = {
+  "_scala_toolchain" : attr.label_list(default=[
+    Label("//external:io_bazel_rules_scala/dependency/scala/scala_library"),
+    Label("//external:io_bazel_rules_scala/dependency/junit/junit"),
+    Label("//external:io_bazel_rules_scala/dependency/hamcrest/hamcrest_core"),
+  ], allow_files=False),
+}
+
 # Common attributes reused across multiple rules.
 _common_attrs = {
   "srcs": attr.label_list(
@@ -644,7 +666,7 @@ scala_library = rule(
   attrs={
       "main_class": attr.string(),
       "exports": attr.label_list(allow_files=False),
-      } + _implicit_deps + _common_attrs,
+      } + _implicit_deps + _common_attrs + _resolve_deps,
   outputs={
       "jar": "%{name}.jar",
       "deploy_jar": "%{name}_deploy.jar",
@@ -658,7 +680,7 @@ scala_macro_library = rule(
   attrs={
       "main_class": attr.string(),
       "exports": attr.label_list(allow_files=False),
-      } + _implicit_deps + _common_attrs,
+      } + _implicit_deps + _common_attrs + _resolve_deps,
   outputs={
       "jar": "%{name}.jar",
       "deploy_jar": "%{name}_deploy.jar",
@@ -670,7 +692,7 @@ scala_binary = rule(
   implementation=_scala_binary_impl,
   attrs={
       "main_class": attr.string(mandatory=True),
-      } + _launcher_template + _implicit_deps + _common_attrs,
+      } + _launcher_template + _implicit_deps + _common_attrs + _resolve_deps,
   outputs={
       "jar": "%{name}.jar",
       "deploy_jar": "%{name}_deploy.jar",
@@ -687,7 +709,7 @@ scala_test = rule(
       "_scalatest": attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scalatest/scalatest"), allow_files=True),
       "_scalatest_runner": attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scala_test:runner.jar"), allow_files=True),
       "_scalatest_reporter": attr.label(default=Label("//scala/support:test_reporter")),
-      } + _launcher_template + _implicit_deps + _common_attrs,
+      } + _launcher_template + _implicit_deps + _common_attrs + _test_resolve_deps,
   outputs={
       "jar": "%{name}.jar",
       "deploy_jar": "%{name}_deploy.jar",
@@ -699,7 +721,7 @@ scala_test = rule(
 
 scala_repl = rule(
   implementation=_scala_repl_impl,
-  attrs= _launcher_template + _implicit_deps + _common_attrs,
+  attrs= _launcher_template + _implicit_deps + _common_attrs + _resolve_deps,
   outputs={
       "jar": "%{name}.jar",
       "deploy_jar": "%{name}_deploy.jar",
@@ -865,7 +887,7 @@ def scala_library_suite(name,
 
 scala_junit_test = rule(
   implementation=_scala_junit_test_impl,
-  attrs= _launcher_template + _implicit_deps + _common_attrs + {
+  attrs= _launcher_template + _implicit_deps + _common_attrs + _junit_resolve_deps + {
       "prefixes": attr.string_list(default=[]),
       "suffixes": attr.string_list(default=[]),
       "print_discovered_classes": attr.bool(default=False, mandatory=False),

--- a/test/aspect/BUILD
+++ b/test/aspect/BUILD
@@ -1,9 +1,34 @@
 load(":aspect.bzl", "aspect_test")
-load("//scala:scala.bzl", "scala_test")
-
-aspect_test(
-    name = "test",
-    scala_rule = ":dummy",
+load(
+    "//scala:scala.bzl",
+    "scala_library",
+    "scala_test",
+    "scala_junit_test",
+    "scala_specs2_junit_test",
 )
 
-scala_test(name = "dummy")
+aspect_test(
+    name = "aspect_test",
+    targets = [
+        ":scala_library",
+        ":scala_test",
+        ":scala_junit_test",
+        ":scala_specs2_junit_test",
+    ],
+)
+
+scala_library(name = "scala_library")
+
+scala_test(name = "scala_test")
+
+scala_junit_test(
+    name = "scala_junit_test",
+    srcs = ["FakeJunitTest.scala"],
+    suffixes = ["Test"],
+)
+
+scala_specs2_junit_test(
+    name = "scala_specs2_junit_test",
+    srcs = ["FakeJunitTest.scala"],
+    suffixes = ["Test"],
+)

--- a/test/aspect/FakeJunitTest.scala
+++ b/test/aspect/FakeJunitTest.scala
@@ -1,0 +1,11 @@
+package test.aspect
+
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.junit.runners.JUnit4
+
+@RunWith(classOf[JUnit4])
+class FakeJunitTest {
+  @Test
+  def fakeTest(): Unit = {}
+}

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -1,21 +1,17 @@
-attr_aspects = [
-    "deps",
-    "runtime_deps",
-    "_scalalib",
-    "_scalareflect",
-    "_scalatest_reporter",
-]
+"""
+This test makes sure that the implicit rule dependencies are discoverable by
+an IDE. We stuff all dependencies into _scala_toolchain so we just need to make
+sure the targets we expect are there.
+"""
+attr_aspects = ["_scala_toolchain", "deps"]
 
 def _aspect_impl(target, ctx):
-    visited = [target.label.name]
-    for name in attr_aspects:
-        if hasattr(ctx.rule.attr, name):
-            attr = getattr(ctx.rule.attr, name)
-            # Need to handle whether attribute is label or label list
-            children = attr if type(attr) == "list" else [attr]
-            for child in children:
-                if hasattr(child, "visited"):
-                    visited += child.visited
+    visited = [str(target.label)]
+    for attr_name in attr_aspects:
+        if hasattr(ctx.rule.attr, attr_name):
+            for dep in getattr(ctx.rule.attr, attr_name):
+                if hasattr(dep, "visited"):
+                    visited += dep.visited
     return struct(visited = visited)
 
 test_aspect = aspect(
@@ -24,26 +20,55 @@ test_aspect = aspect(
 )
 
 def _rule_impl(ctx):
-    expected = [
-        "dummy",
-        "jar", # This is scalatest since @scalatest/jar
-        "scala-library",
-        "scala-reflect",
-        "scala-xml", # dependency of test_reporter
-        "test_reporter",
-    ]
-    # Remove duplicates and sort so can do simple comparison
-    visited = sorted(depset(ctx.attr.scala_rule.visited).to_list())
-    if visited == expected:
-        content = "true"
-    else:
-        content = """
-        echo Expected these rules to be visited by the aspect: 1>&2
-        echo %s, 1>&2
-        echo but got these instead: 1>&2
-        echo %s 1>&2
-        false
-        """ % (', '.join(expected), ', '.join(visited))
+    expected_deps = {
+        "scala_library" : [
+            "//test/aspect:scala_library",
+            "@scala//:scala-library",
+        ],
+        "scala_test" : [
+            "//test/aspect:scala_test",
+            "@scala//:scala-library",
+            "@scalatest//jar:jar",
+        ],
+        "scala_junit_test" : [
+            "//test/aspect:scala_junit_test",
+            "@scala//:scala-library",
+            "@io_bazel_rules_scala_junit_junit//jar:jar",
+            "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
+        ],
+        "scala_specs2_junit_test" : [
+            "//test/aspect:scala_specs2_junit_test",
+            "@scala//:scala-library",
+            "@io_bazel_rules_scala_junit_junit//jar:jar",
+            "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
+            # From specs2/specs2.bzl:specs2_dependencies()
+            "@io_bazel_rules_scala_org_specs2_specs2_core//jar:jar",
+            "@io_bazel_rules_scala_org_specs2_specs2_common//jar:jar",
+            "@io_bazel_rules_scala_org_specs2_specs2_matcher//jar:jar",
+            "@io_bazel_rules_scala_org_scalaz_scalaz_effect//jar:jar",
+            "@io_bazel_rules_scala_org_scalaz_scalaz_core//jar:jar",
+            "@scala//:scala-xml",
+            "@scala//:scala-parser-combinators",
+            "@scala//:scala-library",
+            "@scala//:scala-reflect",
+            # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
+            "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
+        ],
+    }
+    content = ""
+    for target in ctx.attr.targets:
+        visited = sorted(target.visited)
+        expected = sorted(expected_deps[target.label.name])
+        if visited != expected:
+            content += """
+            echo Expected these deps from {name}: 1>&2
+            echo {expected}, 1>&2
+            echo but got these instead: 1>&2
+            echo {visited} 1>&2
+            false # test returns 1 (and fails) if this is the final line
+            """.format(name=target.label.name,
+                       expected=', '.join(expected),
+                       visited=', '.join(visited))
     ctx.file_action(
         output = ctx.outputs.executable,
         content = content,
@@ -52,7 +77,10 @@ def _rule_impl(ctx):
 
 aspect_test = rule(
     implementation = _rule_impl,
-    attrs = { "scala_rule" : attr.label(aspects = [test_aspect]) },
+    attrs = {
+        # The targets whose dependencies we want to verify.
+        "targets" : attr.label_list(aspects = [test_aspect]),
+    },
     test = True,
 )
 


### PR DESCRIPTION
Add a separate attribute whose sole purpose is to propagate dependency
information via aspects.
This will allow the IntelliJ aspect to get every necessary implicit
dependency by just following _scala_toolchain.
This also allows us to avoid the issue of certain dependencies being
required to be used as files instead of java targets.