### PR TITLE
strict-deps clearer message when no transitive jars2labels

### DIFF
--- a/test_expect_failure/missing_direct_deps/internal_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/internal_deps/BUILD
@@ -1,5 +1,6 @@
 package(default_visibility = ["//visibility:public"])
 load("//scala:scala.bzl", "scala_library", "scala_test", "scala_binary")
+load(":custom-jvm-rule.bzl", "custom_jvm")
 
 scala_library(
     name="transitive_dependency_user",
@@ -30,6 +31,19 @@ scala_library(
     srcs=[
         "C.scala",
         ],
+)
+
+scala_library(
+    name="dependent_on_some_java_provider",
+    srcs=[
+        "HasCustomJavaProviderDependency.scala",
+        ],
+    deps = ["direct_java_provider_dependency"],    
+)
+
+custom_jvm(
+    name="direct_java_provider_dependency",
+    deps = ["transitive_dependency"],
 )
 
 scala_binary(

--- a/test_expect_failure/missing_direct_deps/internal_deps/HasCustomJavaProviderDependency.scala
+++ b/test_expect_failure/missing_direct_deps/internal_deps/HasCustomJavaProviderDependency.scala
@@ -1,0 +1,8 @@
+package test_expect_failure.missing_direct_deps.internal_deps
+
+object HasCustomJavaProviderDependency {
+  def foo = {
+    C.foo
+  }
+
+}

--- a/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
+++ b/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
@@ -1,0 +1,24 @@
+def _custom_jvm_impl(ctx):
+    print(ctx.label)
+    transitive_compile_jars = _collect(ctx.attr.deps)
+    print(transitive_compile_jars)
+    return struct(
+        providers = [
+          java_common.create_provider(
+              transitive_compile_time_jars = transitive_compile_jars,
+          )
+        ],
+    )
+
+def _collect(deps):
+  transitive_compile_jars = depset()
+  for dep_target in deps:
+      transitive_compile_jars += dep_target[java_common.provider].transitive_compile_time_jars + dep_target[java_common.provider].compile_jars
+  return transitive_compile_jars
+
+custom_jvm = rule(
+  implementation=_custom_jvm_impl,
+  attrs={
+      "deps": attr.label_list(),
+      },
+)

--- a/test_run.sh
+++ b/test_run.sh
@@ -170,6 +170,16 @@ test_scala_library_expect_failure_on_missing_direct_java() {
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
 }
 
+test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules() {
+  transitive_target='.*transitive_dependency_ijar.jar'
+  direct_target='//test_expect_failure/missing_direct_deps/internal_deps:direct_java_provider_dependency'
+  test_target='//test_expect_failure/missing_direct_deps/internal_deps:dependent_on_some_java_provider'
+
+  expected_message="Unknown label of file $transitive_target which came from $direct_target"
+
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
+}
+
 test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java() {
   dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
@@ -593,3 +603,4 @@ $runner test_scala_library_expect_no_java_recompilation_on_internal_change_of_sc
 $runner test_scala_library_expect_failure_on_missing_direct_java
 $runner bazel run test:test_scala_proto_server
 $runner test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java
+$runner test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules


### PR DESCRIPTION
strict-deps clearer message when no transitive jars2labels
drive-by (mostly optimizations):
iterate over deps one (via current_dep_*_jars)
for runtime_deps skip collecting labels
@johnynek:
This PR came from me troubleshooting our strict deps move with our scala_import. The need comes from a problem in the design of java_common where each rule will have to calculate the transitive labels on their own. I hope to address it via bazel but it will take time. The current solution is the simplest I could find without going into the plugin and introducing more concepts (which I hope will be redundant once Bazel supports them natively).