### PR TITLE
Dependencies cleanup

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -23,8 +23,8 @@ specs2_junit_repositories()
 # test adding a scala jar:
 maven_jar(
   name = "com_twitter__scalding_date",
-  artifact = scala_mvn_artifact("com.twitter:scalding-date:0.16.0-RC4"),
-  sha1 = "659eb2d42945dea37b310d96af4e12bf83f54d14"
+  artifact = scala_mvn_artifact("com.twitter:scalding-date:0.17.0"),
+  sha1 = "420fb0c4f737a24b851c4316ee0362095710caa5"
 )
 
 # For testing that we don't include sources jars to the classpath

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -15,6 +15,7 @@
 """Rules for supporting the Scala language."""
 
 load("//specs2:specs2_junit.bzl", "specs2_junit_dependencies")
+load(":scala_cross_version.bzl", "scala_version", "scala_mvn_artifact")
 _jar_filetype = FileType([".jar"])
 _java_filetype = FileType([".java"])
 _scala_filetype = FileType([".scala"])
@@ -971,17 +972,6 @@ scala_repl = rule(
   executable=True,
   fragments = ["java"]
 )
-
-def scala_version():
-  """return the scala version for use in maven coordinates"""
-  return "2.11"
-
-def scala_mvn_artifact(artifact):
-  gav = artifact.split(":")
-  groupid = gav[0]
-  artifactid = gav[1]
-  version = gav[2]
-  return "%s:%s_%s:%s" % (groupid, artifactid, scala_version(), version)
 
 SCALA_BUILD_FILE = """
 # scala.BUILD

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -1,0 +1,28 @@
+# Copyright 2015 The Bazel Authors. All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Helper functions for Scala cross-version support. Encapsulates the logic
+of abstracting over Scala major version (2.11, 2.12, etc) for dependency
+resolution."""
+
+def scala_version():
+  """return the scala version for use in maven coordinates"""
+  return "2.11"
+
+def scala_mvn_artifact(artifact):
+  gav = artifact.split(":")
+  groupid = gav[0]
+  artifactid = gav[1]
+  version = gav[2]
+  return "%s:%s_%s:%s" % (groupid, artifactid, scala_version(), version)

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -1,4 +1,5 @@
 load("//scala:scala.bzl",
+  "scala_mvn_artifact",
   "scala_library",
   "collect_jars",
   "create_java_provider")
@@ -23,7 +24,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_plugin",
-        artifact = "com.trueaccord.scalapb:compilerplugin_2.11:0.6.5",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:compilerplugin:0.6.5"),
         sha1 = "290094c632c95b36b6f66d7dbfdc15242b9a247f",
         server = "scala_proto_deps_maven_server",
     )
@@ -35,7 +36,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_protoc_bridge",
-        artifact = "com.trueaccord.scalapb:protoc-bridge_2.11:0.3.0-M1",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:protoc-bridge:0.3.0-M1"),
         sha1 = "73d38f045ea8f09cc1264991d1064add6eac9e00",
         server = "scala_proto_deps_maven_server",
     )
@@ -47,7 +48,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapbc",
-        artifact = "com.trueaccord.scalapb:scalapbc_2.11:0.6.5",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapbc:0.6.5"),
         sha1 = "b204d6d56a042b973af5b6fe28f81ece232d1fe4",
         server = "scala_proto_deps_maven_server",
     )
@@ -59,7 +60,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_runtime",
-        artifact = "com.trueaccord.scalapb:scalapb-runtime_2.11:0.6.5",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime:0.6.5"),
         sha1 = "ac9287ff48c632df525773570ee4842e3ddf40e9",
         server = "scala_proto_deps_maven_server",
     )
@@ -71,7 +72,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_runtime_grpc",
-        artifact = "com.trueaccord.scalapb:scalapb-runtime-grpc_2.11:0.6.5",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime-grpc:0.6.5"),
         sha1 = "9dc3374001f4190548db36a7dc87bd4f9bca6f9c",
         server = "scala_proto_deps_maven_server",
     )
@@ -83,7 +84,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_lenses",
-        artifact = "com.trueaccord.lenses:lenses_2.11:0.4.12",
+        artifact = scala_mvn_artifact("com.trueaccord.lenses:lenses:0.4.12"),
         sha1 = "c5fbf5b872ce99d9a16d3392ccc0d15a0e43d823",
         server = "scala_proto_deps_maven_server",
     )
