### PR TITLE
Fix issue with empty args and workers

### DIFF
--- a/src/scala/scripts/TwitterScroogeGenerator.scala
+++ b/src/scala/scripts/TwitterScroogeGenerator.scala
@@ -41,7 +41,7 @@ class ScroogeGenerator extends Processor {
 
   def processRequest(args: java.util.List[String]) {
     def getIdx(i: Int): List[String] =
-      if (args.size > i) args.get(i).split(':').toList.filter(_.nonEmpty)
+      if (args.size > i) args.get(i).drop(1).split(':').toList.filter(_.nonEmpty)
       else Nil
 
     val jarOutput = args.get(0)

--- a/src/scala/scripts/TwitterScroogeGenerator.scala
+++ b/src/scala/scripts/TwitterScroogeGenerator.scala
@@ -40,9 +40,20 @@ class ScroogeGenerator extends Processor {
     }
 
   def processRequest(args: java.util.List[String]) {
-    def getIdx(i: Int): List[String] =
-      if (args.size > i) args.get(i).drop(1).split(':').toList.filter(_.nonEmpty)
+    def getIdx(i: Int): List[String] = {
+      if (args.size > i) {
+        // bazel worker arguments cannot be empty so we pad to ensure non-empty
+        // and drop it off on the other side
+        // https://github.com/bazelbuild/bazel/issues/3329
+        val workerArgPadLen = 1 // workerArgPadLen == "_".length
+        args.get(i)
+          .drop(workerArgPadLen)
+          .split(':')
+          .toList
+          .filter(_.nonEmpty)
+      }
       else Nil
+    }
 
     val jarOutput = args.get(0)
     // These are the files whose output we want

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -140,7 +140,7 @@ def _gen_scrooge_srcjar_impl(ctx):
   # in order to generate code) have targets which will compile them.
   _assert_set_is_subset(only_transitive_thrift_srcs, transitive_owned_srcs)
 
-  path_content = "\n".join([_colon_paths(ps) for ps in [immediate_thrift_srcs, only_transitive_thrift_srcs, remote_jars, external_jars]])
+  path_content = "\n".join(["_" + _colon_paths(ps) for ps in [immediate_thrift_srcs, only_transitive_thrift_srcs, remote_jars, external_jars]])
   worker_content = "{output}\n{paths}\n".format(output = ctx.outputs.srcjar.path, paths = path_content)
 
   argfile = ctx.new_file(ctx.outputs.srcjar, "%s_worker_input" % ctx.label.name)

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -140,7 +140,11 @@ def _gen_scrooge_srcjar_impl(ctx):
   # in order to generate code) have targets which will compile them.
   _assert_set_is_subset(only_transitive_thrift_srcs, transitive_owned_srcs)
 
-  path_content = "\n".join(["_" + _colon_paths(ps) for ps in [immediate_thrift_srcs, only_transitive_thrift_srcs, remote_jars, external_jars]])
+  # bazel worker arguments cannot be empty so we pad to ensure non-empty
+  # and drop it off on the other side
+  # https://github.com/bazelbuild/bazel/issues/3329
+  worker_arg_pad = "_"
+  path_content = "\n".join([worker_arg_pad + _colon_paths(ps) for ps in [immediate_thrift_srcs, only_transitive_thrift_srcs, remote_jars, external_jars]])
   worker_content = "{output}\n{paths}\n".format(output = ctx.outputs.srcjar.path, paths = path_content)
 
   argfile = ctx.new_file(ctx.outputs.srcjar, "%s_worker_input" % ctx.label.name)


### PR DESCRIPTION
when workers are enabled, it seems empty lines are removed from the arguments list. This PR makes sure to always have 1 line per arg (by padding with a leading `_` which is discarded).

This is actually currently a blocker for us. I would love to have better tests around this (that exercise everything with and without workers, but I don't want to try to shave that yak before we get this build issue unblocked).