### PR TITLE
scrooge compiler: disable logging via a method, not a NullLogger instance

### DIFF
--- a/src/scala/io/bazel/rules_scala/scrooge_support/Compiler.scala
+++ b/src/scala/io/bazel/rules_scala/scrooge_support/Compiler.scala
@@ -38,6 +38,7 @@ import com.twitter.scrooge.frontend.{FileParseException, TypeResolver, ThriftPar
 import java.io.{File, FileWriter}
 import java.nio.file.Paths
 import java.util.jar.{ JarFile, JarEntry }
+import java.util.logging.Level
 import scala.collection.concurrent.TrieMap
 import scala.collection.mutable
 
@@ -128,7 +129,8 @@ class Compiler {
           defaultOptional = isJava,
           skipIncludes = false,
           documentCache
-        )(com.twitter.logging.NullLogger) // scrooge warns on file names with "/"
+        )
+        parser.logger.setLevel(Level.OFF) // scrooge warns on file names with "/"
         val doc = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 
         if (verbose) println("+ Compiling %s".format(inputFile))


### PR DESCRIPTION
Versions of scrooge newer than 4.6.0 use java.util.logging directly, instead of com.twitter.logging.  The NullLogger instance is therefore incompatible with newer versions.  By changing to use setLevel, the logging is disabled for any logger: that method is the same on both the twitter and java loggers, and compiles correctly with more versions of scrooge.

I'm using scrooge 4.15.0 instead of the built-in 4.6.0, and everything works great once I have this change.