### PR TITLE
Strip -source's jars from scala's compiler classpath for dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,11 +21,12 @@ before_install:
       OS=darwin
     else
       sysctl kernel.unprivileged_userns_clone=1
-      sudo apt-get update -q 
+      sudo apt-get update -q
       sudo apt-get install libxml2-utils -y
       OS=linux
     fi
-    URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
+    URL="https://storage.googleapis.com/bazel/0.6.0/rc1/bazel-0.6.0rc1-installer-${OS}-x86_64.sh"
+    # URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
     wget -O install.sh "${URL}"
     chmod +x install.sh
     ./install.sh --user

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
   # we want to test the most recent few releases
   - V=0.5.3
   - V=0.5.4
+  - V=0.6.0rc2
 
 before_install:
   - |
@@ -25,8 +26,13 @@ before_install:
       sudo apt-get install libxml2-utils -y
       OS=linux
     fi
-    URL="https://storage.googleapis.com/bazel/0.6.0/rc1/bazel-0.6.0rc1-installer-${OS}-x86_64.sh"
-    # URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
+    if [[ $V =~ .*rc[0-9]+.* ]]; then
+      PRE_RC=$(expr "$V" : '\([0-9.]*\)rc.*')
+      RC_PRC=$(expr "$V" : '[0-9.]*\(rc.*\)')
+      URL="https://storage.googleapis.com/bazel/${PRE_RC}/${RC_PRC}/bazel-${V}-installer-${OS}-x86_64.sh"
+    else
+      URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
+    fi
     wget -O install.sh "${URL}"
     chmod +x install.sh
     ./install.sh --user
@@ -35,3 +41,4 @@ before_install:
 
 script:
   - bash test_run.sh ci
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,8 +1,5 @@
 workspace(name = "io_bazel_rules_scala")
 
-BAZEL_VERSION = "0.6.0rc1"
-BAZEL_VERSION_SHA = "43571405d296be05ef9cc875cb90c49be17409d7cd4d5a81c7bb84b33cbf7707"
-BAZEL_ZIP_PATH = "https://storage.googleapis.com/bazel/0.6.0/rc1/bazel-0.6.0rc1-dist.zip"
 
 
 load("//scala:scala.bzl", "scala_repositories", "scala_mvn_artifact")

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,5 +1,8 @@
 workspace(name = "io_bazel_rules_scala")
 
+BAZEL_VERSION = "0.6.0rc1"
+BAZEL_VERSION_SHA = "43571405d296be05ef9cc875cb90c49be17409d7cd4d5a81c7bb84b33cbf7707"
+BAZEL_ZIP_PATH = "https://storage.googleapis.com/bazel/0.6.0/rc1/bazel-0.6.0rc1-dist.zip"
 
 
 load("//scala:scala.bzl", "scala_repositories", "scala_mvn_artifact")
@@ -23,6 +26,14 @@ maven_jar(
   artifact = scala_mvn_artifact("com.twitter:scalding-date:0.16.0-RC4"),
   sha1 = "659eb2d42945dea37b310d96af4e12bf83f54d14"
 )
