### PR TITLE
increase the use of scala_toolchain

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -262,7 +262,7 @@ StatsfileOutput: {statsfile_output}
   ctx.actions.run(
       inputs = ins,
       outputs = outs,
-      executable = ctx.executable.scalac,
+      executable = ctx.executable._scalac,
       mnemonic = "Scalac",
       progress_message = "scala %s" % ctx.label,
       execution_requirements = {"supports-workers": "1"},

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -148,7 +148,10 @@ def _compile(ctx, cjars, dep_srcjars, buildijar, transitive_compile_jars,
   srcjars = _srcjar_filetype.filter(ctx.files.srcs)
   all_srcjars = depset(srcjars, transitive = [dep_srcjars])
   # look for any plugins:
-  plugins = _collect_plugin_paths(ctx.attr.plugins)
+  plugins = ctx.attr.plugins
+  if len(plugins) == 0:
+    plugins = toolchain.plugins
+  plugins = _collect_plugin_paths(plugins)
   dependency_analyzer_plugin_jars = []
   dependency_analyzer_mode = "off"
   compiler_classpath_jars = cjars
@@ -182,7 +185,8 @@ CurrentTarget: {current_target}
         indirect_targets = indirect_targets,
         current_target = current_target)
 
-  plugin_arg = _join_path(plugins.to_list())
+  plugins_list = plugins.to_list()
+  plugin_arg = _join_path(plugins_list)
 
   separator = ctx.configuration.host_path_separator
   compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
@@ -246,7 +250,7 @@ StatsfileOutput: {statsfile_output}
   if buildijar:
     outs.extend([ctx.outputs.ijar])
   ins = (compiler_classpath_jars.to_list() + dep_srcjars.to_list() +
-         list(srcjars) + list(sources) + ctx.files.srcs + ctx.files.plugins +
+         list(srcjars) + list(sources) + ctx.files.srcs + plugins_list +
          dependency_analyzer_plugin_jars + classpath_resources +
          ctx.files.resources + ctx.files.resource_jars + ctx.files._java_runtime
          + [ctx.outputs.manifest, toolchain.ijar, argfile])

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -262,7 +262,7 @@ StatsfileOutput: {statsfile_output}
   ctx.actions.run(
       inputs = ins,
       outputs = outs,
-      executable = toolchain.scalac,
+      executable = ctx.executable.scalac,
       mnemonic = "Scalac",
       progress_message = "scala %s" % ctx.label,
       execution_requirements = {"supports-workers": "1"},

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -29,6 +29,9 @@ _java_filetype = FileType([".java"])
 _scala_filetype = FileType([".scala"])
 _srcjar_filetype = FileType([".srcjar"])
 
+def _get_toolchain(ctx):
+  return ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
+
 def _adjust_resources_path_by_strip_prefix(path, resource_strip_prefix):
   if not path.startswith(resource_strip_prefix):
     fail("Resource file %s is not under the specified prefix to strip" % path)
@@ -89,10 +92,11 @@ rm -f {jar_output}
 touch {statsfile}
 """ + ijar_cmd
 
+  zipper = _get_toolchain(ctx).zipper
   cmd = cmd.format(
       path = zipper_arg_path.path,
       jar_output = ctx.outputs.jar.path,
-      zipper = ctx.executable._zipper.path,
+      zipper = zipper.path,
       statsfile = ctx.outputs.statsfile.path,
   )
 
@@ -100,9 +104,7 @@ touch {statsfile}
   if buildijar:
     outs.extend([ctx.outputs.ijar])
 
-  inputs = ctx.files.resources + [
-      ctx.outputs.manifest, ctx.executable._zipper, zipper_arg_path
-  ]
+  inputs = ctx.files.resources + [ctx.outputs.manifest, zipper, zipper_arg_path]
 
   ctx.actions.run_shell(
       inputs = inputs,
@@ -134,11 +136,12 @@ def _join_path(args, sep = ","):
 
 def _compile(ctx, cjars, dep_srcjars, buildijar, transitive_compile_jars,
              labels, implicit_junit_deps_needed_for_java_compilation):
+  toolchain = _get_toolchain(ctx)
   ijar_output_path = ""
   ijar_cmd_path = ""
   if buildijar:
     ijar_output_path = ctx.outputs.ijar.path
-    ijar_cmd_path = ctx.executable._ijar.path
+    ijar_cmd_path = toolchain.ijar.path
 
   java_srcs = _java_filetype.filter(ctx.files.srcs)
   sources = _scala_filetype.filter(ctx.files.srcs) + java_srcs
@@ -184,7 +187,6 @@ CurrentTarget: {current_target}
   separator = ctx.configuration.host_path_separator
   compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
 
-  toolchain = ctx.toolchains['@io_bazel_rules_scala//scala:toolchain_type']
   scalacopts = toolchain.scalacopts + ctx.attr.scalacopts
 
   scalac_args = """
@@ -247,11 +249,16 @@ StatsfileOutput: {statsfile_output}
          list(srcjars) + list(sources) + ctx.files.srcs + ctx.files.plugins +
          dependency_analyzer_plugin_jars + classpath_resources +
          ctx.files.resources + ctx.files.resource_jars + ctx.files._java_runtime
-         + [ctx.outputs.manifest, ctx.executable._ijar, argfile])
+         + [ctx.outputs.manifest, toolchain.ijar, argfile])
+
+  scalac_jvm_flags = ctx.attr.scalac_jvm_flags
+  if len(scalac_jvm_flags) == 0:
+    scalac_jvm_flags = toolchain.scalac_jvm_flags
+
   ctx.actions.run(
       inputs = ins,
       outputs = outs,
-      executable = ctx.executable._scalac,
+      executable = toolchain.scalac,
       mnemonic = "Scalac",
       progress_message = "scala %s" % ctx.label,
       execution_requirements = {"supports-workers": "1"},
@@ -264,8 +271,7 @@ StatsfileOutput: {statsfile_output}
       # be correctly handled since the executable is a jvm app that will
       # consume the flags on startup.
       arguments = [
-          "--jvm_flag=%s" % f
-          for f in _expand_location(ctx, ctx.attr.scalac_jvm_flags)
+          "--jvm_flag=%s" % f for f in _expand_location(ctx, scalac_jvm_flags)
       ] + ["@" + argfile.path],
   )
 
