### PR TITLE
adding scala_import

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -1,8 +1,10 @@
+#intellij part is tested manually, tread lightly when changing there
+#if you change make sure to manually re-import an intellij project and see imports
+#are resolved (not red) and clickable
 def _scala_import_impl(ctx):
     target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars)
-    (code_jars, intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
-    jars2labels = _add_labels_of_current_code_jars(code_jars, ctx.label)
-    code_jars_depset = depset(code_jars)
+    (current_target_compile_jars, intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
+    jars2labels = _add_labels_of_current_code_jars(current_target_compile_jars, ctx.label)
     transitive_runtime_jars = _collect_runtime(ctx.attr.runtime_deps)
     jars = _collect(ctx.attr.deps, jars2labels)
     return struct(
@@ -13,25 +15,24 @@ def _scala_import_impl(ctx):
         ),
         jars_to_labels = jars2labels,
         providers = [
-            _create_provider(code_jars_depset, transitive_runtime_jars, jars)
+            _create_provider(depset(current_target_compile_jars), transitive_runtime_jars, jars)
         ],
     )
-def _create_provider(code_jars_depset, transitive_runtime_jars, jars):
+def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars):
   test_provider = java_common.create_provider()
   if hasattr(test_provider, "full_compile_jars"):
       return java_common.create_provider(
           use_ijar = False,
-          compile_time_jars = code_jars_depset,
-          runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars,
-          transitive_compile_time_jars = jars.transitive_compile_jars + code_jars_depset,
-          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + code_jars_depset,
+          compile_time_jars = current_target_compile_jars,
+          transitive_compile_time_jars = jars.transitive_compile_jars + current_target_compile_jars,
+          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + current_target_compile_jars,
       )
   else:
       return java_common.create_provider(
-          compile_time_jars = code_jars_depset,
+          compile_time_jars = current_target_compile_jars,
           runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars,
-          transitive_compile_time_jars = jars.transitive_compile_jars + code_jars_depset,
-          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + code_jars_depset,
+          transitive_compile_time_jars = jars.transitive_compile_jars + current_target_compile_jars,
+          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + current_target_compile_jars,
       )
 
 def _add_labels_of_current_code_jars(code_jars, label):
@@ -46,13 +47,12 @@ def _code_jars_and_intellij_metadata_from(jars):
   for jar in jars:
     current_jar_code_jars = _filter_out_non_code_jars(jar.files)
     code_jars += current_jar_code_jars
-    for current_class_jar in current_jar_code_jars:
+    for current_class_jar in current_jar_code_jars: #intellij, untested
       intellij_metadata.append(struct(
            ijar = None,
            class_jar = current_class_jar,
        )
      )
-  print(intellij_metadata)
   return struct(code_jars = code_jars, intellij_metadata = intellij_metadata)
 
 def _filter_out_non_code_jars(files):
@@ -69,13 +69,16 @@ def _collect(deps, jars2labels):
       java_provider = dep_target[java_common.provider]
       transitive_compile_jars += java_provider.transitive_compile_time_jars
       runtime_jars += java_provider.transitive_runtime_jars
-      if hasattr(dep_target, "jars_to_labels"):  #transitively accumulate labels
-        jars2labels.update(dep_target.jars_to_labels)
-      else:
-        for jar in java_provider.compile_jars:
-          jars2labels[jar.path] = dep_target.label
+      _transitively_accumulate_labels(dep_target, java_provider,jars2labels)
 
   return struct(transitive_runtime_jars = runtime_jars, transitive_compile_jars = transitive_compile_jars)
