### PR TITLE
Support custom runners (@RunWith) on filtered Scala junit tests

### DIFF
--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -44,10 +44,10 @@ private[rulesscala] class FilteredTestClass(testClass: Class[_], pattern: Patter
 object JUnitFilteringRunnerBuilder {
   val f: FilteringRunnerBuilder = {
     case (runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) =>
-      hackRunner(runner, testClass, pattern)
+      replaceRunnerTestClass(runner, testClass, pattern)
   }
 
-  private def hackRunner(runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) = {
+  private def replaceRunnerTestClass(runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) = {
     allFieldsOf(runner.getClass)
       .find(f => f.getName == "testClass" || f.getName == "fTestClass")
       .foreach(field => {

--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -42,6 +42,9 @@ private[rulesscala] class FilteredTestClass(testClass: Class[_], pattern: Patter
 }
 
 object JUnitFilteringRunnerBuilder {
+  private final val TestClassFieldPreJUnit4_12 = "fTestClass"
+  private final val TestClassField = "testClass"
+
   val f: FilteringRunnerBuilder = {
     case (runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) =>
       replaceRunnerTestClass(runner, testClass, pattern)
@@ -49,7 +52,7 @@ object JUnitFilteringRunnerBuilder {
 
   private def replaceRunnerTestClass(runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) = {
     allFieldsOf(runner.getClass)
-      .find(f => f.getName == "testClass" || f.getName == "fTestClass")
+      .find(f => f.getName == TestClassField || f.getName == TestClassFieldPreJUnit4_12)
       .foreach(field => {
         field.setAccessible(true)
         field.set(runner, new FilteredTestClass(testClass, pattern))

--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -1,7 +1,6 @@
 package io.bazel.rulesscala.test_discovery
 
 import java.lang.annotation.Annotation
-import java.lang.reflect.Field
 import java.util
 import java.util.regex.Pattern
 
@@ -49,7 +48,7 @@ object JUnitFilteringRunnerBuilder {
   }
 
   private def hackRunner(runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) = {
-    ReflectionUtils.getAllFields(runner.getClass)
+    allFieldsOf(runner.getClass)
       .find(f => f.getName == "testClass" || f.getName == "fTestClass")
       .foreach(field => {
         field.setAccessible(true)
@@ -58,21 +57,11 @@ object JUnitFilteringRunnerBuilder {
     runner
   }
 
-  private object ReflectionUtils {
-    def getAllFields(clazz: Class[_]): Seq[Field] = {
-      def getAllTypes(clazz: Class[_]) = {
-        var types = Seq.empty[Class[_]]
-        var c = clazz
-        while (c != null) {
-          types :+= c
-          c = c.getSuperclass
-        }
-        types
-      }
-
-      getAllTypes(clazz)
-        .map(_.getDeclaredFields)
-        .flatMap(_.toSeq)
+  private def allFieldsOf(clazz: Class[_]) = {
+    def supers(cl: Class[_]): List[Class[_]] = {
+      if (cl == null) Nil else cl :: supers(cl.getSuperclass)
     }
+
+    supers(clazz).flatMap(_.getDeclaredFields)
   }
 }

--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -1,13 +1,21 @@
 package io.bazel.rulesscala.test_discovery
 
+import java.lang.annotation.Annotation
+import java.lang.reflect.Field
+import java.util
 import java.util.regex.Pattern
 
 import io.bazel.rulesscala.test_discovery.FilteredRunnerBuilder.FilteringRunnerBuilder
+import org.junit.Test
 import org.junit.runner.Runner
 import org.junit.runners.BlockJUnit4ClassRunner
-import org.junit.runners.model.{FrameworkMethod, RunnerBuilder}
+import org.junit.runners.model.{FrameworkMethod, RunnerBuilder, TestClass}
 
-import scala.collection.JavaConverters._
+import scala.collection.JavaConversions._
+
+object FilteredRunnerBuilder {
+  type FilteringRunnerBuilder = PartialFunction[(Runner, Class[_], Pattern), Runner]
+}
 
 class FilteredRunnerBuilder(builder: RunnerBuilder, filteringRunnerBuilder: FilteringRunnerBuilder) extends RunnerBuilder {
   // Defined by --test_filter bazel flag.
@@ -21,29 +29,50 @@ class FilteredRunnerBuilder(builder: RunnerBuilder, filteringRunnerBuilder: Filt
   }
 }
 
-object FilteredRunnerBuilder {
-  type FilteringRunnerBuilder = PartialFunction[(Runner, Class[_], Pattern), Runner]
-}
-
-object JUnitFilteringRunnerBuilder {
-  val f: FilteringRunnerBuilder = {
-    case (_: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) =>
-      new FilteredJUnitClassRunner(testClass, pattern)
+private[rulesscala] class FilteredTestClass(testClass: Class[_], pattern: Pattern) extends TestClass(testClass) {
+  override def getAnnotatedMethods(aClass: Class[_ <: Annotation]): util.List[FrameworkMethod] = {
+    val methods = super.getAnnotatedMethods(aClass)
+    if (aClass == classOf[Test]) methods.filter(method => methodMatchesPattern(method, pattern))
+    else methods
   }
-}
-
-class FilteredJUnitClassRunner(testClass: Class[_], pattern: Pattern)
-  extends BlockJUnit4ClassRunner(testClass) {
-  override def getChildren: java.util.List[FrameworkMethod] =
-    super
-      .getChildren
-      .asScala
-      .filter(method => methodMatchesPattern(method, pattern))
-      .asJava
 
   private def methodMatchesPattern(method: FrameworkMethod, pattern: Pattern): Boolean = {
     val testCase = method.getDeclaringClass.getName + "#" + method.getName
     pattern.matcher(testCase).find
   }
+}
 
+object JUnitFilteringRunnerBuilder {
+  val f: FilteringRunnerBuilder = {
+    case (runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) =>
+      hackRunner(runner, testClass, pattern)
+  }
+
+  private def hackRunner(runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) = {
+    ReflectionUtils.getAllFields(runner.getClass)
+      .find(f => f.getName == "testClass" || f.getName == "fTestClass")
+      .foreach(field => {
+        field.setAccessible(true)
+        field.set(runner, new FilteredTestClass(testClass, pattern))
+      })
+    runner
+  }
+
+  private object ReflectionUtils {
+    def getAllFields(clazz: Class[_]): Seq[Field] = {
+      def getAllTypes(clazz: Class[_]) = {
+        var types = Seq.empty[Class[_]]
+        var c = clazz
+        while (c != null) {
+          types :+= c
+          c = c.getSuperclass
+        }
+        types
+      }
+
+      getAllTypes(clazz)
+        .map(_.getDeclaredFields)
+        .flatMap(_.toSeq)
+    }
+  }
 }

--- a/test/BUILD
+++ b/test/BUILD
@@ -381,6 +381,14 @@ scala_junit_test(
 )
 
 scala_junit_test(
+    name = "JunitCustomRunner",
+    srcs = ["src/main/scala/scala/test/junit/JunitCustomRunnerTest.scala",
+            "src/main/scala/scala/test/junit/JunitCustomRunner.java"],
+    size = "small",
+    suffixes = ["Test"],
+)
+
+scala_junit_test(
     name = "JunitIncludesClassesWithRunWith",
     srcs = ["src/main/scala/scala/test/junit/JunitIncludesRunWith.scala"],
     size = "small",

--- a/test/BUILD
+++ b/test/BUILD
@@ -382,10 +382,10 @@ scala_junit_test(
 
 scala_junit_test(
     name = "JunitCustomRunner",
-    srcs = ["src/main/scala/scala/test/junit/JunitCustomRunnerTest.scala",
-            "src/main/scala/scala/test/junit/JunitCustomRunner.java"],
+    srcs = ["src/main/scala/scala/test/junit/JunitCustomRunnerTest.scala"],
     size = "small",
     suffixes = ["Test"],
+    deps = [":customJunitRunner"]
 )
 
 scala_junit_test(
@@ -408,7 +408,13 @@ scala_library(
     name = "filesWithUtf8",
     srcs = ["src/main/scala/scala/test/utf8/JavaClassWithUtf8.java",
             "src/main/scala/scala/test/utf8/ScalaClassWithUtf8.scala"]
-    )
+)
+
+scala_library(
+    name = "customJunitRunner",
+    srcs = ["src/main/scala/scala/test/junit/JunitCustomRunner.java"],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"]
+)
 
 # make sure making a fat jar strips signatures
 java_import(

--- a/test/src/main/scala/scala/test/junit/JunitCustomRunner.java
+++ b/test/src/main/scala/scala/test/junit/JunitCustomRunner.java
@@ -1,0 +1,23 @@
+package scala.test.junit;
+
+import org.junit.rules.TestRule;
+import org.junit.runners.BlockJUnit4ClassRunner;
+import org.junit.runners.model.InitializationError;
+
+import java.util.List;
+
+public class JunitCustomRunner extends BlockJUnit4ClassRunner {
+
+    public JunitCustomRunner(Class<?> aClass) throws InitializationError {
+        super(aClass);
+    }
+
+    public static final String EXPECTED_MESSAGE = "Hello from getTestRules!";
+    public static String message;
+
+    @Override
+    protected List<TestRule> getTestRules(Object target) {
+        message = EXPECTED_MESSAGE;
+        return super.getTestRules(target);
+    }
+}

--- a/test/src/main/scala/scala/test/junit/JunitCustomRunnerTest.scala
+++ b/test/src/main/scala/scala/test/junit/JunitCustomRunnerTest.scala
@@ -1,0 +1,13 @@
+package scala.test.junit
+
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@RunWith(classOf[JunitCustomRunner])
+class JunitCustomRunnerTest {
+  @Test
+  def myTest() = {
+    assert(JunitCustomRunner.message == JunitCustomRunner.EXPECTED_MESSAGE,
+      "JunitCustomRunner did not run, check the wiring in JUnitFilteringRunnerBuilder")
+  }
+}

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -406,6 +406,14 @@ scala_junit_test_test_filter(){
   done
 }
 
+scala_junit_test_test_filter_custom_runner(){
+  bazel test \
+    --nocache_test_results \
+    --test_output=streamed \
+    '--test_filter=scala.test.junit.JunitCustomRunnerTest#' \
+    test:JunitCustomRunner
+}
+
 scala_specs2_junit_test_test_filter_everything(){
   local output=$(bazel test \
     --nocache_test_results \
@@ -776,6 +784,7 @@ $runner scala_library_jar_without_srcs_must_include_filegroup_resources
 $runner bazel run test/src/main/scala/scala/test/large_classpath:largeClasspath
 $runner scala_test_test_filters
 $runner scala_junit_test_test_filter
+$runner scala_junit_test_test_filter_custom_runner
 $runner scala_specs2_junit_test_test_filter_everything
 $runner scala_specs2_junit_test_test_filter_one_test
 $runner scala_specs2_junit_test_test_filter_whole_spec


### PR DESCRIPTION
Fixes #376

This is a bit hacky, since it requires replacing a private object instance of the current test runner using private reflection.
Unfortunately, there doesn't seem to be a way to set this object from the outside using normal API.

This PR moves the filtering logic to the actual `TestClass` instance that the JUnit runners query internally, allowing us to perform external filtering on custom runner instances. 

Background info:
The actual logic for querying test methods lives in `org.junit.runners.model.TestClass`, which is, unfortunately, a private field, created by the runner.
To be able to support our custom filtering on other runners, this `TestClass` instance has to be modified.

We're currently handling scala junit tests by "intercepting" the runner as a custom suite, and creating a new runner with additional filtering logic. This doesn't work for custom runners, because their `TestClass` instance is already initialized. Using reflection, this PR creates a new instance of `TestClass` with the filtering logic, and replaces it on the runner.
