### PR TITLE
[WIP] Add detection for unused classpath entries as part of strict mode

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -171,17 +171,20 @@ def _compile(ctx, cjars, dep_srcjars, buildijar, transitive_compile_jars, labels
         compiler_classpath_jars = transitive_compile_jars
 
         direct_jars = ",".join([j.path for j in cjars])
+        direct_targets = ",".join([labels[j.path] for j in cjars])
         indirect_jars = ",".join([j.path for j in transitive_compile_jars])
         indirect_targets = ",".join([labels[j.path] for j in transitive_compile_jars])
         current_target = str(ctx.label)
 
         optional_scalac_args = """
 DirectJars: {direct_jars}
+DirectTargets: {direct_targets}
 IndirectJars: {indirect_jars}
 IndirectTargets: {indirect_targets}
 CurrentTarget: {current_target}
         """.format(
               direct_jars=direct_jars,
+              direct_targets=direct_targets,
               indirect_jars=indirect_jars,
               indirect_targets=indirect_targets,
               current_target = current_target
@@ -193,7 +196,7 @@ CurrentTarget: {current_target}
     compiler_classpath = separator.join([j.path for j in compiler_classpath_jars])
 
     toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
-    scalacopts = toolchain.scalacopts + ctx.attr.scalacopts    
+    scalacopts = toolchain.scalacopts + ctx.attr.scalacopts
 
     scalac_args = """
 Classpath: {cp}

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -21,6 +21,7 @@ public class CompileOptions {
   final public String resourceStripPrefix;
   final public String[] resourceJars;
   final public String[] directJars;
+  final public String[] directTargets;
   final public String[] indirectJars;
   final public String[] indirectTargets;
   final public String dependencyAnalyzerMode;
@@ -56,6 +57,7 @@ public class CompileOptions {
     resourceJars = getCommaList(argMap, "ResourceJars");
 
     directJars = getCommaList(argMap, "DirectJars");
+    directTargets = getCommaList(argMap, "DirectTargets");
     indirectJars = getCommaList(argMap, "IndirectJars");
     indirectTargets = getCommaList(argMap, "IndirectTargets");
 

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -196,13 +196,15 @@ class ScalacProcessor implements Processor {
     String[] pluginParams;
 
     if (isModeEnabled(ops.dependencyAnalyzerMode)) {
-      String[] targets = encodeBazelTargets(ops.indirectTargets);
+      String[] indirectTargets = encodeBazelTargets(ops.indirectTargets);
+      String[] directTargets = encodeBazelTargets(ops.directTargets);
       String currentTarget = encodeBazelTarget(ops.currentTarget);
 
       String[] pluginParamsInUse = {
               "-P:dependency-analyzer:direct-jars:" + String.join(":", ops.directJars),
+              "-P:dependency-analyzer:direct-targets:" + String.join(":", directTargets),
               "-P:dependency-analyzer:indirect-jars:" + String.join(":", ops.indirectJars),
-              "-P:dependency-analyzer:indirect-targets:" + String.join(":", targets),
+              "-P:dependency-analyzer:indirect-targets:" + String.join(":", indirectTargets),
               "-P:dependency-analyzer:mode:" + ops.dependencyAnalyzerMode,
               "-P:dependency-analyzer:current-target:" + currentTarget,
       };

--- a/third_party/plugin/src/test/io/bazel/rulesscala/dependencyanalyzer/DependencyAnalyzerTest.scala
+++ b/third_party/plugin/src/test/io/bazel/rulesscala/dependencyanalyzer/DependencyAnalyzerTest.scala
@@ -45,9 +45,11 @@ class DependencyAnalyzerTest {
       """.stripMargin
     val commonsTarget = "commonsTarget"
 
-    val direct = Seq(apacheCommonsClasspath)
+    val direct = Map(apacheCommonsClasspath -> commonsTarget)
     val indirect = Map(apacheCommonsClasspath -> commonsTarget)
-    run(testCode, withDirect = direct, withIndirect = indirect).noErrorOn(commonsTarget)
+    val foo = run(testCode, withDirect = direct, withIndirect = indirect)
+    println(foo)
+    foo.noErrorOn(commonsTarget)
   }
 
 

--- a/third_party/plugin/src/test/io/bazel/rulesscala/dependencyanalyzer/TestUtil.scala
+++ b/third_party/plugin/src/test/io/bazel/rulesscala/dependencyanalyzer/TestUtil.scala
@@ -14,17 +14,18 @@ object TestUtil {
 
   final val defaultTarget = "//..."
 
-  def run(code: String, withDirect: Seq[String] = Seq.empty, withIndirect: Map[String, String] = Map.empty): Seq[String] = {
+  def run(code: String, withDirect: Map[String, String] = Map.empty, withIndirect: Map[String, String] = Map.empty): Seq[String] = {
     val compileOptions = Seq(
-      constructParam("direct-jars", withDirect),
+      constructParam("direct-jars", withDirect.keys),
+      constructParam("direct-targets", withDirect.values),
       constructParam("indirect-jars", withIndirect.keys),
       constructParam("indirect-targets", withIndirect.values),
       constructParam("current-target", Seq(defaultTarget))
     ).mkString(" ")
 
-    val extraClasspath = withDirect ++ withIndirect.keys
+    val extraClasspath = withDirect.keys ++ withIndirect.keys
 
-    val reporter: StoreReporter = runCompilation(code, compileOptions, extraClasspath)
+    val reporter: StoreReporter = runCompilation(code, compileOptions, extraClasspath.toSeq)
     reporter.infos.collect({ case msg if msg.severity == reporter.ERROR => msg.msg }).toSeq
   }
 


### PR DESCRIPTION
Based on what I read in #235, I hacked together a quick `unused_deps` implementation that is currently bundled together with `strict_java_deps`. 

This is a work in progress. I would like to get people's feedback on this before continuing.