### PR TITLE
jmh normalizes jar timestamps

### DIFF
--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -114,6 +114,7 @@ object BenchmarkGenerator {
 
   private def constructJar(output: Path, fileDir: Path): Unit = {
     val creator = new JarCreator(output.toAbsolutePath.toFile.toString)
+    creator.setNormalize(true)
     creator.addDirectory(fileDir.toFile)
     creator.execute
   }

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -26,7 +26,7 @@ echo "$_md5_util"
 }
 
 non_deploy_jar_md5_sum() {
-  find bazel-bin/test -name "*.jar" ! -name "*_deploy.jar" | $(md5_util)
+  find bazel-bin/test -name "*.jar" ! -name "*_deploy.jar" | xargs -n 1 -P 5 $(md5_util) | sort
 }
 
 test_build_is_identical() {


### PR DESCRIPTION
additionally build_is_identical e2e test spits out differences in specific jar md5 files and not only the change in all of them. Actually useful for debugging reproducibility problems