### PR TITLE
exposing transitive_compile_time_jars to java_common.provider

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -606,6 +606,7 @@ def _lib(ctx, non_macro_lib):
     java_provider = java_common.create_provider(
         compile_time_jars = scalaattr.compile_jars,
         runtime_jars = scalaattr.transitive_runtime_jars,
+        transitive_compile_time_jars = jars.transitive_compile_jars,
     )
 
     return struct(

--- a/test_expect_failure/missing_direct_deps/internal_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/internal_deps/BUILD
@@ -10,6 +10,14 @@ scala_library(
 )
 
 scala_library(
+    name="transitive_dependency_java_user",
+    srcs=[
+        "User.java",
+        ],
+    deps = ["direct_dependency"],    
+)
+
+scala_library(
     name="direct_dependency",
     srcs=[
         "B.scala",

--- a/test_expect_failure/missing_direct_deps/internal_deps/User.java
+++ b/test_expect_failure/missing_direct_deps/internal_deps/User.java
@@ -1,0 +1,10 @@
+package test_expect_failure.missing_direct_deps.internal_deps;
+
+public class User {
+
+    public void foo() {
+        B.foo();
+        C.foo();
+    }
+
+}

--- a/test_run.sh
+++ b/test_run.sh
@@ -150,6 +150,15 @@ test_scala_library_expect_failure_on_missing_direct_deps_warn_mode() {
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--strict_java_deps=warn" "ne"
 }
 
+test_scala_library_expect_failure_on_missing_direct_java() {
+  dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
+  test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
+
+  expected_message="$dependency_target[ \t]*to[ \t]*$test_target"
+
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
+}
+
 test_scala_library_expect_failure_on_missing_direct_deps_off_mode() {
   expected_message="test_expect_failure/missing_direct_deps/internal_deps/A.scala:[0-9+]: error: not found: value C"
   test_target='test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_user'
@@ -555,3 +564,4 @@ $runner test_multi_service_manifest
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_scala_dependency
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_java_dependency
 $runner test_scala_library_expect_no_java_recompilation_on_internal_change_of_scala_sibling
+$runner test_scala_library_expect_failure_on_missing_direct_java


### PR DESCRIPTION
exposing transitive_compile_time_jars to java_common.provider to use strict java deps
We still can't run this with `warn` until https://github.com/bazelbuild/bazel/issues/3626 is resolved but it's already a step forward.
Additionally if you're using `java_library` targets with strict deps this currently doesn't work and this fixes it as well