### PR TITLE
Use commons-io to copy bytes in ScalacProcessor.extractJar

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -1150,6 +1150,15 @@ def scala_repositories():
     server = "scalac_deps_maven_server",
   )
 
+  # used by ScalacProcessor
+  native.maven_jar(
+      name = "scalac_rules_commons_io",
+      artifact = "commons-io:commons-io:2.6",
+      sha1 = "815893df5f31da2ece4040fe0a12fd44b577afaf",
+      # bazel maven mirror doesn't have the commons_io artifact
+#      server = "scalac_deps_maven_server",
+    )
+
   # Template for binary launcher
   BAZEL_JAVA_LAUNCHER_VERSION = "0.4.5"
   java_stub_template_url = ("raw.githubusercontent.com/bazelbuild/bazel/" +
@@ -1164,6 +1173,8 @@ def scala_repositories():
   )
 
   native.bind(name = "io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java", actual = "@scalac_rules_protobuf_java//jar")
+
+  native.bind(name = "io_bazel_rules_scala/dependency/commons_io/commons_io", actual = "@scalac_rules_commons_io//jar")
 
   native.bind(name = "io_bazel_rules_scala/dependency/scala/parser_combinators", actual = "@scala//:scala-parser-combinators")
 

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -12,6 +12,7 @@ java_binary(
         "//src/java/com/google/devtools/build/lib:worker",
         "//src/java/io/bazel/rulesscala/jar",
         "//src/java/io/bazel/rulesscala/worker",
+        '//external:io_bazel_rules_scala/dependency/commons_io/commons_io',
         '//external:io_bazel_rules_scala/dependency/scala/scala_compiler',
         '//external:io_bazel_rules_scala/dependency/scala/scala_library',
         '//external:io_bazel_rules_scala/dependency/scala/scala_reflect',

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -4,11 +4,7 @@ import io.bazel.rulesscala.jar.JarCreator;
 import io.bazel.rulesscala.worker.GenericWorker;
 import io.bazel.rulesscala.worker.Processor;
 
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.lang.reflect.Field;
 import java.nio.file.FileSystems;
 import java.nio.file.FileVisitResult;
@@ -21,6 +17,8 @@ import java.util.*;
 import java.util.Map.Entry;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
+import org.apache.commons.io.IOUtils;
 import scala.tools.nsc.Driver;
 import scala.tools.nsc.MainClass;
 import scala.tools.nsc.reporters.ConsoleReporter;
@@ -166,10 +164,8 @@ class ScalacProcessor implements Processor {
       outputPaths.add(f);
 
       InputStream is = jar.getInputStream(file); // get the input stream
-      FileOutputStream fos = new FileOutputStream(f);
-      while (is.available() > 0) {  // write contents of 'is' to 'fos'
-        fos.write(is.read());
-      }
+      OutputStream fos = new FileOutputStream(f);
+      IOUtils.copy(is, fos);
       fos.close();
       is.close();
     }


### PR DESCRIPTION
This greatly improves the performance of that method. It was spotted in
the wild to take up to 50s for relatively small input source jar.