### PR TITLE
remove cargo-culted extra info in protobuf rules

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -294,7 +294,7 @@ def scala_repositories():
       strip_prefix = "scala-2.11.11",
       sha256 =
       "12037ca64c68468e717e950f47fc77d5ceae5e74e3bdca56f6d02fd5bfd6900b",
-      url = "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
+      url = "http://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
       build_file_content = _SCALA_BUILD_FILE,
   )
 

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -363,8 +363,6 @@ def _gen_proto_srcjar_impl(ctx):
       scala = scalaattr,
       providers = [java_provider],
       srcjars = srcjarsattr,
-      extra_information = [struct(srcjars = srcjarsattr,
-                                 )],
   )
 
 scala_proto_srcjar = rule(


### PR DESCRIPTION
extra info is a wart from over 2 years ago to allow walking the dependency graph. Since then, it seems that aspects are the way bazel recommends doing things. We only currently use extra_info in the scrooge rules, but the protobuf rules seem to have copied the idea, but does not use it.

ptal @ittaiz 

cc @azymnis 
