### PR TITLE
Make more use of the toolchain

### DIFF
--- a/scala/BUILD
+++ b/scala/BUILD
@@ -9,7 +9,6 @@ toolchain_type(
 scala_toolchain(
       name = 'default_toolchain_impl',
       scalacopts = [],
-      worker = "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac",
       library = "//external:io_bazel_rules_scala/dependency/scala/scala_library",
       compiler = "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
       reflect = "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -9,6 +9,10 @@ toolchain_type(
 scala_toolchain(
       name = 'default_toolchain_impl',
       scalacopts = [],
+      worker = "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac",
+      library = "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+      compiler = "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
+      reflect = "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
       visibility = ["//visibility:public"]
 )
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -262,7 +262,7 @@ DependencyAnalyzerMode: {dependency_analyzer_mode}
     ctx.action(
         inputs=ins,
         outputs=outs,
-        executable=ctx.executable._scalac,
+        executable=toolchain.worker,
         mnemonic="Scalac",
         progress_message="scala %s" % ctx.label,
         execution_requirements={"supports-workers": "1"},
@@ -594,7 +594,8 @@ def _collect_jars_from_common_ctx(ctx, extra_deps = [], extra_runtime_deps = [])
     dependency_analyzer_is_off = is_dependency_analyzer_off(ctx)
 
     # Get jars from deps
-    auto_deps = [ctx.attr._scalalib, ctx.attr._scalareflect]
+    toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
+    auto_deps = [toolchain.library, toolchain.reflect]
     deps_jars = collect_jars(ctx.attr.deps + auto_deps + extra_deps, dependency_analyzer_is_off)
     (cjars, transitive_rjars, jars2labels, transitive_compile_jars) = (deps_jars.compile_jars, deps_jars.transitive_runtime_jars, deps_jars.jars2labels, deps_jars.transitive_compile_jars)
 
@@ -768,7 +769,8 @@ def _scala_binary_impl(ctx):
 
 def _scala_repl_impl(ctx):
   # need scala-compiler for MainGenericRunner below
-  jars = _collect_jars_from_common_ctx(ctx, extra_runtime_deps = [ctx.attr._scalacompiler])
+  toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
+  jars = _collect_jars_from_common_ctx(ctx, extra_runtime_deps = [toolchain.compiler])
   (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
 
   out = _scala_binary_common(ctx, cjars, transitive_rjars, jars.transitive_compile_jars, jars.jars2labels)
@@ -885,10 +887,6 @@ _launcher_template = {
 _implicit_deps = {
   "_singlejar": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:singlejar"), allow_files=True),
   "_ijar": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:ijar"), allow_files=True),
-  "_scalac": attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scalac"), allow_files=True),
-  "_scalalib": attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_library"), allow_files=True),
-  "_scalacompiler": attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_compiler"), allow_files=True),
-  "_scalareflect": attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_reflect"), allow_files=True),
   "_java": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:java"), allow_files=True),
   "_zipper": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/zip:zipper"), allow_files=True),
   "_java_toolchain": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -262,7 +262,7 @@ DependencyAnalyzerMode: {dependency_analyzer_mode}
     ctx.action(
         inputs=ins,
         outputs=outs,
-        executable=toolchain.worker,
+        executable=ctx.executable._scalac,
         mnemonic="Scalac",
         progress_message="scala %s" % ctx.label,
         execution_requirements={"supports-workers": "1"},
@@ -887,6 +887,7 @@ _launcher_template = {
 _implicit_deps = {
   "_singlejar": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:singlejar"), allow_files=True),
   "_ijar": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:ijar"), allow_files=True),
+  "_scalac": attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scalac"), allow_files=True),
   "_java": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/jdk:java"), allow_files=True),
   "_zipper": attr.label(executable=True, cfg="host", default=Label("@bazel_tools//tools/zip:zipper"), allow_files=True),
   "_java_toolchain": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -1,7 +1,6 @@
 def _scala_toolchain_impl(ctx):
   toolchain = platform_common.ToolchainInfo(
     scalacopts = ctx.attr.scalacopts,
-    worker = ctx.executable.worker,
     library = ctx.attr.library,
     compiler = ctx.attr.compiler,
     reflect = ctx.attr.reflect,
@@ -12,7 +11,6 @@ scala_toolchain = rule(
   _scala_toolchain_impl,
   attrs = {
     'scalacopts': attr.string_list(),
-    'worker': attr.label(executable=True, cfg="host", allow_files=True),
     'library': attr.label(allow_files=True),
     'compiler': attr.label(allow_files=True),
     'reflect': attr.label(allow_files=True),

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -1,6 +1,10 @@
 def _scala_toolchain_impl(ctx):
   toolchain = platform_common.ToolchainInfo(
     scalacopts = ctx.attr.scalacopts,
+    worker = ctx.executable.worker,
+    library = ctx.attr.library,
+    compiler = ctx.attr.compiler,
+    reflect = ctx.attr.reflect,
   )
   return [toolchain]
 
@@ -8,5 +12,9 @@ scala_toolchain = rule(
   _scala_toolchain_impl,
   attrs = {
     'scalacopts': attr.string_list(),
+    'worker': attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scalac"), allow_files=True),
+    'library': attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_library"), allow_files=True),
+    'compiler': attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_compiler"), allow_files=True),
+    'reflect': attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_reflect"), allow_files=True),
   }
 )

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -12,9 +12,9 @@ scala_toolchain = rule(
   _scala_toolchain_impl,
   attrs = {
     'scalacopts': attr.string_list(),
-    'worker': attr.label(executable=True, cfg="host", default=Label("//src/java/io/bazel/rulesscala/scalac"), allow_files=True),
-    'library': attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_library"), allow_files=True),
-    'compiler': attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_compiler"), allow_files=True),
-    'reflect': attr.label(default=Label("//external:io_bazel_rules_scala/dependency/scala/scala_reflect"), allow_files=True),
+    'worker': attr.label(executable=True, cfg="host", allow_files=True),
+    'library': attr.label(allow_files=True),
+    'compiler': attr.label(allow_files=True),
+    'reflect': attr.label(allow_files=True),
   }
 )

--- a/specs2/BUILD
+++ b/specs2/BUILD
@@ -10,9 +10,7 @@ java_import(
       "@io_bazel_rules_scala_org_scalaz_scalaz_core//jar",
     ],
     deps = [
-      "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
       "//external:io_bazel_rules_scala/dependency/scala/parser_combinators",
-      "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-      "//external:io_bazel_rules_scala/dependency/scala/scala_reflect"
+      "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
     ]
 )

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -45,8 +45,6 @@ def _rule_impl(ctx):
             "@io_bazel_rules_scala//specs2:specs2",
             "@scala//:scala-xml",
             "@scala//:scala-parser-combinators",
-            "@scala//:scala-library",
-            "@scala//:scala-reflect",
             # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
             "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
         ],


### PR DESCRIPTION
This is a small change that I think sets us up to make a scala 2.12 toolchain and merge scala 2.12 into master.

I think the next steps are:

- [ ] make toolchain for scalatest
- [ ] make toolchain for specs
- [ ] make toolchain scrooge
- [ ] make toolchain for scalapb
- [ ] merge the above back into 2.12 branch, and make a 2.12 toolchain for each
- [ ] copy the 2.12 toolchains into master selecting 2.11 as the default