### PR TITLE
Use generator fully qualified label

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -459,7 +459,7 @@ def scalapb_proto_library(
     scala_proto_srcjar(
         name = srcjar,
         flags = flags,
-        generator = "//src/scala/scripts:scalapb_generator",
+        generator = "@io_bazel_rules_scala//src/scala/scripts:scalapb_generator",
         deps = deps,
         visibility = visibility,
     )


### PR DESCRIPTION
Including workspace name so others can use it
This fixes #388 
Cc @natansil can you please review?
Didn't add a test since this is our blind spot currently with the current e2e setup