### PR TITLE
Depending on java_proto_library exclusively causes reference to nonexistent object

### DIFF
--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -30,12 +30,12 @@ scalapb_proto_library(
 
 java_proto_library(
     name = "test_proto_java_lib",
-    deps = [":test2", "//test/proto2:test"],
+    deps = ["//test/proto2:test"],
 )
 
 scalapb_proto_library(
     name = "test_proto_java_conversions",
-    deps = [":test2", "//test/proto2:test", ":test_proto_java_lib"],
+    deps = [":test2", ":test_proto_java_lib"],
     with_java = True,
     with_flat_package = True,
     visibility = ["//visibility:public"],


### PR DESCRIPTION
This PR demonstrates what is either a bug, or a misunderstanding on my part. When I build locally with these changes, I get errors like:

```
bazel-out/darwin_x86_64-fastbuild/bin/test/proto/tmp8951578470537701453/test/proto/TestResponse1.scala:98: error: object Test2 is not a member of package test.proto
object TestResponse1 extends com.trueaccord.scalapb.GeneratedMessageCompanion[test.proto.TestResponse1] with com.trueaccord.scalapb.JavaProtoSupport[test.proto.TestResponse1, test.proto.Test2.TestResponse1] {
```

If I understand correctly, what I'm doing here shouldn't break the test, because I'm just removing redundancy. In the real-world example that motivated this, I have a java_proto_library where I can't also straightforwardly define a corresponding proto_library, because it's actually coming from another repository.

If that's not something that I should expect to work / I'm doing something wrong, please let me know.

cc @johnynek @azymnis 