### PR TITLE
Scala import exports fixes

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -4,10 +4,12 @@
 def _scala_import_impl(ctx):
     target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars)
     (current_target_compile_jars, intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
-    current_jars_and_exports = depset(current_target_compile_jars) + _collect_exports(ctx.attr.exports)
-    jars2labels = _add_labels_of_current_code_jars(current_jars_and_exports, ctx.label)
+    current_jars = depset(current_target_compile_jars)
+    exports = _collect(ctx.attr.exports)
+    jars2labels = _add_labels_of_current_code_jars(current_jars + exports.compile_jars , ctx.label)
     transitive_runtime_jars = _collect_runtime(ctx.attr.runtime_deps)
-    jars = _collect(ctx.attr.deps, jars2labels)
+    jars = _collect(ctx.attr.deps)
+    _collect_labels(ctx.attr.deps, jars2labels)
     return struct(
         scala = struct(
           outputs = struct (
@@ -16,17 +18,17 @@ def _scala_import_impl(ctx):
         ),
         jars_to_labels = jars2labels,
         providers = [
-            _create_provider(current_jars_and_exports, transitive_runtime_jars, jars)
+            _create_provider(current_jars, transitive_runtime_jars, jars, exports)
         ],
     )
-def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars):
+def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars, exports):
   test_provider = java_common.create_provider()
   if hasattr(test_provider, "full_compile_jars"):
       return java_common.create_provider(
           use_ijar = False,
-          compile_time_jars = current_target_compile_jars,
-          transitive_compile_time_jars = jars.transitive_compile_jars + current_target_compile_jars,
-          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + current_target_compile_jars,
+          compile_time_jars = current_target_compile_jars + exports.compile_jars ,
+          transitive_compile_time_jars = jars.transitive_compile_jars + current_target_compile_jars + exports.transitive_compile_jars ,
+          transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + current_target_compile_jars + exports.transitive_runtime_jars ,
       )
   else:
       return java_common.create_provider(
@@ -62,17 +64,25 @@ def _filter_out_non_code_jars(files):
 def _is_source_jar(file):
   return file.basename.endswith("-sources.jar")
 
-def _collect(deps, jars2labels):
+def _collect(deps):
   transitive_compile_jars = depset()
   runtime_jars = depset()
+  compile_jars = depset()
 
   for dep_target in deps:
       java_provider = dep_target[java_common.provider]
+      compile_jars += java_provider.compile_jars
       transitive_compile_jars += java_provider.transitive_compile_time_jars
       runtime_jars += java_provider.transitive_runtime_jars
-      _transitively_accumulate_labels(dep_target, java_provider,jars2labels)
 
-  return struct(transitive_runtime_jars = runtime_jars, transitive_compile_jars = transitive_compile_jars)
+  return struct(transitive_runtime_jars = runtime_jars,
+                transitive_compile_jars = transitive_compile_jars,
+                compile_jars = compile_jars)
+
+def _collect_labels(deps, jars2labels):
+  for dep_target in deps:
+      java_provider = dep_target[java_common.provider]
+      _transitively_accumulate_labels(dep_target, java_provider,jars2labels)
 
 def _transitively_accumulate_labels(dep_target, java_provider, jars2labels):
   if hasattr(dep_target, "jars_to_labels"):
@@ -102,7 +112,7 @@ def _collect_exports(exports):
 scala_import = rule(
   implementation=_scala_import_impl,
   attrs={
-      "jars": attr.label_list(),
+      "jars": attr.label_list(), #current hidden assumption is that these point to full, not ijar'd jars
       "deps": attr.label_list(),
       "runtime_deps": attr.label_list(),
       "exports": attr.label_list()

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -6,10 +6,12 @@ def _scala_import_impl(ctx):
     (current_target_compile_jars, intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
     current_jars = depset(current_target_compile_jars)
     exports = _collect(ctx.attr.exports)
-    jars2labels = _add_labels_of_current_code_jars(current_jars + exports.compile_jars , ctx.label)
     transitive_runtime_jars = _collect_runtime(ctx.attr.runtime_deps)
     jars = _collect(ctx.attr.deps)
+    jars2labels = {}
     _collect_labels(ctx.attr.deps, jars2labels)
+    _collect_labels(ctx.attr.exports, jars2labels) #untested
+    _add_labels_of_current_code_jars(current_jars + exports.compile_jars , ctx.label, jars2labels) #last to override the label of the export compile jars to the current target
     return struct(
         scala = struct(
           outputs = struct (
@@ -38,11 +40,9 @@ def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
           transitive_runtime_jars = transitive_runtime_jars + jars.transitive_runtime_jars + current_target_compile_jars,
       )
 
-def _add_labels_of_current_code_jars(code_jars, label):
-  jars2labels = {}
+def _add_labels_of_current_code_jars(code_jars, label, jars2labels):
   for jar in code_jars:
     jars2labels[jar.path] = label
-  return jars2labels
 
 def _code_jars_and_intellij_metadata_from(jars):
   code_jars = []


### PR DESCRIPTION
fixes #359 
Additionally it fixes label propagation of transitive deps of exports
@johnynek this has no tests since quite honestly I'm tired from all of the permutations we need to do here. Given that https://github.com/bazelbuild/bazel/issues/3769 is being worked on and it will remove 90% of the code in this rule I feel ok with this.
We use this code as is today.
cc @gkk-stripe 