+
+def _transitively_accumulate_labels(dep_target, java_provider, jars2labels):
+  if hasattr(dep_target, "jars_to_labels"):
+    jars2labels.update(dep_target.jars_to_labels)
+  else:  #untested, left for semi working backward compatibility with java_library and java_import
+    for jar in java_provider.compile_jars:
+      jars2labels[jar.path] = dep_target.label
 
 def _collect_runtime(runtime_deps):
   runtime_jars = depset()

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -1,0 +1,92 @@
+def _scala_import_impl(ctx):
+    target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jar)
+    (code_jars, intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
+    jars2labels = _add_labels_of_current_code_jars(code_jars, ctx.label)
+    code_jars_depset = depset(code_jars)
+    transitive_runtime_jars = _collect_runtime(ctx.attr.runtime_deps)
+    jars = _collect(ctx.attr.deps, jars2labels)
+    return struct(
+        scala = intellij_metadata,
+        jars_to_labels = jars2labels,
+        providers = [
+            _create_provider(code_jars_depset, transitive_runtime_jars, jars)
+        ],
+    )
+def _create_provider(code_jars_depset, transitive_runtime_jars, jars):
+  test_provider = java_common.create_provider()
+  if hasattr(test_provider, "full_compile_jars"):
+      return java_common.create_provider(
+          use_ijar = False,
+          compile_time_jars = code_jars_depset,
+          runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars,
+          transitive_compile_time_jars = jars.transitive_compile_jars + code_jars_depset,
+          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + code_jars_depset,
+      )
+  else:
+      return java_common.create_provider(
+          compile_time_jars = code_jars_depset,
+          runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars,
+          transitive_compile_time_jars = jars.transitive_compile_jars + code_jars_depset,
+          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + code_jars_depset,
+      )
+
+def _add_labels_of_current_code_jars(code_jars, label):
+  jars2labels = {}
+  for jar in code_jars:
+    jars2labels[jar.path] = label
+  return jars2labels
+
+def _code_jars_and_intellij_metadata_from(jar):
+  if (jar):
+    code_jars = _filter_out_non_code_jars(jar.files)
+    intellij_metadata = struct(
+      outputs = struct(
+        ijar = None,
+        class_jar = code_jars[0],
+      ),
+    )
+  else:
+    code_jars = []
+    intellij_metadata = None
+  return struct(code_jars = code_jars, intellij_metadata = intellij_metadata)
+
+def _filter_out_non_code_jars(files):
+  return [file for file in files if not _is_source_jar(file)]
+
+def _is_source_jar(file):
+  return file.basename.endswith("-sources.jar")
+
+def _collect(deps, jars2labels):
+  transitive_compile_jars = depset()
+  runtime_jars = depset()
+
+  for dep_target in deps:
+      java_provider = dep_target[java_common.provider]
+      transitive_compile_jars += java_provider.transitive_compile_time_jars
+      runtime_jars += java_provider.transitive_runtime_jars
+      if hasattr(dep_target, "jars_to_labels"):  #transitively accumulate labels
+        jars2labels.update(dep_target.jars_to_labels)
+      else:
+        for jar in java_provider.compile_jars:
+          jars2labels[jar.path] = dep_target.label
+
+  return struct(transitive_runtime_jars = runtime_jars, transitive_compile_jars = transitive_compile_jars)
+
+def _collect_runtime(runtime_deps):
+  runtime_jars = depset()
+
+  for dep_target in runtime_deps:
+      java_provider = dep_target[java_common.provider]
+      runtime_jars += java_provider.transitive_runtime_jars
+
+  return runtime_jars
+
+
+scala_import = rule(
+  implementation=_scala_import_impl,
+  attrs={
+      "jar": attr.label(),
+      "deps": attr.label_list(),
+      "runtime_deps": attr.label_list()
+      },
+)

--- a/test/src/main/scala/scala/test/scala_import/BUILD
+++ b/test/src/main/scala/scala/test/scala_import/BUILD
@@ -48,3 +48,18 @@ scala_specs2_junit_test(
     size = "small",
     suffixes = ["Test"],
 )
+
+#Exports
+scala_import(
+  name = "guava_and_commons_lang_as_exports",
+  exports = [":guava_and_commons_lang"],
+)
+
+scala_specs2_junit_test(
+    name = "scala_import_exports_targets",
+    srcs = ["ScalaImportExposesJarsTest.scala"],
+    deps = [":guava_and_commons_lang_as_exports"],
+    size = "small",
+    suffixes = ["Test"],
+)
+

--- a/test/src/main/scala/scala/test/scala_import/BUILD
+++ b/test/src/main/scala/scala/test/scala_import/BUILD
@@ -1,0 +1,50 @@
+load("//scala:scala.bzl", "scala_library","scala_specs2_junit_test")
+load("//scala:scala_import.bzl", "scala_import")
+
+#Many jars
+scala_import(
+  name = "guava_and_commons_lang",
+  jars = ["@com_google_guava_guava_21_0//jar:file", "@org_apache_commons_commons_lang_3_5//jar:file"],
+)
+
+scala_specs2_junit_test(
+    name = "scala_import_exposes_jars",
+    srcs = ["ScalaImportExposesJarsTest.scala"],
+    deps = [":guava_and_commons_lang"],
+    size = "small",
+    suffixes = ["Test"],
+)
+
+#filter source jars
+scala_import(
+  name = "cats",
+  jars = ["@org_typelevel__cats_core//jar:file"],
+)
+
+scala_library(
+  name = "source_jar_not_oncp",
+  srcs = ["ReferCatsImplicits.scala"],
+  deps = [":cats"]
+)
+
+##Runtime deps
+scala_import(
+  name = "indirection_for_transitive_runtime_deps",
+  jars = [],
+  runtime_deps = [":cats"]
+)
+
+scala_import(
+  name = "cats_and_guava_and_commons_lang_as_runtime_deps",
+  jars = [],
+  runtime_deps = [":guava_and_commons_lang", ":indirection_for_transitive_runtime_deps"]
+)
+
+
+scala_specs2_junit_test(
+    name = "scala_import_propagates_runtime_deps",
+    srcs = ["ScalaImportPropagatesRuntimeDepsTest.scala"],
+    runtime_deps = [":cats_and_guava_and_commons_lang_as_runtime_deps"],
+    size = "small",
+    suffixes = ["Test"],
+)

--- a/test/src/main/scala/scala/test/scala_import/ReferCatsImplicits.scala
+++ b/test/src/main/scala/scala/test/scala_import/ReferCatsImplicits.scala
@@ -1,0 +1,6 @@
+package scala.test.scala_import
+
+import cats.implicits._
+
+object TestObj {}
+

--- a/test/src/main/scala/scala/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scala/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -1,0 +1,17 @@
+package scala.test.scala_import
+
+import com.google.common.cache.Cache
+import org.apache.commons.lang3.ArrayUtils
+import org.specs2.mutable.SpecificationWithJUnit
+
+class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
+
+  "scala_import" should {
+    "enable using the jars it exposes" in {
+      println(classOf[Cache[String, String]])
+      println(classOf[ArrayUtils])
+      success
+    }
+  }
+
+}

