### PR TITLE
Use workspace name in tut rule

### DIFF
--- a/tut_rule/tut.bzl
+++ b/tut_rule/tut.bzl
@@ -23,7 +23,7 @@ def scala_tut_doc(**kw):
     name = tool,
     main_class = "io.bazel.rules_scala.tut_support.TutCompiler",
     deps = deps + [
-      "//src/scala/io/bazel/rules_scala/tut_support:tut_compiler_lib"
+      "@io_bazel_rules_scala//src/scala/io/bazel/rules_scala/tut_support:tut_compiler_lib"
     ],
   )
   native.genrule(


### PR DESCRIPTION
when we load this rule in a remote repo, this label looks like a local label. We need to use the full name of the target.