### PR TITLE
Revert "Sync Scala 2.12 with master"

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,22 +24,22 @@ specs2_junit_repositories()
 maven_jar(
   name = "com_twitter__scalding_date",
   artifact = scala_mvn_artifact("com.twitter:scalding-date:0.17.0"),
-  sha1 = "4fede78a279539a9aa394e54d654b2da8f072eb2"
+  sha1 = "420fb0c4f737a24b851c4316ee0362095710caa5"
 )
 
 # For testing that we don't include sources jars to the classpath
 maven_jar(
   name = "org_typelevel__cats_core",
   artifact = scala_mvn_artifact("org.typelevel:cats-core:0.9.0"),
-  sha1 = "267cebe07afbb365b08a6e18be4b137508f16bee"
+  sha1 = "b2f8629c6ec834d8b6321288c9fe77823f1e1314"
 )
 
 
 # test of a plugin
 maven_jar(
   name = "org_psywerx_hairyfotr__linter",
-  artifact = scala_mvn_artifact("org.psywerx.hairyfotr:linter:0.1.17"),
-  sha1 = "4496d757ce23ce84ff91567bb3328f35c52138af")
+  artifact = scala_mvn_artifact("org.psywerx.hairyfotr:linter:0.1.13"),
+  sha1 = "e5b3e2753d0817b622c32aedcb888bcf39e275b4")
 
 # test of strict deps (scalac plugin UT + E2E)
 maven_jar(

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,1 +1,0 @@
-java_library(name = "transitive_scalatest", exports = ["@scalatest//jar", "@scalactic//jar"])

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -205,12 +205,7 @@ DependencyAnalyzerMode: {dependency_analyzer_mode}
 """.format(
         out=ctx.outputs.jar.path,
         manifest=ctx.outputs.manifest.path,
-        # always append -YdisableFlatCpCaching, workaround for
-        # https://github.com/bazelbuild/rules_scala/issues/305
-        # ~remove once we upgrade to Scala 2.12.4~
-        # ^^ turns out that 2.12.4 didn't fix the issue, see:
-        # https://github.com/bazelbuild/rules_scala/pull/310#issuecomment-337466097
-        scala_opts=",".join(ctx.attr.scalacopts + ["-YdisableFlatCpCaching"]),
+        scala_opts=",".join(ctx.attr.scalacopts),
         print_compile_time=ctx.attr.print_compile_time,
         plugin_arg=plugin_arg,
         cp=compiler_classpath,
@@ -1022,13 +1017,13 @@ SCALA_BUILD_FILE = """
 # scala.BUILD
 java_import(
     name = "scala-xml",
-    jars = ["lib/scala-xml_2.12-1.0.6.jar"],
+    jars = ["lib/scala-xml_2.11-1.0.5.jar"],
     visibility = ["//visibility:public"],
 )
 
 java_import(
     name = "scala-parser-combinators",
-    jars = ["lib/scala-parser-combinators_2.12-1.0.6.jar"],
+    jars = ["lib/scala-parser-combinators_2.11-1.0.4.jar"],
     visibility = ["//visibility:public"],
 )
 
@@ -1049,35 +1044,22 @@ java_import(
     jars = ["lib/scala-reflect.jar"],
     visibility = ["//visibility:public"],
 )
-
-java_library(
-    name = "transitive_scalatest",
-    exports = ["@scalatest//jar", "@scalactic//jar"],
-    visibility = ["//visibility:public"],
-)
 """
 
 def scala_repositories():
   native.new_http_archive(
     name = "scala",
-    strip_prefix = "scala-2.12.4",
-    sha256 = "9554a0ca31aa8701863e881281b1772370a87e993ce785bb24505f2431292a21",
-    url = "https://downloads.lightbend.com/scala/2.12.4/scala-2.12.4.tgz",
+    strip_prefix = "scala-2.11.11",
+    sha256 = "12037ca64c68468e717e950f47fc77d5ceae5e74e3bdca56f6d02fd5bfd6900b",
+    url = "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
     build_file_content = SCALA_BUILD_FILE,
   )
 
   # scalatest has macros, note http_jar is invoking ijar
   native.http_jar(
     name = "scalatest",
-    url = "http://oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.12/3.0.3/scalatest_2.12-3.0.3.jar",
-    sha256 = "353f7c2bdde22c4286ee6a3ae0e425a9463b102f4c4cf76055a24f4666996762",
-  )
-
-  # scalatest has macros, note http_jar is invoking ijar
-  native.http_jar(
-    name = "scalactic",
-    url = "https://oss.sonatype.org/content/groups/public/org/scalactic/scalactic_2.12/3.0.3/scalactic_2.12-3.0.3.jar",
-    sha256 = "245ad1baab6661aee70c137c5e1625771c2624596b349b305801d94618673292",
+    url = "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
+    sha256 = "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
   )
 
   native.maven_server(
@@ -1115,7 +1097,7 @@ def scala_repositories():
 
   native.bind(name = "io_bazel_rules_scala/dependency/scala/scala_xml", actual = "@scala//:scala-xml")
 
-  native.bind(name = "io_bazel_rules_scala/dependency/scalatest/scalatest", actual = "@scala//:transitive_scalatest")
+  native.bind(name = "io_bazel_rules_scala/dependency/scalatest/scalatest", actual = "@scalatest//jar")
 
 def _sanitize_string_for_usage(s):
     res_array = []

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -18,7 +18,7 @@ resolution."""
 
 def scala_version():
   """return the scala version for use in maven coordinates"""
-  return "2.12"
+  return "2.11"
 
 def scala_mvn_artifact(artifact):
   gav = artifact.split(":")

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -25,7 +25,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_scalapb_plugin",
         artifact = scala_mvn_artifact("com.trueaccord.scalapb:compilerplugin:0.6.5"),
-        sha1 = "d119bb24e976dacae8f55a678a027d59bc50ffac",
+        sha1 = "290094c632c95b36b6f66d7dbfdc15242b9a247f",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -37,7 +37,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_protoc_bridge",
         artifact = scala_mvn_artifact("com.trueaccord.scalapb:protoc-bridge:0.3.0-M1"),
-        sha1 = "1de84a8176cf0192b68b2873364e26cb4da61a7a",
+        sha1 = "73d38f045ea8f09cc1264991d1064add6eac9e00",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -49,7 +49,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_scalapbc",
         artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapbc:0.6.5"),
-        sha1 = "7dd00d1d5b03be9879194bf917738d69b0126fab",
+        sha1 = "b204d6d56a042b973af5b6fe28f81ece232d1fe4",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -61,7 +61,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_scalapb_runtime",
         artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime:0.6.5"),
-        sha1 = "5375ad64f0cc26b8e8a9377811f9b97645d24bac",
+        sha1 = "ac9287ff48c632df525773570ee4842e3ddf40e9",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -73,7 +73,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_scalapb_runtime_grpc",
         artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime-grpc:0.6.5"),
-        sha1 = "64885c5d96be6ecdfccdb27ca2bdef3ed9ce9fb4",
+        sha1 = "9dc3374001f4190548db36a7dc87bd4f9bca6f9c",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -85,7 +85,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_scalapb_lenses",
         artifact = scala_mvn_artifact("com.trueaccord.lenses:lenses:0.4.12"),
-        sha1 = "d97d2958814bcfe2f19e1ed2f0f03fd9da5a3961",
+        sha1 = "c5fbf5b872ce99d9a16d3392ccc0d15a0e43d823",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -97,7 +97,7 @@ def scala_proto_repositories():
     native.maven_jar(
         name = "scala_proto_rules_scalapb_fastparse",
         artifact = scala_mvn_artifact("com.lihaoyi:fastparse:0.4.4"),
-        sha1 = "aaf2048f9c6223220eac28c9b6a442f27ba83c55",
+        sha1 = "f065fe0afe6fd2b4557d985c37362c36f08f9947",
         server = "scala_proto_deps_maven_server",
     )
 

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -9,31 +9,31 @@ def specs2_repositories():
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_core",
       artifact = scala_mvn_artifact("org.specs2:specs2-core:" + specs2_version()),
-      sha1 = "86cb72427e64e1423edcbf082e8767a60493bbcc",
+      sha1 = "495bed00c73483f4f5f43945fde63c615d03e637",
   )
 
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_common",
       artifact = scala_mvn_artifact("org.specs2:specs2-common:" + specs2_version()),
