### PR TITLE
flatten depset of transitive proto paths (currently broken accumulation)

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -351,7 +351,7 @@ def _gen_proto_srcjar_impl(ctx):
         # Command line args to worker cannot be empty so using padding
         flags_arg = "-" + ",".join(ctx.attr.flags),
         # Command line args to worker cannot be empty so using padding
-        packages = "-" + ":".join(transitive_proto_paths)
+        packages = "-" + ":".join(depset(transitive = transitive_proto_paths).to_list())
     )
     argfile = ctx.actions.declare_file("%s_worker_input" % ctx.label.name, sibling = ctx.outputs.srcjar)
     ctx.actions.write(output=argfile, content=worker_content)

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -805,3 +805,4 @@ $runner test_scala_import_library_passes_labels_of_direct_deps
 $runner java_toolchain_javacopts_are_used
 $runner bazel run test/src/main/scala/scala/test/classpath_resources:classpath_resource
 $runner test_scala_classpath_resources_expect_warning_on_namespace_conflict
+$runner bazel build //test_expect_failure/proto_source_root/... --strict_proto_deps=off


### PR DESCRIPTION
@johnynek #454 broke transitive proto paths. Because the test was not in CI (requires bazel 0.12.0 which we didn't have until yesterday) we didn't notice it.
I'm now running the test and fixed the issue.
This is a serious blocker for us so if you can take a look and sign off I'd appreciate it :)