### PR TITLE
Improve tut rule

### DIFF
--- a/src/scala/io/bazel/rules_scala/tut_support/TutCompiler.scala
+++ b/src/scala/io/bazel/rules_scala/tut_support/TutCompiler.scala
@@ -7,8 +7,7 @@ import tut.TutMain
 
 object TutCompiler {
   def main(args: Array[String]): Unit = {
-    val tmp = Paths.get(Option(System.getenv("TMPDIR")).getOrElse("/tmp"))
-    val mdOutput = Files.createTempDirectory(tmp, "tut")
+    val mdOutput = Files.createTempDirectory("tut")
     val outfile = args(1)
     val classpath = System.getProperty("java.class.path")
     TutMain.main(Array(args(0), mdOutput.toString, ".*\\.md$", "-classpath", classpath))

--- a/tut_rule/tut.bzl
+++ b/tut_rule/tut.bzl
@@ -27,7 +27,7 @@ def scala_tut_doc(**kw):
     ],
   )
   native.genrule(
-      name = "%s__tut" % name,
+      name = name,
       srcs = [src],
       outs = ["%s_tut.md" % name],
       tools = [tool],


### PR DESCRIPTION
We saw two issues which I'm not sure how we didn't catch before:

1) the tmp directory is (sometimes?) outside of bazel's control, so sandboxing fails in one case we have (I thought the build on bazel ci would have caught that).

2) the name for the tut rule is highly unintuitive and not the name you write, so you probably can only build it with a `...` pattern, which is annoying.