### PR TITLE
Fix remaining incompatible changes warnings

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -307,7 +307,7 @@ scala_specs2_junit_test(
 
 # Make sure scala_binary works in test environment
 [sh_test(
-    name = "Run" + "".join([c if c.isalnum() else "_" for c in binary]),
+    name = "Run" + "".join([binary[idx] if binary[idx].isalnum() else "_" for idx in range(len(binary))]),
     srcs = ["test_binary.sh"],
     args = ["$(location %s)" % binary],
     data = [binary if ":" in binary else ":%s" % binary],

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -65,7 +65,7 @@ def _rule_impl(ctx):
             """.format(name=target.label.name,
                        expected=', '.join(expected),
                        visited=', '.join(visited))
-    ctx.file_action(
+    ctx.actions.write(
         output = ctx.outputs.executable,
         content = content,
     )

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -722,9 +722,11 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 $runner bazel build test/...
+$runner bazel build "test/... --all_incompatible_changes"
 $runner bazel test test/...
 $runner bazel test third_party/...
 $runner bazel build "test/... --strict_java_deps=ERROR"
+$runner bazel build "test/... --strict_java_deps=ERROR --all_incompatible_changes"
 $runner bazel test "test/... --strict_java_deps=ERROR"
 $runner bazel run test/src/main/scala/scala/test/twitter_scrooge:justscrooges
 $runner bazel run test:JavaBinary


### PR DESCRIPTION
This fixes the remaining issues to resolve #430. With this, I can pass all tests using `--all_incompatible_changes`.

We test both strict deps and without strict deps to make sure we can pass with the all_incompatible_changes. Since the build should be exactly the same, the cache works when things pass, so it doesn't really increase CI time.