### PR TITLE
Unconditionally use java_executable_runfiles path.

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -196,7 +196,7 @@ CurrentTarget: {current_target}
     compiler_classpath = separator.join([j.path for j in compiler_classpath_jars])
 
     toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
-    scalacopts = toolchain.scalacopts + ctx.attr.scalacopts    
+    scalacopts = toolchain.scalacopts + ctx.attr.scalacopts
 
     scalac_args = """
 Classpath: {cp}
@@ -431,20 +431,11 @@ def _write_launcher(ctx, rjars, main_class, jvm_flags, args="", wrapper_preamble
     # https://github.com/bazelbuild/bazel/blob/0.4.5/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt#L227
     classpath = ":".join(["${RUNPATH}%s" % (j.short_path) for j in rjars])
     jvm_flags = " ".join([ctx.expand_location(f, ctx.attr.data) for f in jvm_flags])
-    # TODO: Replace the following if/else with just .java_executable_runfiles_path
-    # when that becomes generally available in Bazel (submitted in
-    # https://github.com/bazelbuild/bazel/commit/f2075d27ca124156fcd7c01242c552175c0cf145).
-    if hasattr(ctx.attr._java_runtime[java_common.JavaRuntimeInfo], "java_executable_runfiles_path"):
-      java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
-
-      javabin = "%s/%s" % (runfiles_root, java_path)
+    java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_runfiles_path)
+    if _path_is_absolute(java_path):
+      javabin = java_path
     else:
-      java_path = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_exec_path)
-
-      if _path_is_absolute(java_path):
-        javabin = java_path
-      else:
-        javabin = "%s/%s" % (runfiles_root, java_path)
+      javabin = "%s/%s" % (runfiles_root, java_path)
 
     template = ctx.attr._java_stub_template.files.to_list()[0]
 


### PR DESCRIPTION
This is now in Bazel in the latest release, so it works this way.