### PR TITLE
create provider conditionally based on existence of attribute

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ os:
 env:
   # we want to test the most recent few releases
   - V=0.6.0
+  - V=0.7.0
 
 before_install:
   - |

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -598,7 +598,7 @@ def _collect_jars_from_common_ctx(ctx, extra_deps = [], extra_runtime_deps = [])
 def _format_full_jars_for_intellij_plugin(full_jars):
     return [struct (class_jar = jar, ijar = None) for jar in full_jars]
 
-def create_java_provider(ctx, scalaattr, transitive_compile_time_jars):
+def create_java_provider(scalaattr, transitive_compile_time_jars):
     # This is needed because Bazel >=0.7.0 requires ctx.actions and a Java
     # toolchain. Fortunately, the same change that added this requirement also
     # added this field to the Java provider so we can use it to test which
@@ -672,7 +672,7 @@ def _lib(ctx, non_macro_lib):
         transitive_exports = [] #needed by intellij plugin
     )
 
-    java_provider = create_java_provider(ctx, scalaattr, jars.transitive_compile_jars)
+    java_provider = create_java_provider(scalaattr, jars.transitive_compile_jars)
 
     return struct(
         files = depset([ctx.outputs.jar]),  # Here is the default output
@@ -736,7 +736,7 @@ def _scala_binary_common(ctx, cjars, rjars, transitive_compile_time_jars, jars2l
       transitive_exports = [] #needed by intellij plugin
   )
 
-  java_provider = create_java_provider(ctx, scalaattr, transitive_compile_time_jars)
+  java_provider = create_java_provider(scalaattr, transitive_compile_time_jars)
 
   return struct(
       files=depset([ctx.outputs.executable]),

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -369,7 +369,7 @@ def _gen_proto_srcjar_impl(ctx):
       compile_jars =  deps_jars.compile_jars,
       transitive_runtime_jars = deps_jars.transitive_runtime_jars,
     )
-    java_provider = create_java_provider(ctx, scalaattr, depset())
+    java_provider = create_java_provider(scalaattr, depset())
     return struct(
         scala = scalaattr,
         providers = [java_provider],


### PR DESCRIPTION
fixes compatibility with 0.7.0 onwards
fixes #280 
fixes #314 
fixes https://github.com/bazelbuild/bazel/issues/3792
Good news:
Small and easy fix. Identical to what @lberki did but just for the additional provider that was added.
Bad news:
Actually utilizing the feature @iirina exposed for us proves to be more tricky than expected for two reasons:
1. We have intimate handling of ijar and output gluing throughout our code.
2. I think the current `create_provider` API doesn't take into account `exports`

**Note**:
The provider is hardcoded to not create an ijar exactly due to the problems above. The current fix is just to play nice with the skylark API and sidestep the new feature.