--- a/test/src/main/scala/scala/test/scala_import/ScalaImportPropagatesRuntimeDepsTest.scala
+++ b/test/src/main/scala/scala/test/scala_import/ScalaImportPropagatesRuntimeDepsTest.scala
@@ -1,0 +1,16 @@
+package scala.test.scala_import
+
+import org.specs2.mutable.SpecificationWithJUnit
+
+class ScalaImportPropagatesRuntimeDepsTest extends SpecificationWithJUnit {
+
+  "scala_import" should {
+    "propagate runtime deps" in {
+      println(Class.forName("com.google.common.cache.Cache"))
+      println(Class.forName("org.apache.commons.lang3.ArrayUtils"))
+      println(Class.forName("cats.Applicative"))
+      success
+    }
+  }
+
+}

--- a/test_expect_failure/scala_import/BUILD
+++ b/test_expect_failure/scala_import/BUILD
@@ -1,0 +1,41 @@
+load("//scala:scala.bzl", "scala_library","scala_specs2_junit_test")
+load("//scala:scala_import.bzl", "scala_import")
+
+#deps, transitive_deps and propagation of deps as transitive_runtime_deps
+#also labels handling- transitive and transitive-transitive
+
+scala_import(
+  name = "dummy_dependency_to_trigger_create_provider_transitive_compile_jar_usage",
+  jars = ["@org_psywerx_hairyfotr__linter//jar:file"],
+)
+
+scala_import(
+  name = "guava",
+  jars = ["@com_google_guava_guava_21_0//jar:file"],
+  deps = [":dummy_dependency_to_trigger_create_provider_transitive_compile_jar_usage"] 
+)
+
+scala_import(
+  name = "cats",
+  jars = ["@org_typelevel__cats_core//jar:file"],
+)
+
+scala_import(
+  name = "indirection_for_transitive_compile_deps",
+  jars = [],
+  deps = [":cats"]
+)
+
+scala_import(
+  name = "commons_lang_as_imported_jar_cats_and_guava_as_compile_deps",
+  jars = ["@org_apache_commons_commons_lang_3_5//jar:file"],
+  deps = [":guava", ":indirection_for_transitive_compile_deps"]
+)
+
+scala_specs2_junit_test(
+    name = "scala_import_propagates_compile_deps",
+    srcs = ["ScalaImportPropagatesCompileDepsTest.scala"],
+    deps = [":commons_lang_as_imported_jar_cats_and_guava_as_compile_deps"],
+    size = "small",
+    suffixes = ["Test"],
+)

--- a/test_expect_failure/scala_import/ScalaImportPropagatesCompileDepsTest.scala
+++ b/test_expect_failure/scala_import/ScalaImportPropagatesCompileDepsTest.scala
@@ -1,0 +1,18 @@
+package test_expect_failure.scala_import
+
+import com.google.common.cache.Cache
+import org.apache.commons.lang3.ArrayUtils
+import org.specs2.mutable.SpecificationWithJUnit
+
+class ScalaImportPropagatesCompileDepsTest extends SpecificationWithJUnit {
+
+  "scala_import" should {
+    "propagate runtime deps" in {
+      println(classOf[Cache[String, String]])
+      println(classOf[ArrayUtils])
+      println(classOf[cats.Applicative[Any]])
+      success
+    }
+  }
+
+}


### PR DESCRIPTION
Motivation:
The need for `scala_import` stems from the lack of support for scala's macros in ijar (see https://github.com/bazelbuild/bazel/issues/632 fro more details). This means we need a way to import external jars which doesn't pass through ijar. The current workaround is to use `maven_jar` and then use the `//jar:file` target which exposes a raw filegroup target.
Unfortunately that doesn't play nicely with bazel-intellij plugin which needs metadata about the target.
Current state:
Does:
Supports intellij
Creates java_provider
has deps and runtime_deps
Partial support for "aggregators" (you can pass None)

Does not (yet):
Support neverlink
Support many code jars
Supports exports (not sure will be supported)
Allow to give a raw jar and have the rule create an ijar if needed for it. This will enable working against ijars of 3rd party. When supporting this we'll probably add another flag to say if to use ijar or not for scala macros. 
Have tests

This will hopefully take more form and especially get some coverage but in the meantime it's here for people to see, think and maybe even contribute tests