### PR TITLE
Use zipper rather than jdk/jar in the thrift rules

### DIFF
--- a/.bazelrc.travis
+++ b/.bazelrc.travis
@@ -17,7 +17,7 @@ build --verbose_failures
 # runs stuff in a container, and since Travis already runs its script
 # in a container (unless you require sudo in your .travis.yml) this
 # fails to run tests.
-build --spawn_strategy=standalone --genrule_strategy=standalone
+build --spawn_strategy=standalone --genrule_strategy=standalone --strategy=Scalac=worker --strategy=ScroogeRule=worker --worker_max_instances=3
 test --test_strategy=standalone
 
 # Below this line, .travis.yml will cat the default bazelrc.

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ env:
   # we want to test the most recent few releases
   - V=0.5.3
   - V=0.5.4
-  - V=0.6.0rc2
+  - V=0.6.0
 
 before_install:
   - |

--- a/test/src/main/scala/scala/test/twitter_scrooge/thrift/BUILD
+++ b/test/src/main/scala/scala/test/twitter_scrooge/thrift/BUILD
@@ -9,3 +9,9 @@ thrift_library(
   ],
   visibility = ["//visibility:public"],
 )
+
+thrift_library(
+  name = "thrift_many",
+  srcs = ["ThriftMany1.thrift", "ThriftMany2.thrift"],
+  visibility = ["//visibility:public"],
+)

--- a/test/src/main/scala/scala/test/twitter_scrooge/thrift/ThriftMany1.thrift
+++ b/test/src/main/scala/scala/test/twitter_scrooge/thrift/ThriftMany1.thrift
@@ -1,0 +1,3 @@
+struct Many1 {
+  1: i32 one
+}

--- a/test/src/main/scala/scala/test/twitter_scrooge/thrift/ThriftMany2.thrift
+++ b/test/src/main/scala/scala/test/twitter_scrooge/thrift/ThriftMany2.thrift
@@ -1,0 +1,3 @@
+struct Many2 {
+  1: i16 two
+}

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -25,7 +25,7 @@ def _thrift_library_impl(ctx):
   if len(src_paths) <= 0 and len(ctx.attr.external_jars) <= 0:
     fail("we require at least one thrift file in a target")
 
-  zipper_args = "\n".join(src_paths)
+  zipper_args = "\n".join(src_paths) + "\n"
   if len(prefixes) > 0:
     common_prefix = _common_prefix(src_paths)
     found_prefixes = [p for p in prefixes if common_prefix.find(p) >= 0]
@@ -43,7 +43,7 @@ def _thrift_library_impl(ctx):
       pos = common_prefix.find(prefix)
       endpos = pos + len(prefix)
       actual_prefix = common_prefix[0:endpos]
-      zipper_args = "\n".join([ "%s=%s" % (src[endpos+1:], src) for src in src_paths ])
+      zipper_args = "\n".join([ "%s=%s" % (src[endpos+1:], src) for src in src_paths ]) + "\n"
 
   if len(src_paths) > 0:
     zipper_arg_path = ctx.actions.declare_file("%s_zipper_args" % ctx.outputs.libarchive.path)

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -25,7 +25,7 @@ def _thrift_library_impl(ctx):
   if len(src_paths) <= 0 and len(ctx.attr.external_jars) <= 0:
     fail("we require at least one thrift file in a target")
 
-  zipper_args = " ".join(src_paths)
+  zipper_args = "\n".join(src_paths)
   if len(prefixes) > 0:
     common_prefix = _common_prefix(src_paths)
     found_prefixes = [p for p in prefixes if common_prefix.find(p) >= 0]
@@ -43,7 +43,7 @@ def _thrift_library_impl(ctx):
       pos = common_prefix.find(prefix)
       endpos = pos + len(prefix)
       actual_prefix = common_prefix[0:endpos]
-      zipper_args = " ".join([ "%s=%s" % (src[endpos+1:], src) for src in src_paths ])
+      zipper_args = "\n".join([ "%s=%s" % (src[endpos+1:], src) for src in src_paths ])
 
   if len(src_paths) > 0:
     zipper_arg_path = ctx.actions.declare_file("%s_zipper_args" % ctx.outputs.libarchive.path)
@@ -59,7 +59,6 @@ rm -f {out}
     cmd = cmd.format(out=ctx.outputs.libarchive.path,
                      path=zipper_arg_path.path,
                      zipper=ctx.executable._zipper.path)
-
     ctx.action(
       inputs = ctx.files.srcs + [ctx.executable._zipper, zipper_arg_path],
       outputs = [ctx.outputs.libarchive],


### PR DESCRIPTION
Bazel has a built in command for building zips deterministically. Use that rather than the find + timestamp setting trick.

closes #282 