### PR TITLE
printing stderr / stdout of javac

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -270,15 +270,24 @@ class ScalacProcessor implements Processor {
     commandParts.add("@" + normalizeSlash(argsFile.toFile().getAbsolutePath()));
     try {
       Process iostat = new ProcessBuilder(commandParts)
-        .inheritIO()
         .start();
+      String error = getInputAsString(iostat.getErrorStream());
+      String output = getInputAsString(iostat.getInputStream());
       int exitCode = iostat.waitFor();
       if(exitCode != 0) {
-        throw new RuntimeException("javac process failed!");
+        throw new RuntimeException("javac process failed! "+ error + " " + output);
+      } else {
+        System.out.println("Javac stdout: " + output);
       }
     }
     finally {
       removeTmp(argsFile);
+    }
+  }
+
+  private static String getInputAsString(InputStream is) {
+    try(java.util.Scanner s = new java.util.Scanner(is)) {
+      return s.useDelimiter("\\A").hasNext() ? s.next() : "";
     }
   }
 


### PR DESCRIPTION
@johnynek I just spent some time trying to debug a failing javac issue and decided that this small change is good even though it's not the actual solution (which is moving to `java_common.compile`).

WDYT?