### PR TITLE
Remove some old java_common checks

### DIFF
--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -28,8 +28,8 @@ def _collect_jars_when_dependency_analyzer_is_off(dep_targets):
   runtime_jars = []
 
   for dep_target in dep_targets:
-    if java_common.provider in dep_target:
-        java_provider = dep_target[java_common.provider]
+    if JavaInfo in dep_target:
+        java_provider = dep_target[JavaInfo]
         compile_jars.append(java_provider.compile_jars)
         runtime_jars.append(java_provider.transitive_runtime_jars)
     else:
@@ -53,8 +53,8 @@ def _collect_jars_when_dependency_analyzer_is_on(dep_targets):
     current_dep_compile_jars = None
     current_dep_transitive_compile_jars = None
 
-    if java_common.provider in dep_target:
-        java_provider = dep_target[java_common.provider]
+    if JavaInfo in dep_target:
+        java_provider = dep_target[JavaInfo]
         current_dep_compile_jars = java_provider.compile_jars
         current_dep_transitive_compile_jars = java_provider.transitive_compile_time_jars
         runtime_jars.append(java_provider.transitive_runtime_jars)
@@ -117,25 +117,12 @@ def _label_already_exists(jars2labels, jar):
 def _provider_of_dependency_contains_label_of(dependency, jar):
   return hasattr(dependency, "jars_to_labels") and jar.path in dependency.jars_to_labels
 
+# TODO this seems to have limited value now that JavaInfo has everything
 def create_java_provider(scalaattr, transitive_compile_time_jars):
-    # This is needed because Bazel >=0.7.0 requires ctx.actions and a Java
-    # toolchain. Fortunately, the same change that added this requirement also
-    # added this field to the Java provider so we can use it to test which
-    # Bazel version we are running under.
-    test_provider = java_common.create_provider()
-
-    if hasattr(test_provider, "full_compile_jars"):
-      return java_common.create_provider(
-          use_ijar = False,
-          compile_time_jars = scalaattr.compile_jars,
-          runtime_jars = scalaattr.transitive_runtime_jars,
-          transitive_compile_time_jars = depset(transitive = [transitive_compile_time_jars, scalaattr.compile_jars]),
-          transitive_runtime_jars = scalaattr.transitive_runtime_jars,
-      )
-    else:
-      return java_common.create_provider(
-          compile_time_jars = scalaattr.compile_jars,
-          runtime_jars = scalaattr.transitive_runtime_jars,
-          transitive_compile_time_jars = transitive_compile_time_jars,
-          transitive_runtime_jars = scalaattr.transitive_runtime_jars,
-      )
+    return java_common.create_provider(
+        use_ijar = False,
+        compile_time_jars = scalaattr.compile_jars,
+        runtime_jars = scalaattr.transitive_runtime_jars,
+        transitive_compile_time_jars = depset(transitive = [transitive_compile_time_jars, scalaattr.compile_jars]),
+        transitive_runtime_jars = scalaattr.transitive_runtime_jars,
+    )

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -296,22 +296,11 @@ StatsfileOutput: {statsfile_output}
 
 
 def _interim_java_provider_for_java_compilation(scala_output):
-    # This is needed because Bazel >=0.7.0 requires ctx.actions and a Java
-    # toolchain. Fortunately, the same change that added this requirement also
-    # added this field to the Java provider so we can use it to test which
-    # Bazel version we are running under.
-    test_provider = java_common.create_provider()
-    if hasattr(test_provider, "full_compile_jars"):
-      return java_common.create_provider(
-          use_ijar = False,
-          compile_time_jars = [scala_output],
-          runtime_jars = [],
-      )
-    else:
-      return java_common.create_provider(
-          compile_time_jars = [scala_output],
-          runtime_jars = [],
-      )
+    return java_common.create_provider(
+        use_ijar = False,
+        compile_time_jars = [scala_output],
+        runtime_jars = [],
+    )
 
 def try_to_compile_java_jar(ctx,
                             scala_output,
@@ -348,8 +337,8 @@ def try_to_compile_java_jar(ctx,
 def collect_java_providers_of(deps):
     providers = []
     for dep in deps:
-        if java_common.provider in dep:
-          providers.append(dep[java_common.provider])
+        if JavaInfo in dep:
+          providers.append(dep[JavaInfo])
     return providers
 
 def _compile_or_empty(ctx, jars, srcjars, buildijar, transitive_compile_jars, jars2labels, implicit_junit_deps_needed_for_java_compilation):
@@ -474,8 +463,8 @@ def _collect_runtime_jars(dep_targets):
   runtime_jars = []
 
   for dep_target in dep_targets:
-    if java_common.provider in dep_target:
-        runtime_jars.append(dep_target[java_common.provider].transitive_runtime_jars)
+    if JavaInfo in dep_target:
+        runtime_jars.append(dep_target[JavaInfo].transitive_runtime_jars)
     else:
         # support http_file pointed at a jar. http_jar uses ijar,
         # which breaks scala macros


### PR DESCRIPTION
I think we already require a bazel version that means we don't need to use these checks.

Just some small housekeeping on the way to using modern providers on all the rules now that https://github.com/bazelbuild/intellij/issues/279 is solved.