### PR TITLE
`+` operator on a depset is forbidden

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -320,7 +320,7 @@ def _colon_paths(data):
 
 def _gen_proto_srcjar_impl(ctx):
     acc_imports = []
-    transitive_proto_paths = depset()
+    transitive_proto_paths = []
 
     proto_deps, jvm_deps = [], []
     for target in ctx.attr.deps:
@@ -329,7 +329,7 @@ def _gen_proto_srcjar_impl(ctx):
             acc_imports.append(target.proto.transitive_sources)
             #inline this if after 0.12.0 is the oldest supported version
             if hasattr(target.proto, 'transitive_proto_path'):
-              transitive_proto_paths += target.proto.transitive_proto_path
+              transitive_proto_paths.append(target.proto.transitive_proto_path)
         else:
             jvm_deps.append(target)
 
@@ -345,7 +345,7 @@ def _gen_proto_srcjar_impl(ctx):
         # Command line args to worker cannot be empty so using padding
         flags_arg = "-" + ",".join(ctx.attr.flags),
         # Command line args to worker cannot be empty so using padding
-        packages = "-" + ":".join(transitive_proto_paths.to_list())
+        packages = "-" + ":".join(transitive_proto_paths)
     )
     argfile = ctx.actions.declare_file("%s_worker_input" % ctx.label.name, sibling = ctx.outputs.srcjar)
     ctx.actions.write(output=argfile, content=worker_content)


### PR DESCRIPTION
Fixes:

```
ERROR: test/proto/BUILD:36:1: in scala_proto_srcjar rule //test/proto:test_proto_java_conversions_srcjar:
Traceback (most recent call last):
	File "test/proto/BUILD", line 36
		scala_proto_srcjar(name = 'test_proto_java_conversions_srcjar')
	File "scala_proto/scala_proto.bzl", line 332, in _gen_proto_srcjar_impl
		transitive_proto_paths += target.proto.transitive_proto_path
`+` operator on a depset is forbidden. See https://docs.bazel.build/versions/master/skylark/depsets.html for recommendations. Use --incompatible_depset_union=false to temporarily disable this check.
```

See also #480