### PR TITLE
Always pass the transitive classpath to the compiler for scala_library

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -816,9 +816,8 @@ def _scala_test_impl(ctx):
     cjars += scalatest_jars
     transitive_rjars += scalatest_jars
 
-    if is_dependency_analyzer_on(ctx):
-      transitive_compile_jars += scalatest_jars
-      add_labels_of_jars_to(jars_to_labels, ctx.attr._scalatest, scalatest_jars, scalatest_jars)
+    transitive_compile_jars += scalatest_jars
+    add_labels_of_jars_to(jars_to_labels, ctx.attr._scalatest, scalatest_jars, scalatest_jars)
 
     args = " ".join([
         "-R \"{path}\"".format(path=ctx.outputs.jar.short_path),


### PR DESCRIPTION
java_library always includes transitive dependencies, regardless of strict deps.

> Bazel always passes the entire transitive classpath to javac, not only the direct classpath. This frees the user from having to aggregate their transitive dependencies manually. In other words, javac never fails because of a missing symbol, as long as every rule specifies its direct dependencies. 
> [https://blog.bazel.build/2017/06/28/sjd-unused_deps.html](https://blog.bazel.build/2017/06/28/sjd-unused_deps.html)

I think scala_library should work similarly.

And unless I am mistaken, scalac more or less requires essentially the full transitive classpath. There seems to be little practical benefit in ever not including the transitive dependencies.

(FYI, tangentially: The reason I am not just using strict deps anyway is because I don't care enough about its guarantees. Code modifications can break downstream targets. I'm okay with dependency modifications breaking downstream targets.)