@@ -95,7 +96,7 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_fastparse",
-        artifact = "com.lihaoyi:fastparse_2.11:0.4.4",
+        artifact = scala_mvn_artifact("com.lihaoyi:fastparse:0.4.4"),
         sha1 = "f065fe0afe6fd2b4557d985c37362c36f08f9947",
         server = "scala_proto_deps_maven_server",
     )

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -1,38 +1,42 @@
+load("//scala:scala_cross_version.bzl",
+  "scala_mvn_artifact",
+  )
+
 def specs2_version():
   return "3.8.8"
 def specs2_repositories():
 
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_core",
-      artifact = "org.specs2:specs2-core_2.11:" + specs2_version(),
+      artifact = scala_mvn_artifact("org.specs2:specs2-core:" + specs2_version()),
       sha1 = "495bed00c73483f4f5f43945fde63c615d03e637",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2_core', actual = '@io_bazel_rules_scala_org_specs2_specs2_core//jar')
   
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_common",
-      artifact = "org.specs2:specs2-common_2.11:" + specs2_version(),
+      artifact = scala_mvn_artifact("org.specs2:specs2-common:" + specs2_version()),
       sha1 = "15bc009eaae3a574796c0f558d8696b57ae903c3",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2_common', actual = '@io_bazel_rules_scala_org_specs2_specs2_common//jar')
   
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_matcher",
-      artifact = "org.specs2:specs2-matcher_2.11:" + specs2_version(),
+      artifact = scala_mvn_artifact("org.specs2:specs2-matcher:" + specs2_version()),
       sha1 = "d2e967737abef7421e47b8994a8c92784e624d62",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2_matcher', actual = '@io_bazel_rules_scala_org_specs2_specs2_matcher//jar')
   
   native.maven_jar(
       name = "io_bazel_rules_scala_org_scalaz_scalaz_effect",
-      artifact = "org.scalaz:scalaz-effect_2.11:7.2.7",
+      artifact = scala_mvn_artifact("org.scalaz:scalaz-effect:7.2.7"),
       sha1 = "824bbb83da12224b3537c354c51eb3da72c435b5",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/scalaz/scalaz_effect', actual = '@io_bazel_rules_scala_org_scalaz_scalaz_effect//jar')
 
   native.maven_jar(
       name = "io_bazel_rules_scala_org_scalaz_scalaz_core",
-      artifact = "org.scalaz:scalaz-core_2.11:7.2.7",
+      artifact = scala_mvn_artifact("org.scalaz:scalaz-core:7.2.7"),
       sha1 = "ebf85118d0bf4ce18acebf1d8475ee7deb7f19f1",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/scalaz/scalaz_core', actual = '@io_bazel_rules_scala_org_scalaz_scalaz_core//jar')

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -1,4 +1,5 @@
 load("//specs2:specs2.bzl", "specs2_repositories", "specs2_dependencies", "specs2_version")
+load("//scala:scala_cross_version.bzl", "scala_mvn_artifact")
 load("//junit:junit.bzl", "junit_repositories")
   
 def specs2_junit_repositories():
@@ -7,7 +8,7 @@ def specs2_junit_repositories():
   # Aditional dependencies for specs2 junit runner
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_junit_2_11",
-      artifact = "org.specs2:specs2-junit_2.11:" + specs2_version(),
+      artifact = scala_mvn_artifact("org.specs2:specs2-junit:" + specs2_version()),
       sha1 = "1dc9e43970557c308ee313842d84094bc6c1c1b5",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2_junit', actual = '@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar')

--- a/tut_rule/tut.bzl
+++ b/tut_rule/tut.bzl
@@ -1,4 +1,5 @@
 load("//scala:scala.bzl", "scala_binary")
+load("//scala:scala_cross_version.bzl", "scala_mvn_artifact")
 
 def tut_repositories():
   native.maven_server(
@@ -8,7 +9,7 @@ def tut_repositories():
 
   native.maven_jar(
     name = "io_bazel_rules_scala_org_tpolecat_tut_core",
-    artifact = "org.tpolecat:tut-core_2.11:0.4.8",
+    artifact = scala_mvn_artifact("org.tpolecat:tut-core:0.4.8"),
     sha1 = "fc723eb822494580cc05d6b3b3a6039d2280a5a0",
     server = "tut_repositories_maven_server",
   )


### PR DESCRIPTION
* migrate from hardcoded _2.11 to `scala_mvn_artifact`
* upgrade to scalding-date 0.17.0

See commits for details.