### PR TITLE
Specs2 produced junit xml report as additional test output

### DIFF
--- a/specs2/BUILD
+++ b/specs2/BUILD
@@ -1,13 +1,14 @@
+load("//scala:scala_import.bzl", "scala_import")
+
 package(default_visibility = ["//visibility:public"])
 java_import(
     name = "specs2",
-    jars = [],
-    exports = [
-      "@io_bazel_rules_scala_org_specs2_specs2_core//jar",
-      "@io_bazel_rules_scala_org_specs2_specs2_common//jar",
-      "@io_bazel_rules_scala_org_specs2_specs2_matcher//jar",
-      "@io_bazel_rules_scala_org_scalaz_scalaz_effect//jar",
-      "@io_bazel_rules_scala_org_scalaz_scalaz_core//jar",
+    jars = [
+      "@io_bazel_rules_scala_org_specs2_specs2_core//jar:file",
+      "@io_bazel_rules_scala_org_specs2_specs2_common//jar:file",
+      "@io_bazel_rules_scala_org_specs2_specs2_matcher//jar:file",
+      "@io_bazel_rules_scala_org_scalaz_scalaz_effect//jar:file",
+      "@io_bazel_rules_scala_org_scalaz_scalaz_core//jar:file",
     ],
     deps = [
       "//external:io_bazel_rules_scala/dependency/scala/scala_xml",

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -93,7 +93,9 @@ class Specs2ClassRunner(testClass: Class[_], testFilter: Pattern)
   override def runWithEnv(n: RunNotifier, env: Env): Action[Stats] = {
     val specs2MatchedExamplesRegex = specs2ExamplesMatching(testFilter, getDescription).toRegexAlternation
 
-    val newArgs = Arguments(select = Select(_ex = specs2MatchedExamplesRegex), commandLine = CommandLine.create(testClass.getName))
+    val newArgs = Arguments(
+      select = Select(_ex = specs2MatchedExamplesRegex),
+      commandLine = CommandLine.create(testClass.getName :: junitXmlCmdLineParameters:_*))
     val newEnv = env.copy(arguments overrideWith newArgs)
 
     super.runWithEnv(n, newEnv)
@@ -108,4 +110,7 @@ class Specs2ClassRunner(testClass: Class[_], testFilter: Pattern)
       if (coll.isEmpty) None
       else Some(coll.map(_.toQuotedRegex).mkString("(", "|", ")"))
   }
+
+  val specs2JunitXmlOutputDir = System.getenv("TEST_UNDECLARED_OUTPUTS_DIR")
+  val junitXmlCmdLineParameters = List("console", "junitxml", "junit.outdir", specs2JunitXmlOutputDir)
 }


### PR DESCRIPTION
This is needed to use the report with external tools, e.g. comparing against junit xml reports produced by other runners (e.g. Surefire)

@ittaiz please review