### PR TITLE
refactor the _compile function

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -294,7 +294,7 @@ def scala_repositories():
       strip_prefix = "scala-2.11.11",
       sha256 =
       "12037ca64c68468e717e950f47fc77d5ceae5e74e3bdca56f6d02fd5bfd6900b",
-      url = "https://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
+      url = "http://downloads.lightbend.com/scala/2.11.11/scala-2.11.11.tgz",
       build_file_content = _SCALA_BUILD_FILE,
   )
 


### PR DESCRIPTION
The goal here is to produce a skylark function we can call to compile source or source jars. The first step is to stop getting all the arguments implicitly from the ctx which implies that they were set up by a rule.

Instead, we want to have a function we could call inside any other rule, which may not have the right attrs or files.

This does not get all the way there, maybe halfway, but I'd rather send the PR.