### PR TITLE
Fix mixup that occured when adding scala_import files test

### DIFF
--- a/test/src/main/scala/scala/test/scala_import/BUILD
+++ b/test/src/main/scala/scala/test/scala_import/BUILD
@@ -9,16 +9,24 @@ scala_import(
 
 # Jars as files
 scala_import(
-  name = "relate",
-  jars = [
-   "relate_2.11-2.1.1.jar",
-  ],
+    name = "relate",
+    jars = [
+      "relate_2.11-2.1.1.jar",
+    ],
 )
 
 scala_specs2_junit_test(
     name = "scala_import_exposes_jars",
     srcs = ["ScalaImportExposesJarsTest.scala"],
     deps = [":guava_and_commons_lang"],
+    size = "small",
+    suffixes = ["Test"],
+)
+
+scala_specs2_junit_test(
+    name = "scala_import_exposes_file_jars",
+    srcs = ["ScalaImportExposesFileJarsTest.scala"],
+    deps = [":relate"],
     size = "small",
     suffixes = ["Test"],
 )

--- a/test/src/main/scala/scala/test/scala_import/ScalaImportExposesFileJarsTest.scala
+++ b/test/src/main/scala/scala/test/scala_import/ScalaImportExposesFileJarsTest.scala
@@ -1,19 +1,11 @@
 package scala.test.scala_import
 
-import com.google.common.cache.Cache
-import org.apache.commons.lang3.ArrayUtils
 import org.specs2.mutable.SpecificationWithJUnit
 import com.lucidchart.relate.SqlRow
 
 class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
 
   "scala_import" should {
-    "enable using the jars it exposes" in {
-      println(classOf[Cache[String, String]])
-      println(classOf[ArrayUtils])
-      success
-    }
-
     "enable importing jars from files" in {
       println(classOf[SqlRow])
       success


### PR DESCRIPTION
When adding a test for scala_import files support, a test was added that
is never run. This fixes that mixup.