### PR TITLE
Use java_executable_runfiles_path if available

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -435,7 +435,9 @@ def _write_launcher(ctx, rjars, main_class, jvm_flags, args="", wrapper_preamble
     # when that becomes generally available in Bazel (submitted in
     # https://github.com/bazelbuild/bazel/commit/f2075d27ca124156fcd7c01242c552175c0cf145).
     if hasattr(ctx.attr._java_runtime[java_common.JavaRuntimeInfo], "java_executable_runfiles_path"):
-      javabin = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
+      java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
+
+      javabin = "%s/%s" % (runfiles_root, java_path)
     else:
       java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_exec_path)
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -434,11 +434,15 @@ def _write_launcher(ctx, rjars, main_class, jvm_flags, args="", wrapper_preamble
     # TODO: Replace the following if/else with just .java_executable_runfiles_path
     # when that becomes generally available in Bazel (submitted in
     # https://github.com/bazelbuild/bazel/commit/f2075d27ca124156fcd7c01242c552175c0cf145).
-    java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_exec_path)
-    if _path_is_absolute(java_path):
-      javabin = java_path
+    if hasattr(ctx.attr._java_runtime[java_common.JavaRuntimeInfo], "java_executable_runfiles_path"):
+      javabin = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
     else:
-      javabin = "%s/%s" % (runfiles_root, java_path)
+      java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_exec_path)
+
+      if _path_is_absolute(java_path):
+        javabin = java_path
+      else:
+        javabin = "%s/%s" % (runfiles_root, java_path)
 
     template = ctx.attr._java_stub_template.files.to_list()[0]
 


### PR DESCRIPTION
This is a workaround for the issue described [here](https://stackoverflow.com/q/49373212/334519). Instead of waiting for bazel 0.11 to be generally available (see [discussion](https://github.com/bazelbuild/rules_scala/pull/409/files#r164850044)), this change checks whether the new `java_executable_runfiles_path` method is available and uses it now if it is. Otherwise the logic is the same as what it was previously.