### PR TITLE
Use zipper for empty-srcs targets

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -86,7 +86,7 @@ def _build_nosrc_jar(ctx, buildijar):
           ijar_output=ctx.outputs.ijar.path)
 
     # this ensures the file is not empty
-    resources += ctx.outputs.manifest.path + "\n"
+    resources += "META-INF/MANIFEST.MF=%s\n" % ctx.outputs.manifest.path
 
     zipper_arg_path = ctx.actions.declare_file("%s_zipper_args" % ctx.outputs.jar.path)
     ctx.file_action(zipper_arg_path, resources)

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -17,8 +17,6 @@ public class CompileOptions {
   final public String ijarOutput;
   final public String ijarCmdPath;
   final public String[] javaFiles;
-  final public String javacPath;
-  final public String javacOpts;
   final public Map<String, String> resourceFiles;
   final public String resourceStripPrefix;
   final public String[] resourceJars;
@@ -41,8 +39,6 @@ public class CompileOptions {
     files = getCommaList(argMap, "Files");
 
     javaFiles = getCommaList(argMap, "JavaFiles");
-    javacPath = getOrEmpty(argMap, "JavacPath");
-    javacOpts = getOrEmpty(argMap, "JavacOpts");
 
     sourceJars = getCommaList(argMap, "SourceJars");
     iJarEnabled = booleanGetOrFalse(argMap, "EnableIjar");


### PR DESCRIPTION
closes #288 

While I was at it, I trimmed out some stuff we are no longer using from scalac compilation, which was relevant because I was trying to remove uses of `_jdk` and related dependencies.