### PR TITLE
Add struct members that IntelliJ plugin expects to exist

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -625,7 +625,7 @@ def _collect_jars_from_common_ctx(ctx, extra_deps = [], extra_runtime_deps = [])
     return struct(compile_jars = cjars, transitive_runtime_jars = transitive_rjars, jars2labels=jars2labels, transitive_compile_jars = transitive_compile_jars)
 
 def _format_full_jars_for_intellij_plugin(full_jars):
-    return [struct (class_jar = jar, ijar = None) for jar in full_jars]
+    return [struct (class_jar = jar, ijar = None, source_jar = None, source_jars = []) for jar in full_jars]
 
 def create_java_provider(scalaattr, transitive_compile_time_jars):
     # This is needed because Bazel >=0.7.0 requires ctx.actions and a Java

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -54,6 +54,8 @@ def _code_jars_and_intellij_metadata_from(jars):
       intellij_metadata.append(struct(
            ijar = None,
            class_jar = current_class_jar,
+           source_jar = None,
+           source_jars = [],
        )
      )
   return struct(code_jars = code_jars, intellij_metadata = intellij_metadata)


### PR DESCRIPTION
The IntelliJ plugin assumes that source_jar and source_jars are both
present on the jars struct. This sets those to empty values, so the
IntelliJ plugin does not fail.