### PR TITLE
Add failing test for jar with only resources

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -160,6 +160,14 @@ scala_library(
 )
 
 scala_library(
+    name = "ResourcesOnlyLib",
+    resources = [
+        "//test/data:bar.txt",
+        "//test/src/main/resources/scala/test:welcomes",
+    ],
+)
+
+scala_library(
     name = "ResourcesStripScalaLib",
     srcs = ["src/main/scala/scala/test/ResourcesStripScalaLib.scala"],
     resources = [
@@ -176,7 +184,7 @@ scala_binary(
     name = "ScalaLibBinary",
     srcs = ["src/main/scala/scala/test/ScalaLibBinary.scala"],
     main_class = "scala.test.ScalaLibBinary",
-    deps = ["ScalaLibResources"],
+    deps = ["ScalaLibResources", "ResourcesOnlyLib"],
 )
 
 scala_binary(

--- a/test/data/BUILD
+++ b/test/data/BUILD
@@ -1,1 +1,1 @@
-exports_files(["some.txt", "more.txt", "foo.txt"])
+exports_files(["some.txt", "more.txt", "foo.txt", "bar.txt"])

--- a/test/data/bar.txt
+++ b/test/data/bar.txt
@@ -1,0 +1,1 @@
+baz, of course!

--- a/test/src/main/resources/scala/test/BUILD
+++ b/test/src/main/resources/scala/test/BUILD
@@ -1,4 +1,4 @@
-exports_files(["byes", "hellos", "hellos-and-byes.jar", "more-byes", "more-hellos"])
+exports_files(["byes", "hellos", "hellos-and-byes.jar", "more-byes", "more-hellos", "welcomes"])
 
 genrule(
     name = "generated-hello",

--- a/test/src/main/resources/scala/test/welcomes
+++ b/test/src/main/resources/scala/test/welcomes
@@ -1,0 +1,3 @@
+Welcome
+Bienvenido
+أهلاً و سهل

--- a/test/src/main/scala/scala/test/resource_jars/TestResourceJars.scala
+++ b/test/src/main/scala/scala/test/resource_jars/TestResourceJars.scala
@@ -6,12 +6,13 @@ import org.scalatest._
 
 
 class TestResourceJars extends FlatSpec {
-  "this jar" should "contain resources from its resource jar dependency" in {
+  "this jar" should "contain resources from its resource jar dependencies" in {
     val expectedSubstrings = Map(
       "byes" -> "later",
       "hellos" -> "Bonjour",
       "more-byes" -> "more see ya",
-      "more-hellos" -> "More Hello"
+      "more-hellos" -> "More Hello",
+      "welcomes" -> "Bienvenido"
     )
     expectedSubstrings.foreach {
       case (resource_name, substring) => {


### PR DESCRIPTION
Context: when we generate a `scala_library` with only resources, and no srcs, we end up unable to load those resources. This appears to mean that there's a bug in this method: https://github.com/bazelbuild/rules_scala/blob/master/scala/scala.bzl#L81

I tried reverting @johnynek's commits 830ff628e693de9c172bdaa261fe1fadef673b76 and 65ef1009346955c3513025f4c3938aa121790fc0, the last major change to that method, but doing so didn't appear to fix the bug.