### PR TITLE
handling none ijar case

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -410,7 +410,8 @@ def provider_of_dependency_contains_label_of(dependency, jar):
   return hasattr(dependency, "jars_to_labels") and jar.path in dependency.jars_to_labels
 
 def dep_target_contains_ijar(dep_target):
-  return hasattr(dep_target, 'scala') and hasattr(dep_target.scala, 'outputs') and hasattr(dep_target.scala.outputs, 'ijar') and dep_target.scala.outputs.ijar
+  return (hasattr(dep_target, 'scala') and hasattr(dep_target.scala, 'outputs') and 
+          hasattr(dep_target.scala.outputs, 'ijar') and dep_target.scala.outputs.ijar)
 
 def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
   compile_jars = depset()

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -410,7 +410,7 @@ def provider_of_dependency_contains_label_of(dependency, jar):
   return hasattr(dependency, "jars_to_labels") and jar.path in dependency.jars_to_labels
 
 def dep_target_contains_ijar(dep_target):
-  return hasattr(dep_target, 'scala') and hasattr(dep_target.scala, 'outputs') and hasattr(dep_target.scala.outputs, 'ijar')
+  return hasattr(dep_target, 'scala') and hasattr(dep_target.scala, 'outputs') and hasattr(dep_target.scala.outputs, 'ijar') and dep_target.scala.outputs.ijar
 
 def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
   compile_jars = depset()


### PR DESCRIPTION
If ijar is none that means dep target does not contain ijar.
This happens to us when working on intellij integration (which we'll contribute back in a few weeks).
Essentially the intellij plugin needs the `scala_import` rule to set ijar as None so that it will take the `class_jar`. This is important for the whole macros handling.
This is also why there isn't a test for this right now. 
This will be covered when we contribute back the `scala_import`
@natansil I'd appreciate your review