@@ -375,7 +381,7 @@ def _build_deployable(ctx, jars_list):
   ctx.actions.run(
       inputs = jars_list,
       outputs = [ctx.outputs.deploy_jar],
-      executable = ctx.executable._singlejar,
+      executable = _get_toolchain(ctx).singlejar,
       mnemonic = "ScalaDeployJar",
       progress_message = "scala deployable %s" % ctx.label,
       arguments = args)
@@ -480,8 +486,9 @@ def _collect_jars_from_common_ctx(ctx, extra_deps = [],
 
   dependency_analyzer_is_off = is_dependency_analyzer_off(ctx)
 
+  toolchain = _get_toolchain(ctx)
   # Get jars from deps
-  auto_deps = [ctx.attr._scalalib, ctx.attr._scalareflect]
+  auto_deps = toolchain.default_classpath
   deps_jars = collect_jars(ctx.attr.deps + auto_deps + extra_deps,
                            dependency_analyzer_is_off)
   (cjars, transitive_rjars, jars2labels,
@@ -636,9 +643,10 @@ def scala_binary_impl(ctx):
   return out
 
 def scala_repl_impl(ctx):
+  toolchain = _get_toolchain(ctx)
   # need scala-compiler for MainGenericRunner below
   jars = _collect_jars_from_common_ctx(
-      ctx, extra_runtime_deps = [ctx.attr._scalacompiler])
+      ctx, extra_runtime_deps = toolchain.repl_runtime_deps)
   (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
 
   args = " ".join(ctx.attr.scalacopts)

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -17,39 +17,10 @@ _launcher_template = {
         default = Label("@java_stub_template//file")),
 }
 
+# TODO, we should resolve these by ctx.toolchains to find the java toolchain.
+# but I don't know what the toolchain type is for java
+# https://stackoverflow.com/questions/50977784/how-to-resolve-the-java-toolchain-in-bazel
 _implicit_deps = {
-    "_singlejar": attr.label(
-        executable = True,
-        cfg = "host",
-        default = Label("@bazel_tools//tools/jdk:singlejar"),
-        allow_files = True),
-    "_ijar": attr.label(
-        executable = True,
-        cfg = "host",
-        default = Label("@bazel_tools//tools/jdk:ijar"),
-        allow_files = True),
-    "_scalac": attr.label(
-        executable = True,
-        cfg = "host",
-        default = Label("//src/java/io/bazel/rulesscala/scalac"),
-        allow_files = True),
-    "_scalalib": attr.label(
-        default = Label(
-            "//external:io_bazel_rules_scala/dependency/scala/scala_library"),
-        allow_files = True),
-    "_scalacompiler": attr.label(
-        default = Label(
-            "//external:io_bazel_rules_scala/dependency/scala/scala_compiler"),
-        allow_files = True),
-    "_scalareflect": attr.label(
-        default = Label(
-            "//external:io_bazel_rules_scala/dependency/scala/scala_reflect"),
-        allow_files = True),
-    "_zipper": attr.label(
-        executable = True,
-        cfg = "host",
-        default = Label("@bazel_tools//tools/zip:zipper"),
-        allow_files = True),
     "_java_toolchain": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),
     "_host_javabase": attr.label(
@@ -60,6 +31,7 @@ _implicit_deps = {
 }
 
 # Single dep to allow IDEs to pickup all the implicit dependencies.
+# these are private deps, but aspects can traverse private deps
 _resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -21,6 +21,13 @@ _launcher_template = {
 # but I don't know what the toolchain type is for java
 # https://stackoverflow.com/questions/50977784/how-to-resolve-the-java-toolchain-in-bazel
 _implicit_deps = {
+    # TODO: putting this into the toolchain seems to cause it to fail from not finding runfiles
+    'scalac': attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label(
+            "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac"),
+        allow_files = True),
     "_java_toolchain": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),
     "_host_javabase": attr.label(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -22,7 +22,7 @@ _launcher_template = {
 # https://stackoverflow.com/questions/50977784/how-to-resolve-the-java-toolchain-in-bazel
 _implicit_deps = {
     # TODO: putting this into the toolchain seems to cause it to fail from not finding runfiles
-    'scalac': attr.label(
+    "_scalac": attr.label(
         executable = True,
         cfg = "host",
         default = Label(
@@ -235,31 +235,33 @@ scala_repl = rule(
 
 _SCALA_BUILD_FILE = """
 # scala.BUILD
-java_import(
+load("@io_bazel_rules_scala//scala:scala_import.bzl", "scala_import")
+
+scala_import(
     name = "scala-xml",
     jars = ["lib/scala-xml_2.11-1.0.5.jar"],
     visibility = ["//visibility:public"],
 )
 
-java_import(
+scala_import(
     name = "scala-parser-combinators",
     jars = ["lib/scala-parser-combinators_2.11-1.0.4.jar"],
     visibility = ["//visibility:public"],
 )
 
-java_import(
+scala_import(
     name = "scala-library",
     jars = ["lib/scala-library.jar"],
     visibility = ["//visibility:public"],
 )
 
-java_import(
+scala_import(
     name = "scala-compiler",
     jars = ["lib/scala-compiler.jar"],
     visibility = ["//visibility:public"],
 )
 
-java_import(
+scala_import(
     name = "scala-reflect",
     jars = ["lib/scala-reflect.jar"],
     visibility = ["//visibility:public"],

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -1,8 +1,59 @@
 def _scala_toolchain_impl(ctx):
-  toolchain = platform_common.ToolchainInfo(scalacopts = ctx.attr.scalacopts,)
+  toolchain = platform_common.ToolchainInfo(
+      scalacopts = ctx.attr.scalacopts,
+      plugins = ctx.attr.plugins,
+      scalac_jvm_flags = ctx.attr.plugins,
+      singlejar = ctx.executable.singlejar,
+      ijar = ctx.executable.ijar,
+      zipper = ctx.executable.zipper,
+      scalac = ctx.executable.scalac,
+      default_classpath = ctx.attr.default_classpath,
+      repl_runtime_deps = ctx.attr.repl_runtime_deps,
+  )
   return [toolchain]
 
 scala_toolchain = rule(
-    _scala_toolchain_impl, attrs = {
+    _scala_toolchain_impl,
+    attrs = {
         'scalacopts': attr.string_list(),
+        'plugins': attr.label_list(allow_files = ['.jar']),
+        'scalac_jvm_flags': attr.string_list(),
+        'singlejar': attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/jdk:singlejar"),
+            allow_files = True),
+        'ijar': attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/jdk:ijar"),
+            allow_files = True),
+        'zipper': attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label("@bazel_tools//tools/zip:zipper"),
+            allow_files = True),
+        'scalac': attr.label(
+            executable = True,
+            cfg = "host",
+            default = Label(
+                "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac"),
+            allow_files = True),
+        'default_classpath': attr.label_list(
+            default = [
+                Label(
+                    "//external:io_bazel_rules_scala/dependency/scala/scala_library"
+                ),
+                Label(
+                    "//external:io_bazel_rules_scala/dependency/scala/scala_reflect"
+                ),
+            ],
+            providers = [JavaInfo]),
+        'repl_runtime_deps': attr.label_list(
+            default = [
+                Label(
+                    "//external:io_bazel_rules_scala/dependency/scala/scala_compiler"
+                ),
+            ],
+            providers = [JavaInfo]),
     })

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -6,7 +6,6 @@ def _scala_toolchain_impl(ctx):
       singlejar = ctx.executable.singlejar,
       ijar = ctx.executable.ijar,
       zipper = ctx.executable.zipper,
-      scalac = ctx.executable.scalac,
       default_classpath = ctx.attr.default_classpath,
       repl_runtime_deps = ctx.attr.repl_runtime_deps,
   )
@@ -32,12 +31,6 @@ scala_toolchain = rule(
             executable = True,
             cfg = "host",
             default = Label("@bazel_tools//tools/zip:zipper"),
-            allow_files = True),
-        'scalac': attr.label(
-            executable = True,
-            cfg = "host",
-            default = Label(
-                "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac"),
             allow_files = True),
         'default_classpath': attr.label_list(
             default = [


### PR DESCRIPTION
closes #380 related to #170 

@ittaiz @ianoc-stripe please take a look.

I will test our largest repo with this build to make sure it doesn't fail when used as an external repo (which I think happened before).

TODO (maybe not in this PR): we should not use private attributes, I don't think, to get the java toolchain, instead, we should use `ctx.toolchains[...]` inside the rule, but I don't know the toolchain type to put there. I asked this question:

https://stackoverflow.com/questions/50977784/how-to-resolve-the-java-toolchain-in-bazel

cc @katre if you know the answer to how to get the java toolchain.