### PR TITLE
Fix issue building all outputs rather than just default

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -614,7 +614,7 @@ def _scala_binary_common(ctx,
   java_provider = create_java_provider(scalaattr, transitive_compile_time_jars)
 
   return struct(
-      files=depset([ctx.outputs.executable, ctx.outputs.jar]),
+      files = depset([ctx.outputs.executable, ctx.outputs.jar]),
       providers = [java_provider],
       scala = scalaattr,
       transitive_rjars =

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -614,6 +614,7 @@ def _scala_binary_common(ctx,
   java_provider = create_java_provider(scalaattr, transitive_compile_time_jars)
 
   return struct(
+      files=depset([ctx.outputs.executable, ctx.outputs.jar]),
       providers = [java_provider],
       scala = scalaattr,
       transitive_rjars =


### PR DESCRIPTION
https://github.com/bazelbuild/rules_scala/pull/511 introduced a bug meaning we always build all non-default outputs for our binary rules. So we were always building the deploy jars (ultimately filling disks in our CI cluster :) )

@ittaiz can you take a look? i didn't remove any of the tests you added so this shouldn't be a regression i don't believe for what you were looking at. 