### PR TITLE
Fix bug in the provider we create in scala_library/binary/rest

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -541,7 +541,7 @@ def _collect_jars_when_dependency_analyzer_is_on(dep_targets):
     if java_common.provider in dep_target:
         java_provider = dep_target[java_common.provider]
         current_dep_compile_jars = java_provider.compile_jars
-        current_dep_transitive_compile_jars = java_provider.transitive_compile_time_jars + java_provider.compile_jars
+        current_dep_transitive_compile_jars = java_provider.transitive_compile_time_jars
         runtime_jars += java_provider.transitive_runtime_jars
     else:
         # support http_file pointed at a jar. http_jar uses ijar,
@@ -609,7 +609,7 @@ def create_java_provider(scalaattr, transitive_compile_time_jars):
           use_ijar = False,
           compile_time_jars = scalaattr.compile_jars,
           runtime_jars = scalaattr.transitive_runtime_jars,
-          transitive_compile_time_jars = transitive_compile_time_jars,
+          transitive_compile_time_jars = transitive_compile_time_jars + scalaattr.compile_jars,
           transitive_runtime_jars = scalaattr.transitive_runtime_jars,
       )
     else:

--- a/test_expect_failure/missing_direct_deps/internal_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/internal_deps/BUILD
@@ -72,3 +72,25 @@ scala_binary(
         ],
     deps = ["direct_binary_dependency"],
 )
+
+java_library(
+    name="java_library_dependent_on_some_java_provider",
+    srcs=[
+        "JavaLibraryHasCustomJavaProviderDependency.java",
+        ],
+    deps = ["direct_java_provider_dependency"],
+)
+
+java_library(
+    name="java_library_dependent_on_java_library",
+    srcs=[
+        "JavaLibraryHasCustomJavaProviderDependency.java",
+        ],
+    deps = ["direct_java_library_dependency"],
+)
+
+java_library(
+    name="direct_java_library_dependency",
+    srcs = ["Placeholder.java"],
+    deps = ["transitive_dependency"],
+)

--- a/test_expect_failure/missing_direct_deps/internal_deps/JavaLibraryHasCustomJavaProviderDependency.java
+++ b/test_expect_failure/missing_direct_deps/internal_deps/JavaLibraryHasCustomJavaProviderDependency.java
@@ -1,0 +1,8 @@
+package test_expect_failure.missing_direct_deps.internal_deps;
+
+public class JavaLibraryHasCustomJavaProviderDependency {
+  public void foo() {
+      C.foo();
+  }
+
+}

--- a/test_expect_failure/missing_direct_deps/internal_deps/Placeholder.java
+++ b/test_expect_failure/missing_direct_deps/internal_deps/Placeholder.java
@@ -1,0 +1,5 @@
+package test_expect_failure.missing_direct_deps.internal_deps;
+
+public class Placeholder {
+
+}

--- a/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
+++ b/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
@@ -1,7 +1,6 @@
 def _custom_jvm_impl(ctx):
     print(ctx.label)
     transitive_compile_jars = _collect(ctx.attr.deps)
-    print(transitive_compile_jars)
     return struct(
         providers = [
           java_common.create_provider(
@@ -13,7 +12,7 @@ def _custom_jvm_impl(ctx):
 def _collect(deps):
   transitive_compile_jars = depset()
   for dep_target in deps:
-      transitive_compile_jars += dep_target[java_common.provider].transitive_compile_time_jars + dep_target[java_common.provider].compile_jars
+      transitive_compile_jars += dep_target[java_common.provider].transitive_compile_time_jars
   return transitive_compile_jars
 
 custom_jvm = rule(

--- a/test_run.sh
+++ b/test_run.sh
@@ -704,7 +704,7 @@ else
   runner="run_test_ci"
 fi
 
-test_scala_library_expect_failure_on_missing_direct_deps_warn_mode2() {
+test_scala_import_expect_failure_on_missing_direct_deps_warn_mode() {
   dependency_target1='//test_expect_failure/scala_import:cats'
   dependency_target2='//test_expect_failure/scala_import:guava'
   test_target='test_expect_failure/scala_import:scala_import_propagates_compile_deps'
@@ -775,4 +775,5 @@ $runner test_scala_library_expect_failure_on_missing_direct_java
 $runner bazel run test:test_scala_proto_server
 $runner test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java
 $runner test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules
-$runner test_scala_library_expect_failure_on_missing_direct_deps_warn_mode2
+$runner test_scala_import_expect_failure_on_missing_direct_deps_warn_mode
+$runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn"


### PR DESCRIPTION
scala_* rules create java_provider with compile_jars in transitive_compile_jars

@johnynek we saw internally that with a scala_library depending on a scala_import depending on scala_library  (somewhat similar to bazel-deps `replacements` mode) the compile jars of the root scala library dep aren't propagated. Only its transitive compile ones.
I initially fixed it in scala_import but then I suspected the root problem is with the scala rules themselves.
I added two tests that show it and actually removed the crutches we had (scala.bzl and custom_jvm_rule) which did it themselves. This was a problem since every passing rule type needed to implement it themselves (like scala_import which is how I caught this).
@damienmg @lberki @dslomov @iirina 
FYI- The current state of the create_provider is causing a massive amount of pain and bugs.
We have so much code and tests around it and still sometimes fall over...