### PR TITLE
Add default javac opts when compiling java srcs

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -330,7 +330,7 @@ def try_to_compile_java_jar(ctx,
                 source_jars = all_srcjars.to_list(),
                 source_files = java_srcs,
                 output = full_java_jar,
-                javac_opts = _expand_location(ctx, ctx.attr.javacopts + ctx.attr.javac_jvm_flags),
+                javac_opts = _expand_location(ctx, ctx.attr.javacopts + ctx.attr.javac_jvm_flags + java_common.default_javac_opts(ctx, java_toolchain_attr = "_java_toolchain")),
                 deps = providers_of_dependencies,
                 #exports can be empty since the manually created provider exposes exports
                 #needs to be empty since we want the provider.compile_jars to only contain the sources ijar

--- a/test_expect_failure/compilers_javac_opts/BUILD
+++ b/test_expect_failure/compilers_javac_opts/BUILD
@@ -1,0 +1,18 @@
+load("//scala:scala.bzl", "scala_library")
+load("@bazel_tools//tools/jdk:default_java_toolchain.bzl", "default_java_toolchain")
+
+scala_library(
+  name = "can_configure_jvm_flags_for_javac_via_javacopts",
+  srcs = ["WillNotCompileSinceJavaToolchainAddsAnInvalidJvmFlag.java"]
+)
+
+default_java_toolchain(
+    name = "a_java_toolchain",
+    jvm_opts = ["-Xbootclasspath/p:$(location @bazel_tools//third_party/java/jdk/langtools:javac_jar)",],
+    javac = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar",],
+    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath.jar",],
+    visibility = ["//visibility:public",],
+    misc = [
+        "-InvalidFlag"
+    ],
+)

--- a/test_expect_failure/compilers_javac_opts/WillNotCompileSinceJavaToolchainAddsAnInvalidJvmFlag.java
+++ b/test_expect_failure/compilers_javac_opts/WillNotCompileSinceJavaToolchainAddsAnInvalidJvmFlag.java
@@ -1,0 +1,4 @@
+package test_expect_failure.compilers_javac_opts;
+
+public class WillNotCompileSinceJavaToolchainAddsAnInvalidJvmFlag {
+}

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -612,6 +612,13 @@ javac_jvm_flags_via_javacopts_are_expanded(){
     build --verbose_failures //test_expect_failure/compilers_jvm_flags:can_expand_jvm_flags_for_javac_via_javacopts
 }
 
+java_toolchain_javacopts_are_used(){
+  action_should_fail_with_message \
+    "invalid flag: -InvalidFlag" \
+    build --java_toolchain=//test_expect_failure/compilers_javac_opts:a_java_toolchain \
+      --verbose_failures //test_expect_failure/compilers_javac_opts:can_configure_jvm_flags_for_javac_via_javacopts
+}
+
 revert_internal_change() {
   sed -i.bak "s/println(\"altered\")/println(\"orig\")/" $no_recompilation_path/C.scala
   rm $no_recompilation_path/C.scala.bak
@@ -788,6 +795,7 @@ $runner test_scala_import_expect_failure_on_missing_direct_deps_warn_mode
 $runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn"
 $runner test_scalaopts_from_scala_toolchain
 $runner test_scala_import_library_passes_labels_of_direct_deps
+$runner java_toolchain_javacopts_are_used
 
 # This test is last since it compares the current outputs to new ones to make sure they're identical
 # If it runs before some of the above (like jmh) the "current" output in CI might be too close in time to the "new" one


### PR DESCRIPTION
Scala rules compile java sources using `java_common.compile`. When building the required input for `java_common.compile` scala rules uses only `javacopts` and `javac_jvm_flags` attributes while ignoring any global/default `javac_opts` such as the ones from `.bazelrc` file, e.g., `build --javacopt=...` or `build --java_toolchain=//:some_tool_chain`

This PR uses `java_common.default_javac_opts` to add the default `javac_opts` to `java_common.compile` `javac_opts`