### PR TITLE
Upgrade protoc-jar from 3.2.0 to 3.5.0.

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -12,8 +12,8 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_protoc_jar",
-        artifact = "com.github.os72:protoc-jar:3.2.0",
-        sha1 = "7c06b12068193bd2080caf45580b0a00d2a31638",
+        artifact = "com.github.os72:protoc-jar:3.5.0",
+        sha1 = "8e984359154a9ee3d1f3525529dd3f985f277ce6",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -24,8 +24,8 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_plugin",
-        artifact = scala_mvn_artifact("com.trueaccord.scalapb:compilerplugin:0.6.5"),
-        sha1 = "290094c632c95b36b6f66d7dbfdc15242b9a247f",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:compilerplugin:0.6.7"),
+        sha1 = "7842555b0b5542086e8d305d6fe192517e4e2f00",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -48,8 +48,8 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapbc",
-        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapbc:0.6.5"),
-        sha1 = "b204d6d56a042b973af5b6fe28f81ece232d1fe4",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapbc:0.6.7"),
+        sha1 = "61ad90558110d5e6e47fce57bd3efa7f38b5a346",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -60,8 +60,8 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_runtime",
-        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime:0.6.5"),
-        sha1 = "ac9287ff48c632df525773570ee4842e3ddf40e9",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime:0.6.7"),
+        sha1 = "efe84a4e6570c095f4ae4defab4fea33ac0317d4",
         server = "scala_proto_deps_maven_server",
     )
 
@@ -72,8 +72,8 @@ def scala_proto_repositories():
 
     native.maven_jar(
         name = "scala_proto_rules_scalapb_runtime_grpc",
-        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime-grpc:0.6.5"),
-        sha1 = "9dc3374001f4190548db36a7dc87bd4f9bca6f9c",
+        artifact = scala_mvn_artifact("com.trueaccord.scalapb:scalapb-runtime-grpc:0.6.7"),
+        sha1 = "c98a02462c5962f8116ed6ed4f208dc3258eb96d",
         server = "scala_proto_deps_maven_server",
     )
 

--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -41,7 +41,7 @@ class ScalaPBGenerator extends Processor {
     val extractRequestResult = PBGenerateRequest.from(args)
     val config = ScalaPBC.processArgs(extractRequestResult.scalaPBArgs.toArray)
     val code = ProtocBridge.runWithGenerators(
-      protoc = a => com.github.os72.protocjar.Protoc.runProtoc(config.version +: a.toArray),
+      protoc = a => com.github.os72.protocjar.Protoc.runProtoc(a.toArray),
       namedGenerators = Seq("scala" -> ScalaPbCodeGenerator),
       params = config.args)
 


### PR DESCRIPTION
FreeBSD binaries don't exist for 3.2.0, but they do for various other
versions including 3.5.0.

Note that 3.5.1 does not work:
https://github.com/os72/protoc-jar/issues/43

Also, I had to remove the explicit version setting that ScalaPBC does:
https://github.com/scalapb/ScalaPB/blob/master/scalapbc/src/main/scala/scalapb/ScalaPBC.scala#L8
This seems a bit pointless, given that we provide our own version of
protoc anyway, but also there is no 3.1.0 for FreeBSD.