### PR TITLE
Moved to java_common.compile

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -800,11 +800,14 @@ library_attrs = {
   "exports": attr.label_list(allow_files=False),
 }
 
-library_outputs = {
+common_outputs = {
   "jar": "%{name}.jar",
   "deploy_jar": "%{name}_deploy.jar",
-  "ijar": "%{name}_ijar.jar",
   "manifest": "%{name}_MANIFEST.MF",
+}
+
+library_outputs = common_outputs + {
+  "ijar": "%{name}_ijar.jar",
 }
 
 scala_library = rule(
@@ -830,11 +833,7 @@ scala_macro_library = rule(
       "main_class": attr.string(),
       "exports": attr.label_list(allow_files=False),
       } + _implicit_deps + _common_attrs + _resolve_deps,
-  outputs={
-      "jar": "%{name}.jar",
-      "deploy_jar": "%{name}_deploy.jar",
-      "manifest": "%{name}_MANIFEST.MF",
-      },
+  outputs= common_outputs,
   fragments = ["java"]
 )
 
@@ -843,11 +842,7 @@ scala_binary = rule(
   attrs={
       "main_class": attr.string(mandatory=True),
       } + _launcher_template + _implicit_deps + _common_attrs + _resolve_deps,
-  outputs={
-      "jar": "%{name}.jar",
-      "deploy_jar": "%{name}_deploy.jar",
-      "manifest": "%{name}_MANIFEST.MF",
-      },
+  outputs= common_outputs,
   executable=True,
   fragments = ["java"]
 )
@@ -863,11 +858,7 @@ scala_test = rule(
       "_scalatest_runner": attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scala_test:runner.jar"), allow_files=True),
       "_scalatest_reporter": attr.label(default=Label("//scala/support:test_reporter")),
       } + _launcher_template + _implicit_deps + _common_attrs + _test_resolve_deps,
-  outputs={
-      "jar": "%{name}.jar",
-      "deploy_jar": "%{name}_deploy.jar",
-      "manifest": "%{name}_MANIFEST.MF",
-      },
+  outputs= common_outputs,
   executable=True,
   test=True,
   fragments = ["java"]
@@ -876,11 +867,7 @@ scala_test = rule(
 scala_repl = rule(
   implementation=_scala_repl_impl,
   attrs= _launcher_template + _implicit_deps + _common_attrs + _resolve_deps,
-  outputs={
-      "jar": "%{name}.jar",
-      "deploy_jar": "%{name}_deploy.jar",
-      "manifest": "%{name}_MANIFEST.MF",
-  },
+  outputs= common_outputs,
   executable=True,
   fragments = ["java"]
 )
@@ -1052,11 +1039,7 @@ scala_junit_test = rule(
       "_suite": attr.label(default=Label("//src/java/io/bazel/rulesscala/test_discovery:test_discovery")),
       "_bazel_test_runner": attr.label(default=Label("@bazel_tools//tools/jdk:TestRunner_deploy.jar"), allow_files=True),
       },
-  outputs={
-      "jar": "%{name}.jar",
-      "deploy_jar": "%{name}_deploy.jar",
-      "manifest": "%{name}_MANIFEST.MF",
-      },
+  outputs= common_outputs,
   test=True,
   fragments = ["java"]
 )

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -644,9 +644,14 @@ def _scala_binary_common(ctx, cjars, rjars, transitive_compile_time_jars, jars2l
       class_jar=outputs.class_jar,
       deploy_jar=ctx.outputs.deploy_jar,
   )
+
+  compile_outputs = [outputs.class_jar]
+  if outputs.java_jar:
+    compile_outputs.extend([outputs.java_jar]) #handle java ijar
+
   scalaattr = struct(
       outputs = rule_outputs,
-      compile_jars = depset([outputs.class_jar]),
+      compile_jars = depset(compile_outputs),
       transitive_runtime_jars = rjars,
   )
 

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -55,7 +55,7 @@ object PrefixSuffixTestDiscoveringSuite {
     classes
   }
 
-  private def discoverClassesIn(archivePath: String) = {
+  private def discoverClassesIn(archivePath: String): Array[Class[_]] = {
     val archive = archiveInputStream(archivePath)
     val classes = discoverClasses(archive, prefixes, suffixesWithClassSuffix)
     archive.close()

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -45,24 +45,30 @@ object PrefixSuffixTestDiscoveringSuite {
 
   private def discoverClasses(): Array[Class[_]] = {
 
-    val archive = archiveInputStream()
+    val archives = archivesPath.split(',')
+    val classes = archives.flatMap(discoverClassesIn)
+    if (classes.isEmpty)
+      throw new IllegalStateException("Was not able to discover any classes " +
+                                      s"for archive=$archives, " +
+                                      s"prefixes=$prefixes, " +
+                                      s"suffixes=$suffixes")
+    classes
+  }
+
+  private def discoverClassesIn(archivePath: String) = {
+    val archive = archiveInputStream(archivePath)
     val classes = discoverClasses(archive, prefixes, suffixesWithClassSuffix)
     archive.close()
     if (printDiscoveredClasses) {
       println("Discovered classes:")
       classes.foreach(c => println(c.getName))
     }
-    if (classes.isEmpty)
-      throw new IllegalStateException("Was not able to discover any classes " +
-                                      s"for archive=$archivePath, " +
-                                      s"prefixes=$prefixes, " +
-                                      s"suffixes=$suffixes")
     classes
   }
 
   private def discoverClasses(archive: JarInputStream,
-    prefixes: Set[String],
-    suffixes: Set[String]): Array[Class[_]] =
+                              prefixes: Set[String],
+                              suffixes: Set[String]): Array[Class[_]] =
     matchingEntries(archive, prefixes, suffixes)
       .map(dropFileSuffix)
       .map(fileToClassFormat)
@@ -108,11 +114,11 @@ object PrefixSuffixTestDiscoveringSuite {
     .map(_.getName)
     .toList
 
-  private def archiveInputStream() =
+  private def archiveInputStream(archivePath: String) =
     new JarInputStream(new FileInputStream(archivePath))
 
-  private def archivePath: String =
-    System.getProperty("bazel.discover.classes.archive.file.path")
+  private def archivesPath: String =
+    System.getProperty("bazel.discover.classes.archives.file.paths")
 
   private def suffixesWithClassSuffix: Set[String] =
     suffixes.map(_ + ".class")

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -118,7 +118,7 @@ object PrefixSuffixTestDiscoveringSuite {
     new JarInputStream(new FileInputStream(archivePath))
 
   private def archivesPath: String =
-    System.getProperty("bazel.discover.classes.archives.file.paths")
+    System.getProperty("bazel.discover.classes.archives.file.paths") //this is set by scala_junit_test rule in scala.bzl
 
   private def suffixesWithClassSuffix: Set[String] =
     suffixes.map(_ + ".class")

--- a/test/BUILD
+++ b/test/BUILD
@@ -285,6 +285,13 @@ scala_junit_test(
     print_discovered_classes = True
 )
 
+scala_junit_test(
+    name = "JunitJavaTest",
+    srcs = ["src/main/scala/scala/test/junit/JunitJavaTest.java"],
+    suffixes = ["Test"],
+    size = "small",
+)
+
 scala_specs2_junit_test(
     name = "Specs2Tests",
     srcs = ["src/main/scala/scala/test/junit/specs2/Specs2Tests.scala"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -424,3 +424,11 @@ scala_binary(
     main_class = "scala.test.A",
     deps = ["//test/example_jars:example_jar1", "//test/example_jars:example_jar2"]
 )
+
+scala_binary(
+    name = "ScalaBinary_dependent_on_binary_with_java",
+    srcs = ["src/main/scala/scala/test/BinaryDependentOnJava.scala"],
+    main_class = "scala.test.BinaryDependentOnJava",
+    deps = [":JavaOnlySources"],
+)
+

--- a/test/src/main/scala/scala/test/BinaryDependentOnJava.scala
+++ b/test/src/main/scala/scala/test/BinaryDependentOnJava.scala
@@ -1,0 +1,5 @@
+package scala.test
+
+object BinaryDependentOnJava extends App {
+  println(classOf[Alpha])
+}

--- a/test/src/main/scala/scala/test/ijar/A.scala
+++ b/test/src/main/scala/scala/test/ijar/A.scala
@@ -1,0 +1,8 @@
+package scala.test.ijar
+
+object A {
+	def foo = {
+		B.foo
+		C.foo
+	}
+}

--- a/test/src/main/scala/scala/test/ijar/B.scala
+++ b/test/src/main/scala/scala/test/ijar/B.scala
@@ -4,4 +4,8 @@ object B {
 	def foo = {
 		println("orig")
 	}
+
+	def bar = {
+		println("orig_sibling")
+	}
 }

--- a/test/src/main/scala/scala/test/ijar/B.scala
+++ b/test/src/main/scala/scala/test/ijar/B.scala
@@ -1,0 +1,7 @@
+package scala.test.ijar
+
+object B {
+	def foo = {
+		println("orig")
+	}
+}

--- a/test/src/main/scala/scala/test/ijar/BUILD
+++ b/test/src/main/scala/scala/test/ijar/BUILD
@@ -1,0 +1,17 @@
+package(default_visibility = ["//visibility:public"])
+load("//scala:scala.bzl", "scala_library", "scala_test", "scala_binary")
+
+scala_library(
+    name="user",
+    srcs=[
+        "A.scala",
+        ],
+    deps = ["dependency"],
+)
+
+scala_library(
+    name="dependency",
+    srcs=[
+        "B.scala", "C.java"
+        ],
+)

--- a/test/src/main/scala/scala/test/ijar/C.java
+++ b/test/src/main/scala/scala/test/ijar/C.java
@@ -4,4 +4,8 @@ class C {
 	public static void foo() {
 		System.out.println("orig");
 	}
+
+	public C() {
+		B$.MODULE$.bar();
+	}
 }

--- a/test/src/main/scala/scala/test/ijar/C.java
+++ b/test/src/main/scala/scala/test/ijar/C.java
@@ -1,0 +1,7 @@
+package scala.test.ijar;
+
+class C {
+	public static void foo() {
+		System.out.println("orig");
+	}
+}

--- a/test/src/main/scala/scala/test/junit/JunitJavaTest.java
+++ b/test/src/main/scala/scala/test/junit/JunitJavaTest.java
@@ -1,0 +1,9 @@
+package scala.test.junit;
+
+import org.junit.Test;
+
+public class JunitJavaTest {
+    @Test
+    public void someTest() {
+    }
+}

--- a/test_expect_failure/compilers_jvm_flags/BUILD
+++ b/test_expect_failure/compilers_jvm_flags/BUILD
@@ -9,3 +9,8 @@ scala_library(
 	srcs = ["WillNotCompileJavaSinceXmxTooLow.java"],
 	javac_jvm_flags = ["-Xmx1M"],
 )
+scala_library(
+	name = "can_configure_jvm_flags_for_javac_via_javacopts",
+	srcs = ["WillNotCompileJavaSinceXmxTooLow.java"],
+	javacopts = ["-Xmx1M"],
+)

--- a/test_run.sh
+++ b/test_run.sh
@@ -417,6 +417,10 @@ javac_jvm_flags_are_configured(){
   action_should_fail build //test_expect_failure/compilers_jvm_flags:can_configure_jvm_flags_for_javac
 }
 
+javac_jvm_flags_via_javacopts_are_configured(){
+  action_should_fail build //test_expect_failure/compilers_jvm_flags:can_configure_jvm_flags_for_javac_via_javacopts
+}
+
 revert_internal_change() {
   sed -i.bak "s/println(\"altered\")/println(\"orig\")/" $no_recompilation_path/C.scala
   rm $no_recompilation_path/C.scala.bak
@@ -488,6 +492,7 @@ $runner scala_test_test_filters
 $runner scala_junit_test_test_filter
 $runner scalac_jvm_flags_are_configured
 $runner javac_jvm_flags_are_configured
+$runner javac_jvm_flags_via_javacopts_are_configured
 $runner test_scala_library_expect_failure_on_missing_direct_internal_deps
 $runner test_scala_library_expect_failure_on_missing_direct_external_deps_jar
 $runner test_scala_library_expect_failure_on_missing_direct_external_deps_file_group


### PR DESCRIPTION
Was supposed to be a refactoring but found a few missing tests.
The good news are that we indeed have good coverage since this hits many code paths and the tests gave me good (though long) feedback about what I'm breaking.

Possible open issues:
1) I haven't changed the "files" being returned- No tests demanded it and I'm trying to understand what needs this. I think our internal aspect actually will be broken by this so I'll try to add a test like it today and see if it breaks.
2) Not sure Intellij integration continues to work now- will see how I triage this. @chaoren can the intellij aspect try to use the java_provider before falling back to scala attr?