### PR TITLE
Change from procedure syntax to address compiler warnings

### DIFF
--- a/scala/support/JUnitXmlReporter.scala
+++ b/scala/support/JUnitXmlReporter.scala
@@ -50,7 +50,7 @@ class JUnitXmlReporter extends Reporter {
   // Records events in 'events' set.  Generates xml from events upon receipt
   // of SuiteCompleted or SuiteAborted events.
   //
-  def apply(event: Event) {
+  def apply(event: Event): Unit = {
     events += event
 
     event match {
@@ -500,7 +500,7 @@ class JUnitXmlReporter extends Reporter {
   //
   // Throws an exception if an unexpected Event is encountered.
   //
-  def unexpected(event: Event) {
+  def unexpected(event: Event): Unit = {
     throw new RuntimeException("unexpected event [" + event + "]")
   }
 


### PR DESCRIPTION
Testing with strict scala compiler warnings in another project gave me this error:

```
INFO: From scala @io_bazel_rules_scala//scala/support:test_reporter:
external/io_bazel_rules_scala/scala/support/JUnitXmlReporter.scala:53: warning: Procedure syntax is deprecated. Convert procedure `apply` to method by adding `: Unit =`.
  def apply(event: Event) {
                          ^
external/io_bazel_rules_scala/scala/support/JUnitXmlReporter.scala:503: warning: Procedure syntax is deprecated. Convert procedure `unexpected` to method by adding `: Unit =`.
  def unexpected(event: Event) {
```