### PR TITLE
exec in wrapper script if we aren't in the repl

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -389,15 +389,20 @@ def _write_launcher(ctx, rjars, main_class, jvm_flags, args="", wrapper_preamble
     javabin = "%s/%s" % (runfiles_root, ctx.executable._java.short_path)
     template = ctx.attr._java_stub_template.files.to_list()[0]
 
+    exec_str = ""
+    if wrapper_preamble == "":
+      exec_str = "exec "
+
     wrapper = ctx.new_file(ctx.label.name + "_wrapper.sh")
     ctx.file_action(
         output = wrapper,
         content = """#!/bin/bash
 {preamble}
 
-{javabin} "$@" {args}
+{exec_str}{javabin} "$@" {args}
 """.format(
             preamble=wrapper_preamble,
+            exec_str=exec_str,
             javabin=javabin,
             args=args,
         ),


### PR DESCRIPTION
we had an internal system that didn't work when someone used the `_wrapper` script because we hadn't exec'ed.

This fixes it. Really, users should only use the `wrapper.sh` for the repl, but this is probably not clear, so this error is easy to make.

~~Alternatively, we could actually just not generate this file for non-repl targets, which I also think would work although it would be a break for people who have assumed it exists. This seems the most conservative change.~~

actually, the standard launcher calls this wrapper, so I think we do want this PR exactly as is.