### PR TITLE
scala_import keeps labels of direct deps

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -87,9 +87,9 @@ def _collect_labels(deps, jars2labels):
 def _transitively_accumulate_labels(dep_target, java_provider, jars2labels):
   if hasattr(dep_target, "jars_to_labels"):
     jars2labels.update(dep_target.jars_to_labels)
-  else:  #untested, left for semi working backward compatibility with java_library and java_import
-    for jar in java_provider.compile_jars:
-      jars2labels[jar.path] = dep_target.label
+  #scala_library doesn't add labels to the direct dependency itself
+  for jar in java_provider.compile_jars:
+    jars2labels[jar.path] = dep_target.label
 
 def _collect_runtime(runtime_deps):
   runtime_jars = depset()

--- a/test_expect_failure/scala_import/BUILD
+++ b/test_expect_failure/scala_import/BUILD
@@ -39,3 +39,21 @@ scala_specs2_junit_test(
     size = "small",
     suffixes = ["Test"],
 )
+
+scala_library(
+    name = "leaf_for_scala_import_passes_labels_of_direct_deps",
+    deps = [":middle_for_scala_import_passes_labels_of_direct_deps"],
+    srcs = ["LeafScalaImportPassesLabelsDirectDeps.scala"]
+)
+
+scala_import(
+  name = "middle_for_scala_import_passes_labels_of_direct_deps",
+  jars = [],
+  deps = [":root_for_scala_import_passes_labels_of_direct_deps"]
+)
+
+scala_library(
+    name = "root_for_scala_import_passes_labels_of_direct_deps",
+    srcs = ["RootScalaImportPassesLabelsDirectDeps.scala"]
+)
+

--- a/test_expect_failure/scala_import/LeafScalaImportPassesLabelsDirectDeps.scala
+++ b/test_expect_failure/scala_import/LeafScalaImportPassesLabelsDirectDeps.scala
@@ -1,0 +1,5 @@
+package test_expect_failure.scala_import
+
+class LeafScalaImportPassesLabelsDirectDeps {
+  println(classOf[RootScalaImportPassesLabelsDirectDeps])
+}

--- a/test_expect_failure/scala_import/RootScalaImportPassesLabelsDirectDeps.scala
+++ b/test_expect_failure/scala_import/RootScalaImportPassesLabelsDirectDeps.scala
@@ -1,0 +1,2 @@
+package test_expect_failure.scala_import
+class RootScalaImportPassesLabelsDirectDeps

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -707,6 +707,14 @@ test_scalaopts_from_scala_toolchain() {
   action_should_fail build --extra_toolchains="//test_expect_failure/scalacopts_from_toolchain:failing_scala_toolchain" //test_expect_failure/scalacopts_from_toolchain:failing_build
 }
 
+test_scala_import_library_passes_labels_of_direct_deps() {
+  dependency_target='//test_expect_failure/scala_import:root_for_scala_import_passes_labels_of_direct_deps'
+  test_target='test_expect_failure/scala_import:leaf_for_scala_import_passes_labels_of_direct_deps'
+
+  test_scala_library_expect_failure_on_missing_direct_deps $dependency_target $test_target
+}
+
+
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # shellcheck source=./test_runner.sh
 . "${dir}"/test_runner.sh
@@ -779,3 +787,5 @@ $runner test_scala_library_expect_better_failure_message_on_missing_transitive_d
 $runner test_scala_import_expect_failure_on_missing_direct_deps_warn_mode
 $runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn"
 $runner test_scalaopts_from_scala_toolchain
+$runner test_scala_import_library_passes_labels_of_direct_deps
+


### PR DESCRIPTION
Currently scala_import doesn't keep labels of direct deps, only of transitive deps.
This causes "unknown label" warnings for some use-cases (as the test shows).
A more thorough revamp is needed for label propagation but I'm trying to sync with the bazel team on it since it sounds a bazel issue