### PR TITLE
Emit a the Scala compilation time for downstream metrics

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -96,7 +96,7 @@ def _build_nosrc_jar(ctx, buildijar):
     cmd = """
 rm -f {jar_output}
 {zipper} c {jar_output} @{path}
-echo 0 > {statsfile}
+touch {statsfile}
 """ + ijar_cmd
 
     cmd = cmd.format(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -96,15 +96,17 @@ def _build_nosrc_jar(ctx, buildijar):
     cmd = """
 rm -f {jar_output}
 {zipper} c {jar_output} @{path}
+echo 0 > {statsfile}
 """ + ijar_cmd
 
     cmd = cmd.format(
         path = zipper_arg_path.path,
         jar_output=ctx.outputs.jar.path,
         zipper=ctx.executable._zipper.path,
+        statsfile=ctx.outputs.statsfile.path,
         )
 
-    outs = [ctx.outputs.jar]
+    outs = [ctx.outputs.jar, ctx.outputs.statsfile]
     if buildijar:
         outs.extend([ctx.outputs.ijar])
 
@@ -189,9 +191,7 @@ CurrentTarget: {current_target}
     compiler_classpath = ":".join([j.path for j in compiler_classpath_jars])
 
     toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
-    scalacopts = toolchain.scalacopts + ctx.attr.scalacopts
-
-    statsfile = ctx.new_file(ctx.outputs.jar, "%s.statsfile" % ctx.label.name)
+    scalacopts = toolchain.scalacopts + ctx.attr.scalacopts    
 
     scalac_args = """
 Classpath: {cp}
@@ -234,16 +234,16 @@ StatsfileOutput: {statsfile_output}
         resource_strip_prefix=ctx.attr.resource_strip_prefix,
         resource_jars=",".join([f.path for f in ctx.files.resource_jars]),
         dependency_analyzer_mode = dependency_analyzer_mode,
-        statsfile_output = statsfile.path
+        statsfile_output = ctx.outputs.statsfile.path
         )
     argfile = ctx.new_file(
       ctx.outputs.jar,
       "%s_worker_input" % ctx.label.name
     )
 
-    ctx.file_action(output=argfile, content=scalac_args + optional_scalac_args)    
+    ctx.file_action(output=argfile, content=scalac_args + optional_scalac_args)
 
-    outs = [ctx.outputs.jar, statsfile]
+    outs = [ctx.outputs.jar, ctx.outputs.statsfile]
     if buildijar:
         outs.extend([ctx.outputs.ijar])
     # _java_toolchain added manually since _java doesn't currently setup runfiles
@@ -958,6 +958,7 @@ common_outputs = {
   "jar": "%{name}.jar",
   "deploy_jar": "%{name}_deploy.jar",
   "manifest": "%{name}_MANIFEST.MF",
+  "statsfile": "%{name}.statsfile",
 }
 
 library_outputs = {}

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -96,6 +96,7 @@ def _build_nosrc_jar(ctx, buildijar):
     cmd = """
 rm -f {jar_output}
 {zipper} c {jar_output} @{path}
+# ensures that empty src targets still emit a statsfile
 touch {statsfile}
 """ + ijar_cmd
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -191,6 +191,8 @@ CurrentTarget: {current_target}
     toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
     scalacopts = toolchain.scalacopts + ctx.attr.scalacopts
 
+    statsfile = ctx.new_file(ctx.outputs.jar, "%s.statsfile" % ctx.label.name)
+
     scalac_args = """
 Classpath: {cp}
 EnableIjar: {enableijar}
@@ -210,6 +212,7 @@ ResourceStripPrefix: {resource_strip_prefix}
 ScalacOpts: {scala_opts}
 SourceJars: {srcjars}
 DependencyAnalyzerMode: {dependency_analyzer_mode}
+StatsfileOutput: {statsfile_output}
 """.format(
         out=ctx.outputs.jar.path,
         manifest=ctx.outputs.manifest.path,
@@ -231,15 +234,16 @@ DependencyAnalyzerMode: {dependency_analyzer_mode}
         resource_strip_prefix=ctx.attr.resource_strip_prefix,
         resource_jars=",".join([f.path for f in ctx.files.resource_jars]),
         dependency_analyzer_mode = dependency_analyzer_mode,
+        statsfile_output = statsfile.path
         )
     argfile = ctx.new_file(
       ctx.outputs.jar,
       "%s_worker_input" % ctx.label.name
     )
 
-    ctx.file_action(output=argfile, content=scalac_args + optional_scalac_args)
+    ctx.file_action(output=argfile, content=scalac_args + optional_scalac_args)    
 
-    outs = [ctx.outputs.jar]
+    outs = [ctx.outputs.jar, statsfile]
     if buildijar:
         outs.extend([ctx.outputs.ijar])
     # _java_toolchain added manually since _java doesn't currently setup runfiles

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -25,6 +25,7 @@ public class CompileOptions {
   final public String[] indirectTargets;
   final public String dependencyAnalyzerMode;
   final public String currentTarget;
+  final public String statsfile;
 
   public CompileOptions(List<String> args) {
     Map<String, String> argMap = buildArgMap(args);
@@ -60,6 +61,8 @@ public class CompileOptions {
 
     dependencyAnalyzerMode = getOrElse(argMap, "DependencyAnalyzerMode", "off");
     currentTarget = getOrElse(argMap, "CurrentTarget", "NA");
+
+    statsfile = getOrError(argMap, "StatsfileOutput", "Missing required arg StatsfileOutput");
   }
 
   private static Map<String, Resource> getResources(Map<String, String> args) {

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -9,6 +9,7 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -247,6 +248,13 @@ class ScalacProcessor implements Processor {
       System.err.println("Compiler runtime: " + (stop - start) + "ms.");
     }
 
+    try {
+      PrintWriter writer = new PrintWriter(ops.statsfile, "UTF-8");
+      writer.println(Long.toString(stop - start));
+      writer.close();
+    } catch (Throwable ex) {
+      throw new RuntimeException("YOLO", ex);
+    }
 
     ConsoleReporter reporter = (ConsoleReporter) reporterField.get(comp);
 

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -9,7 +9,6 @@ import java.io.FileNotFoundException;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.PrintWriter;
 import java.lang.reflect.Field;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -249,11 +248,11 @@ class ScalacProcessor implements Processor {
     }
 
     try {
-      PrintWriter writer = new PrintWriter(ops.statsfile, "UTF-8");
-      writer.println(Long.toString(stop - start));
-      writer.close();
-    } catch (Throwable ex) {
-      throw new RuntimeException("YOLO", ex);
+      Files.write(Paths.get(ops.statsfile), Arrays.asList(
+        "build_time=" + Long.toString(stop - start)));
+    } catch (IOException ex) {
+        throw new RuntimeException(
+            "Unable to write statsfile to " + ops.statsfile, ex);
     }
 
     ConsoleReporter reporter = (ConsoleReporter) reporterField.get(comp);

--- a/test/BUILD
+++ b/test/BUILD
@@ -455,3 +455,8 @@ scalapb_proto_library(
     deps = ["//test/proto:test2", ":HelloLib"],
     visibility = ["//visibility:public"],
 )
+
+load(":check_statsfile.bzl", "check_statsfile")
+
+check_statsfile("ScalaBinary")
+check_statsfile("ScalaLibBinary")

--- a/test/check_statsfile.bzl
+++ b/test/check_statsfile.bzl
@@ -1,0 +1,24 @@
+def check_statsfile(
+        target
+):
+    statsfile = ":%s.statsfile" % target
+    outfile = "%s.statsfile.good" % target
+
+    cmd = """
+TIME_MS=`awk -F '=' '$$1 == "build_time" {{ print $$2 }}' {statsfile}`
+if [ ! -z "$$TIME_MS" ]; then
+  touch '{outfile}'
+fi
+"""
+    cmd = cmd.format(
+        statsfile = "$(location %s)" % statsfile,
+        outfile = "$(location %s)" % outfile,
+    )
+
+    native.genrule(
+        name = "%s_statsfile" % target,
+        outs = [outfile],
+        tools = [statsfile],
+        cmd = cmd,
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
As it stands there isn't clean path to getting target level metrics from Bazel. The build event protocol currently doesn't have timing information for non-test targets [0]. But that doesn't have to stop us from being the first to get this kind of metric from Scala [1].

This adds an output file, the "statsfile" with a very basic property file inspired syntax. The values can be read easily with basic text manipulation utilities, for example `awk -F '=' '$1 == "property_name" { print $2 }' 'path_to.statsfile'` to read the value for `property_name`.

One downside is that this statsfile is non-deterministic. As long as this file is only used for downstream metrics, it shouldn't be problematic. The long term hope is that timing information can be added to the build event protocol and that this PR can be reverted.

### Sample Usage

At Stripe, we're proxying scala rules with macros of the same name. The macro adds additional metrics related target that use the statsfile output. This looks roughly like:

```python
def scala_binary(
        name,
        srcs = [],
        # ...
):
    upstream_scala_binary(...)
    _add_timed_target(name, srcs)

# Adds an extra target named `{name}-timed` that prints out
# timing information to the console
def _add_timed_target(
        name,
        srcs
):
    cmd = """
# ...
TIME_MS=`awk -F '=' '$$1 == "build_time" {{ print $$2 }}' '{statsfile}'` 
# ...
"""
    cmd = cmd.format(statsfile = "$(location :%s.statsfile)" % name)
    native.genrule(
        name = "%s-timed" % name,
        tools = [":%s.statsfile" % name, "//tools:cloc"],
        srcs = srcs, cmd = cmd,
        ...)
```

We're also using https://github.com/AlDanial/cloc to derive the LOC/sec compilation speed. I'd be happy to share the fuller code once all of the kinds are worked out.

[0] Timing support for BEP asked here https://groups.google.com/forum/#!topic/bazel-discuss/WnWq1b9l8Es, by @johnynek 
[1] See open Scala issue https://github.com/scala/bug/issues/10601