+
+# For testing that we don't include sources jars to the classpath
+maven_jar(
+  name = "org_typelevel__cats_core",
+  artifact = scala_mvn_artifact("org.typelevel:cats-core:0.9.0"),
+  sha1 = "b2f8629c6ec834d8b6321288c9fe77823f1e1314"
+)
+
 
 # test of a plugin
 maven_jar(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -481,8 +481,7 @@ def dep_target_contains_ijar(dep_target):
 # import cats.implicits._
 
 def filter_not_sources(deps):
-  return deps
-  # return depset([dep for dep in deps.to_list() if "-sources.jar" not in dep.basename ])
+  return depset([dep for dep in deps.to_list() if "-sources.jar" not in dep.basename ])
 
 def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
   compile_jars = depset()

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -481,7 +481,8 @@ def dep_target_contains_ijar(dep_target):
 # import cats.implicits._
 
 def filter_not_sources(deps):
-  return depset([dep for dep in deps.to_list() if "-sources.jar" not in dep.basename ])
+  return deps
+  # return depset([dep for dep in deps.to_list() if "-sources.jar" not in dep.basename ])
 
 def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
   compile_jars = depset()

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -523,7 +523,7 @@ def _collect_jars_when_dependency_analyzer_is_on(dep_targets):
         # which breaks scala macros
         compile_jars += filter_not_sources(dep_target.files)
         runtime_jars += filter_not_sources(dep_target.files)
-        transitive_compile_jars += dep_target.files
+        transitive_compile_jars += filter_not_sources(dep_target.files)
 
     add_labels_of_jars_to(jars2labels, dep_target, transitive_compile_jars)
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -145,7 +145,7 @@ def _collect_plugin_paths(plugins):
         # support http_file pointed at a jar. http_jar uses ijar,
         # which breaks scala macros
         elif hasattr(p, "files"):
-            paths += [f.path for f in p.files if "-sources.jar" not in f.basename ]
+            paths += [f.path for f in p.files if not_sources_jar(f.basename) ]
     return paths
 
 
@@ -480,8 +480,11 @@ def dep_target_contains_ijar(dep_target):
 # one of them needs to be removed from classpath
 # import cats.implicits._
 
+def not_sources_jar(name):
+  return "-sources.jar" not in name
+
 def filter_not_sources(deps):
-  return depset([dep for dep in deps.to_list() if "-sources.jar" not in dep.basename ])
+  return depset([dep for dep in deps.to_list() if not_sources_jar(dep.basename) ])
 
 def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
   compile_jars = depset()

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -145,7 +145,7 @@ def _collect_plugin_paths(plugins):
         # support http_file pointed at a jar. http_jar uses ijar,
         # which breaks scala macros
         elif hasattr(p, "files"):
-            paths += [f.path for f in p.files]
+            paths += [f.path for f in p.files if "-sources.jar" not in f.basename ]
     return paths
 
 
@@ -495,10 +495,10 @@ def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
     else:
         # support http_file pointed at a jar. http_jar uses ijar,
         # which breaks scala macros
-        compile_jars += dep_target.files
-        runtime_jars += dep_target.files
+        compile_jars += filter_not_sources(dep_target.files)
+        runtime_jars += filter_not_sources(dep_target.files)
 
-  return struct(compile_jars = filter_not_sources(compile_jars),
+  return struct(compile_jars = compile_jars,
       transitive_runtime_jars = runtime_jars,
       jars2labels = {},
       transitive_compile_jars = depset())
@@ -518,16 +518,16 @@ def _collect_jars_when_dependency_analyzer_is_on(dep_targets):
     else:
         # support http_file pointed at a jar. http_jar uses ijar,
         # which breaks scala macros
-        compile_jars += dep_target.files
-        runtime_jars += dep_target.files
+        compile_jars += filter_not_sources(dep_target.files)
+        runtime_jars += filter_not_sources(dep_target.files)
         transitive_compile_jars += dep_target.files
 
     add_labels_of_jars_to(jars2labels, dep_target, transitive_compile_jars)
 
-  return struct(compile_jars = filter_not_sources(compile_jars),
+  return struct(compile_jars = compile_jars,
     transitive_runtime_jars = runtime_jars,
     jars2labels = jars2labels,
-    transitive_compile_jars = filter_not_sources(transitive_compile_jars))
+    transitive_compile_jars = transitive_compile_jars)
 
 def _collect_jars(dep_targets, dependency_analyzer_is_off = True):
     """Compute the runtime and compile-time dependencies from the given targets"""  # noqa

--- a/test/src/main/scala/scala/test/sources_jars_in_deps/BUILD
+++ b/test/src/main/scala/scala/test/sources_jars_in_deps/BUILD
@@ -1,0 +1,9 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+  name = "source_jar_not_oncp",
+  srcs = ["ReferCatsImplicits.scala"],
+  deps = [
+    "@org_typelevel__cats_core//jar:file",
+  ]
+)

--- a/test/src/main/scala/scala/test/sources_jars_in_deps/ReferCatsImplicits.scala
+++ b/test/src/main/scala/scala/test/sources_jars_in_deps/ReferCatsImplicits.scala
@@ -1,0 +1,6 @@
+package scala_rules.bazel
+import cats.implicits._
+
+
+object TestObj {}
+


### PR DESCRIPTION
This won't effect compiling source jars, but they shouldn't be in the dependency tree.

The issue here is that for maven_jar type imports we need to use the `jar:file` to avoid the ijar behavior for importing scala macros. But since scala 0.6.0 
https://github.com/bazelbuild/bazel/commit/7a7c41d7d342cd427e74f091b55690eed13e280d
Means that the source jars are also being included into this filegroup. Either we need a custom maven fetching rule, or this will strip `-sources.jar` from the dependencies tree. Since we wouldn't expect class files to be in sources jars already compiled this seems safe?

(First push here should fail build with error all going well, then the new code can be activated to pass build)
r? @johnynek 
