### PR TITLE
expose scala binary jars in build even protocol

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -594,7 +594,6 @@ def _scala_binary_common(ctx, cjars, rjars, transitive_compile_time_jars, jars2l
   java_provider = create_java_provider(scalaattr, transitive_compile_time_jars)
 
   return struct(
-      files=depset([ctx.outputs.executable]),
       providers = [java_provider],
       scala = scalaattr,
       transitive_rjars = rjars, #calling rules need this for the classpath in the launcher


### PR DESCRIPTION
@johnynek apparently we only expose the wrapper script for scala binary targets.
Added tests for scala_binary/scala_test/scala_junit_test
There is some redundancy between the three but they felt important enough to protect if we re-implement them without a shared method