### PR TITLE
Specs2: fixing a NPE when trying to match against a "should" descripition

### DIFF
--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -53,9 +53,10 @@ class Specs2ClassRunner(testClass: Class[_], testFilter: Pattern)
       .find(sanitize(_) == desc)
       .getOrElse(desc)
 
-  private def toDisplayName(description: Description) = description.getMethodName.split("::").reverse.headOption
-    .map(specs2Description)
-    .getOrElse("")
+  private def toDisplayName(description: Description): Option[String] = for {
+      name <- Option(description.getMethodName)
+      desc <- name.split("::").reverse.headOption
+    } yield specs2Description(desc)
 
   /**
     * Turns a JUnit description structure into a flat list:
@@ -88,7 +89,7 @@ class Specs2ClassRunner(testClass: Class[_], testFilter: Pattern)
   private def specs2ExamplesMatching(testFilter: Pattern, junitDescription: Description): List[String] =
     flattenDescription(junitDescription)
       .filter(matching(testFilter))
-      .map(toDisplayName)
+      .flatMap(toDisplayName)
 
   override def runWithEnv(n: RunNotifier, env: Env): Action[Stats] = {
     val specs2MatchedExamplesRegex = specs2ExamplesMatching(testFilter, getDescription).toRegexAlternation

--- a/test_run.sh
+++ b/test_run.sh
@@ -459,6 +459,36 @@ scala_junit_test_test_filter(){
   done
 }
 
+scala_specs2_junit_test_test_filter_everything(){
+  local output=$(bazel test \
+    --nocache_test_results \
+    --test_output=streamed \
+    '--test_filter=.*' \
+    test:Specs2Tests)
+  local expected=(
+    "[info] JunitSpec2RegexTest"
+    "[info] JunitSpecs2AnotherTest"
+    "[info] JunitSpecs2Test")
+  local unexpected=(
+      "[info] UnrelatedTest")
+  for method in "${expected[@]}"; do
+    if ! grep "$method" <<<$output; then
+      echo "output:"
+      echo "$output"
+      echo "Expected $method in output, but was not found."
+      exit 1
+    fi
+  done
+  for method in "${unexpected[@]}"; do
+    if grep "$method" <<<$output; then
+      echo "output:"
+      echo "$output"
+      echo "Not expecting $method in output, but was found."
+      exit 1
+    fi
+  done
+}
+
 scala_specs2_junit_test_test_filter_whole_spec(){
   local output=$(bazel test \
     --nocache_test_results \
@@ -749,6 +779,7 @@ $runner scala_library_jar_without_srcs_must_include_filegroup_resources
 $runner bazel run test/src/main/scala/scala/test/large_classpath:largeClasspath
 $runner scala_test_test_filters
 $runner scala_junit_test_test_filter
+$runner scala_specs2_junit_test_test_filter_everything
 $runner scala_specs2_junit_test_test_filter_one_test
 $runner scala_specs2_junit_test_test_filter_whole_spec
 $runner scala_specs2_junit_test_test_filter_exact_match


### PR DESCRIPTION
This happens if a give test filter matches everything (e.g. `.*`), including the intermediate `should` scopes, which are not real test method descriptions.