### PR TITLE
docs: Remove stale comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,8 +621,8 @@ Test & Build:
 ```
 bash test_all.sh
 ```
-This doesn't currently pass on OS X (see #136 for details) and so you can also use:
 
+You can also use:
 ```
 bazel test //test/...
 ```


### PR DESCRIPTION
Issues referenced for building in MAC (#136, #396 and #398)  are closed/merged

Having the comment `This doesn't currently pass on OS X (see #136 for details)` is not accurate. 

BTW, I cannot confirm it's true, because in my env have bazel 0.14 and `test_all.sh` is failing
(`bazel test //test/...` is OK)