### PR TITLE
Add Bazel 0.9.0 to the Travis build matrix.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
   # we want to test the most recent few releases
   - V=0.7.0 TEST_SCRIPT=test_rules_scala.sh
   - V=0.7.0 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.8.1 TEST_SCRIPT=test_rules_scala.sh
-  - V=0.8.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.9.0 TEST_SCRIPT=test_rules_scala.sh
   - V=0.9.0 TEST_SCRIPT=test_intellij_aspect.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ env:
   - V=0.7.0 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.8.1 TEST_SCRIPT=test_rules_scala.sh
   - V=0.8.1 TEST_SCRIPT=test_intellij_aspect.sh
+  - V=0.9.0 TEST_SCRIPT=test_rules_scala.sh
+  - V=0.9.0 TEST_SCRIPT=test_intellij_aspect.sh
 
 before_install:
   - |

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -1076,12 +1076,14 @@ def scala_repositories():
 
   # Template for binary launcher
   BAZEL_JAVA_LAUNCHER_VERSION = "0.4.5"
+  java_stub_template_url = ("raw.githubusercontent.com/bazelbuild/bazel/" +
+                            BAZEL_JAVA_LAUNCHER_VERSION +
+                            "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
+                            "java_stub_template.txt")
   native.http_file(
     name = "java_stub_template",
-    url = ("https://raw.githubusercontent.com/bazelbuild/bazel/" +
-           BAZEL_JAVA_LAUNCHER_VERSION +
-           "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
-           "java_stub_template.txt"),
+    urls = ["https://mirror.bazel.build/%s" % java_stub_template_url,
+            "https://%s" % java_stub_template_url],
     sha256 = "f09d06d55cd25168427a323eb29d32beca0ded43bec80d76fc6acd8199a24489",
   )
 


### PR DESCRIPTION
Good news:

- 0.9.0 passes without any changes
- 0.8.1 and 0.9.0 are [faster](https://travis-ci.org/greggdonovan/rules_scala/builds/322222475) to run the rules_scala tests than 0.7.0 (~18-25 minutes vs. ~33-35 minutes).

Bad news:
- Adding a third Bazel build to the build matrix increases the overall wall-clock time from ~56 minutes to to ~85 minutes. 
- It might be too soon to drop 0.7.0 support?