### PR TITLE
Remove tools/bazel.rc on CI as it's incompatible.

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,16 +1,25 @@
 ---
 platforms:
   ubuntu1404:
+    shell_commands:
+    # Disable local disk caching on CI.
+    - rm -f tools/bazel.rc
     build_targets:
     - "//test/..."
     test_targets:
     - "//test/..."
   ubuntu1604:
+    shell_commands:
+    # Disable local disk caching on CI.
+    - rm -f tools/bazel.rc
     build_targets:
     - "//test/..."
     test_targets:
     - "//test/..."
   macos:
+    shell_commands:
+    # Disable local disk caching on CI.
+    - rm -f tools/bazel.rc
     build_targets:
     - "//test/..."
     test_targets:


### PR DESCRIPTION
Local disk caching does not work on Bazel's CI and actually causes the project to fail in our downstream tests at the moment:
https://buildkite.com/bazel/bazel-with-downstream-projects-bazel/builds/224#e8eab4eb-9baf-4503-8328-62d1ca2f454d