-      sha1 = "83bd14fb54f81a886901fa7ed136bcf887322440",
+      sha1 = "15bc009eaae3a574796c0f558d8696b57ae903c3",
   )
 
   native.maven_jar(
       name = "io_bazel_rules_scala_org_specs2_specs2_matcher",
       artifact = scala_mvn_artifact("org.specs2:specs2-matcher:" + specs2_version()),
-      sha1 = "921d9ef6bf98c3e5a59d535e1139b5522625d6ba",
+      sha1 = "d2e967737abef7421e47b8994a8c92784e624d62",
   )
 
   native.maven_jar(
       name = "io_bazel_rules_scala_org_scalaz_scalaz_effect",
       artifact = scala_mvn_artifact("org.scalaz:scalaz-effect:7.2.7"),
-      sha1 = "5d0bbd74323d8c7467cde95dcdc298eb3d9dcdb1",
+      sha1 = "824bbb83da12224b3537c354c51eb3da72c435b5",
   )
 
   native.maven_jar(
       name = "io_bazel_rules_scala_org_scalaz_scalaz_core",
       artifact = scala_mvn_artifact("org.scalaz:scalaz-core:7.2.7"),
-      sha1 = "ee06c07e856bad6ce112b2a5b96e1df1609ad57f",
+      sha1 = "ebf85118d0bf4ce18acebf1d8475ee7deb7f19f1",
   )
 
   native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2', actual = "@io_bazel_rules_scala//specs2:specs2")

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -7,11 +7,11 @@ def specs2_junit_repositories():
   junit_repositories()
   # Aditional dependencies for specs2 junit runner
   native.maven_jar(
-      name = "io_bazel_rules_scala_org_specs2_specs2_junit_2_12",
+      name = "io_bazel_rules_scala_org_specs2_specs2_junit_2_11",
       artifact = scala_mvn_artifact("org.specs2:specs2-junit:" + specs2_version()),
-      sha1 = "aa6af850ccd428673add3840652cdd8e82791391",
+      sha1 = "1dc9e43970557c308ee313842d84094bc6c1c1b5",
   )
