### PR TITLE
use transitive_proto_path_flags if exist

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -327,6 +327,7 @@ def _gen_proto_srcjar_impl(ctx):
         if hasattr(target, 'proto'):
             proto_deps.append(target)
             acc_imports += target.proto.transitive_sources
+            #inline this if after 0.12.0 is the oldest supported version
             if hasattr(target.proto, 'transitive_proto_path_flags'):
               transitive_proto_path_flags += target.proto.transitive_proto_path_flags
         else:

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -320,12 +320,15 @@ def _colon_paths(data):
 
 def _gen_proto_srcjar_impl(ctx):
     acc_imports = depset()
+    transitive_proto_path_flags = depset()
 
     proto_deps, jvm_deps = [], []
     for target in ctx.attr.deps:
         if hasattr(target, 'proto'):
             proto_deps.append(target)
             acc_imports += target.proto.transitive_sources
+            if hasattr(target.proto, 'transitive_proto_path_flags'):
+              transitive_proto_path_flags += target.proto.transitive_proto_path_flags
         else:
             jvm_deps.append(target)
 
@@ -334,11 +337,13 @@ def _gen_proto_srcjar_impl(ctx):
 
     deps_jars = collect_jars(jvm_deps)
 
-    worker_content = "{output}\n{paths}\n{flags_arg}".format(
+    worker_content = "{output}\n{paths}\n{flags_arg}\n{packages}".format(
         output = ctx.outputs.srcjar.path,
         paths = _colon_paths(acc_imports),
         # Command line args to worker cannot be empty so using padding
         flags_arg = "-" + ",".join(ctx.attr.flags),
+        # Command line args to worker cannot be empty so using padding
+        packages = "-" + ":".join(transitive_proto_path_flags.to_list())
     )
     argfile = ctx.new_file(ctx.outputs.srcjar, "%s_worker_input" % ctx.label.name)
     ctx.file_action(output=argfile, content=worker_content)

--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -31,11 +31,15 @@ object PBGenerateRequest {
       case s if s.charAt(0) == '-' => Some(s.tail) //drop padding character
       case other => sys.error(s"expected a padding character of - (dash), but found: $other")
     }
-
+    val transitiveProtoPathFlags = args.get(3) match {
+      case "-" => Nil
+      case s if s.charAt(0) == '-' => s.tail.split(':').toList //drop padding character
+      case other => sys.error(s"expected a padding character of - (dash), but found: $other")
+    }
     val tmp = Paths.get(Option(System.getProperty("java.io.tmpdir")).getOrElse("/tmp"))
     val scalaPBOutput = Files.createTempDirectory(tmp, "bazelscalapb")
     val flagPrefix = flagOpt.fold("")(_ + ":")
-    val scalaPBArgs = s"--scala_out=$flagPrefix$scalaPBOutput" :: (imports ++ protoFiles)
+    val scalaPBArgs = s"--scala_out=$flagPrefix$scalaPBOutput" :: (transitiveProtoPathFlags ++ imports ++ protoFiles)
     new PBGenerateRequest(jarOutput, scalaPBOutput, scalaPBArgs)
   }
 }

--- a/test_expect_failure/proto_source_root/dependency/BUILD
+++ b/test_expect_failure/proto_source_root/dependency/BUILD
@@ -1,0 +1,6 @@
+proto_library(
+    name = "dependency",
+    srcs = glob(["*.proto"]),
+    proto_source_root = package_name(),
+    visibility = ["//visibility:public"],
+)

--- a/test_expect_failure/proto_source_root/dependency/zip_code.proto
+++ b/test_expect_failure/proto_source_root/dependency/zip_code.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+package demo; // Requried to generate valid code.
+
+message ZipCode {
+  string code = 1;
+}

--- a/test_expect_failure/proto_source_root/user/BUILD
+++ b/test_expect_failure/proto_source_root/user/BUILD
@@ -1,0 +1,15 @@
+load("//scala_proto:scala_proto.bzl",
+    "scalapb_proto_library")
+
+proto_library(
+    name = "user",
+    srcs = glob(["*.proto"]),
+    deps = ["//test_expect_failure/proto_source_root/dependency"],
+    proto_source_root = package_name(),
+)
+
+scalapb_proto_library(
+    name = "user_scala",
+    deps = [":user"],
+    visibility = ["//visibility:public"],
+)

--- a/test_expect_failure/proto_source_root/user/address.proto
+++ b/test_expect_failure/proto_source_root/user/address.proto
@@ -1,0 +1,10 @@
+syntax = "proto3";
+
+package demo; // Requried to generate valid code.
+
+import "zip_code.proto";
+
+message Address {
+  string city = 1;
+  ZipCode zip_code = 2;
+}

--- a/test_expect_failure/proto_source_root/user/person.proto
+++ b/test_expect_failure/proto_source_root/user/person.proto
@@ -1,0 +1,13 @@
+syntax = "proto3";
+
+package demo; // Requried to generate valid code.
+
+import "address.proto";
+
+message Person {
+  string name = 1;
+  int32 id = 2;
+  string email = 3;
+  Address address = 4;
+}
+


### PR DESCRIPTION
following https://github.com/bazelbuild/bazel/issues/4544 I'm adding an optional propagation of transitive_proto_path_flags to protoc.
It's optional since it's not currently in a released version and in fact the exposition to skylark will only land in an hour or two but I've tested it manually.
For the above reason the test is under `test_expect_failure` and not part of CI since we can't run only that test against bazel head.
@azymnis @johnynek I'd like to merge this soon so I'd appreciate your review