### PR TITLE
Prepend generated file root to protobuf input root path.

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -310,8 +310,13 @@ def scala_proto_repositories():
         actual = '@scala_proto_rules_netty_handler_proxy//jar'
     )
 
+def _root_path(f):
+    if f.is_source:
+        return f.owner.workspace_root
+    return '/'.join([f.root.path, f.owner.workspace_root])
+
 def _colon_paths(data):
-  return ':'.join(["{root},{path}".format(root=f.owner.workspace_root, path=f.path) for f in data])
+    return ':'.join(["{root},{path}".format(root=_root_path(f), path=f.path) for f in data])
 
 def _gen_proto_srcjar_impl(ctx):
     acc_imports = depset()


### PR DESCRIPTION
Protobufs generated in a separate repository do not have their root set properly. This causes builds to fail when using well known protos from the latest https://github.com/google/protobuf.

Fixes https://github.com/bazelbuild/rules_scala/issues/312.

I could not find documentation on the right way to join paths in `bzl` files so have resorted to `'/'.join(...)`. Open to suggestions on a better way to do that.