-  native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2_junit', actual = '@io_bazel_rules_scala_org_specs2_specs2_junit_2_12//jar')
+  native.bind(name = 'io_bazel_rules_scala/dependency/specs2/specs2_junit', actual = '@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar')
 
 def specs2_junit_dependencies():
     return specs2_dependencies() + ["//external:io_bazel_rules_scala/dependency/specs2/specs2_junit"]

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -7,12 +7,6 @@ java_binary(
         "Resource.java",
     ],
     main_class = "io.bazel.rulesscala.scalac.ScalaCInvoker",
-    # this probably should be set globally for the entire rules_scala
-    # but I don't know how to do it
-    javacopts = [
-    "-source 1.8",
-    "-target 1.8"
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//src/java/com/google/devtools/build/lib:worker",

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -137,9 +137,6 @@ object BenchmarkGenerator {
         val generator = new JMHGenerator
 
         collectClassesFromJar(benchmarkJarPath).foreach { path =>
-          // this would fail due to https://github.com/bazelbuild/rules_scala/issues/295
-          // let's throw a useful message instead
-          sys.error("jmh in rules_scala doesn't work with Java 8 bytecode: https://github.com/bazelbuild/rules_scala/issues/295")
           source.processClass(Files.newInputStream(path))
         }
         generator.generate(source, destination)

--- a/src/scala/io/bazel/rules_scala/scrooge_support/Compiler.scala
+++ b/src/scala/io/bazel/rules_scala/scrooge_support/Compiler.scala
@@ -130,7 +130,7 @@ class Compiler {
           skipIncludes = false,
           documentCache
         )
-        parser.logger.setUseParentHandlers(false) // scrooge warns on file names with "/"
+        parser.logger.setLevel(Level.OFF) // scrooge warns on file names with "/"
         val doc = parser.parseFile(inputFile).mapNamespaces(namespaceMappings.toMap)
 
         if (verbose) println("+ Compiling %s".format(inputFile))

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -28,7 +28,7 @@ def _rule_impl(ctx):
         "scala_test" : [
             "//test/aspect:scala_test",
             "@scala//:scala-library",
-            "@scala//:transitive_scalatest",
+            "@scalatest//jar:jar",
         ],
         "scala_junit_test" : [
             "//test/aspect:scala_junit_test",
@@ -48,7 +48,7 @@ def _rule_impl(ctx):
             "@scala//:scala-library",
             "@scala//:scala-reflect",
             # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
-            "@io_bazel_rules_scala_org_specs2_specs2_junit_2_12//jar:jar",
+            "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
         ],
     }
     content = ""

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -20,9 +20,8 @@ scala_library(
     visibility = ["//visibility:public"],
 )
 
-# Disable the jmh test due to https://github.com/bazelbuild/rules_scala/issues/295
-# scala_benchmark_jmh(
-#     name = "test_benchmark",
-#     srcs = ["TestBenchmark.scala"],
-#     deps = [":add_numbers"],
-# )
+scala_benchmark_jmh(
+    name = "test_benchmark",
+    srcs = ["TestBenchmark.scala"],
+    deps = [":add_numbers"],
+)

--- a/test_run.sh
+++ b/test_run.sh
@@ -735,8 +735,7 @@ $runner test_transitive_deps
 $runner test_scala_library_suite
 $runner test_repl
 $runner bazel run test:JavaOnlySources
-# Disable the jmh test due to https://github.com/bazelbuild/rules_scala/issues/295
-# $runner test_benchmark_jmh
+$runner test_benchmark_jmh
 $runner multiple_junit_suffixes
 $runner multiple_junit_prefixes
 $runner test_scala_junit_test_can_fail

--- a/tut_rule/tut.bzl
+++ b/tut_rule/tut.bzl
@@ -10,7 +10,7 @@ def tut_repositories():
   native.maven_jar(
     name = "io_bazel_rules_scala_org_tpolecat_tut_core",
     artifact = scala_mvn_artifact("org.tpolecat:tut-core:0.4.8"),
-    sha1 = "b68b5a52474bf249d1156f5002033498054b813c",
+    sha1 = "fc723eb822494580cc05d6b3b3a6039d2280a5a0",
     server = "tut_repositories_maven_server",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/tut/tut_core', actual = '@io_bazel_rules_scala_org_tpolecat_tut_core//jar')

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -10,7 +10,7 @@ load("//scala:scala.bzl",
 def twitter_scrooge():
   native.maven_server(
     name = "twitter_scrooge_maven_server",
-    url = "http://repo1.maven.org/maven2/",
+    url = "http://mirror.bazel.build/repo1.maven.org/maven2/",
   )
 
   native.maven_jar(
@@ -23,8 +23,8 @@ def twitter_scrooge():
 
   native.maven_jar(
     name = "scrooge_core",
-    artifact = scala_mvn_artifact("com.twitter:scrooge-core:4.18.0"),
-    sha1 = "8a10e4da9fd636a8225a5068aa0b57072142a30b",
+    artifact = scala_mvn_artifact("com.twitter:scrooge-core:4.6.0"),
+    sha1 = "84b86c2e082aba6e0c780b3c76281703b891a2c8",
     server = "twitter_scrooge_maven_server",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/thrift/scrooge_core', actual = '@scrooge_core//jar')
@@ -32,24 +32,24 @@ def twitter_scrooge():
   #scrooge-generator related dependencies
   native.maven_jar(
     name = "scrooge_generator",
-    artifact = scala_mvn_artifact("com.twitter:scrooge-generator:4.18.0"),
-    sha1 = "d456f18b5c478b6356e2e09f4be4784cd4f05765",
+    artifact = scala_mvn_artifact("com.twitter:scrooge-generator:4.6.0"),
+    sha1 = "cacf72eedeb5309ca02b2d8325c587198ecaac82",
     server = "twitter_scrooge_maven_server",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/thrift/scrooge_generator', actual = '@scrooge_generator//jar')
 
   native.maven_jar(
     name = "util_core",
-    artifact = scala_mvn_artifact("com.twitter:util-core:6.45.0"),
-    sha1 = "d7bbc819d90d06dfd4c76c25b82869b27048c886",
+    artifact = scala_mvn_artifact("com.twitter:util-core:6.33.0"),
+    sha1 = "bb49fa66a3ca9b7db8cd764d0b26ce498bbccc83",
     server = "twitter_scrooge_maven_server",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/thrift/util_core', actual = '@util_core//jar')
 
   native.maven_jar(
     name = "util_logging",
-    artifact = scala_mvn_artifact("com.twitter:util-logging:6.45.0"),
-    sha1 = "b83552e8980557b5dd767de40db1d44c3a39c400",
+    artifact = scala_mvn_artifact("com.twitter:util-logging:6.33.0"),
+    sha1 = "3d28e46f8ee3b7ad1b98a51b98089fc01c9755dd",
     server = "twitter_scrooge_maven_server",
   )
   native.bind(name = 'io_bazel_rules_scala/dependency/thrift/util_logging', actual = '@util_logging//jar')
@@ -245,13 +245,11 @@ def scrooge_scala_library(name, deps=[], remote_jars=[], jvm_flags=[], visibilit
         deps = deps + remote_jars + [
             srcjar,
             "//external:io_bazel_rules_scala/dependency/thrift/libthrift",
-            "//external:io_bazel_rules_scala/dependency/thrift/scrooge_core",
-            "//external:io_bazel_rules_scala/dependency/thrift/util_core",
+            "//external:io_bazel_rules_scala/dependency/thrift/scrooge_core"
         ],
         exports = deps + remote_jars + [
             "//external:io_bazel_rules_scala/dependency/thrift/libthrift",
             "//external:io_bazel_rules_scala/dependency/thrift/scrooge_core",
-            "//external:io_bazel_rules_scala/dependency/thrift/util_core",
         ],
         jvm_flags = jvm_flags,
         visibility = visibility,


### PR DESCRIPTION
Reverts bazelbuild/rules_scala#358
Mistakenly targeted master instead of scala2_12 branch.