### PR TITLE
Use java_common.run_ijar

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -329,7 +329,7 @@ def _compile_or_empty(ctx, manifest, jars, srcjars, buildijar,
                   ctx.attr.print_compile_time, ctx.attr.expect_java_output,
                   ctx.attr.scalac_jvm_flags)
 
-    # compile the java now
+    # build ijar if needed
     if buildijar:
       ijar = java_common.run_ijar(
           ctx.actions,
@@ -340,6 +340,8 @@ def _compile_or_empty(ctx, manifest, jars, srcjars, buildijar,
       #  macro code needs to be available at compile-time,
       #  so set ijar == jar
       ijar = ctx.outputs.jar
+
+    # compile the java now
     java_jar = try_to_compile_java_jar(
         ctx, ijar, all_srcjars, java_srcs,
         implicit_junit_deps_needed_for_java_compilation)

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -127,23 +127,10 @@ def _expand_location(ctx, flags):
 def _join_path(args, sep = ","):
   return sep.join([f.path for f in args])
 
-def compile_scala(ctx,
-                  target_label,
-                  output,
-                  manifest,
-                  statsfile,
-                  sources,
-                  cjars,
-                  all_srcjars,
-                  transitive_compile_jars,
-                  plugins,
-                  resource_strip_prefix,
-                  resources,
-                  resource_jars,
-                  labels,
-                  in_scalacopts,
-                  print_compile_time,
-                  expect_java_output,
+def compile_scala(ctx, target_label, output, manifest, statsfile, sources,
+                  cjars, all_srcjars, transitive_compile_jars, plugins,
+                  resource_strip_prefix, resources, resource_jars, labels,
+                  in_scalacopts, print_compile_time, expect_java_output,
                   scalac_jvm_flags):
   # look for any plugins:
   plugins = _collect_plugin_paths(plugins)
@@ -238,8 +225,7 @@ StatsfileOutput: {statsfile_output}
   outs = [output, statsfile]
   ins = (compiler_classpath_jars.to_list() + all_srcjars.to_list() +
          list(sources) + plugins_list + dependency_analyzer_plugin_jars +
-         classpath_resources + resources + resource_jars +
-         [manifest, argfile])
+         classpath_resources + resources + resource_jars + [manifest, argfile])
 
   ctx.actions.run(
       inputs = ins,

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -23,11 +23,6 @@ _implicit_deps = {
         cfg = "host",
         default = Label("@bazel_tools//tools/jdk:singlejar"),
         allow_files = True),
-    "_ijar": attr.label(
-        executable = True,
-        cfg = "host",
-        default = Label("@bazel_tools//tools/jdk:ijar"),
-        allow_files = True),
     "_scalac": attr.label(
         executable = True,
         cfg = "host",
@@ -144,9 +139,6 @@ _common_outputs = {
 
 _library_outputs = {}
 _library_outputs.update(_common_outputs)
-_library_outputs.update({
-    "ijar": "%{name}_ijar.jar",
-})
 
 _scala_library_attrs = {}
 _scala_library_attrs.update(_implicit_deps)

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -14,9 +14,6 @@ public class CompileOptions {
   public final String classpath;
   public final String[] files;
   public final String[] sourceJars;
-  public final boolean iJarEnabled;
-  public final String ijarOutput;
-  public final String ijarCmdPath;
   public final String[] javaFiles;
   public final Map<String, Resource> resourceFiles;
   public final String resourceStripPrefix;
@@ -49,16 +46,6 @@ public class CompileOptions {
     }
 
     sourceJars = getCommaList(argMap, "SourceJars");
-    iJarEnabled = booleanGetOrFalse(argMap, "EnableIjar");
-    if (iJarEnabled) {
-      ijarOutput =
-          getOrError(argMap, "IjarOutput", "Missing required arg ijarOutput when ijar enabled");
-      ijarCmdPath =
-          getOrError(argMap, "IjarCmdPath", "Missing required arg ijarCmdPath when ijar enabled");
-    } else {
-      ijarOutput = null;
-      ijarCmdPath = null;
-    }
     resourceFiles = getResources(argMap);
     resourceStripPrefix = getOrEmpty(argMap, "ResourceStripPrefix");
     resourceJars = getCommaList(argMap, "ResourceJars");

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -79,19 +79,6 @@ class ScalacProcessor implements Processor {
       /** Now build the output jar */
       String[] jarCreatorArgs = {"-m", ops.manifestPath, outputPath.toString(), tmpPath.toString()};
       JarCreator.main(jarCreatorArgs);
-
-      /** Now build the output ijar */
-      if (ops.iJarEnabled) {
-        Process iostat =
-            new ProcessBuilder()
-                .command(ops.ijarCmdPath, ops.outputName, ops.ijarOutput)
-                .inheritIO()
-                .start();
-        int exitCode = iostat.waitFor();
-        if (exitCode != 0) {
-          throw new RuntimeException("ijar process failed!");
-        }
-      }
     } finally {
       removeTmp(tmpPath);
     }

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -176,11 +176,9 @@ test_scala_library_expect_failure_on_missing_direct_deps_warn_mode() {
 
 test_scala_library_expect_failure_on_missing_direct_java() {
   dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  #since bazel 0.12.0 the labels are only emmitted if ijar is in play 
-  dependency_file='test_expect_failure/missing_direct_deps/internal_deps/transitive_dependency_ijar.jar'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
 
-  expected_message="$dependency_file.*$test_target"
+  expected_message=".*$test_target"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
 }

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -178,7 +178,7 @@ test_scala_library_expect_failure_on_missing_direct_java() {
   dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
 
-  expected_message=".*$dependency_target"
+  expected_message="$dependency_target.*$test_target"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
 }
@@ -205,7 +205,7 @@ test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java() {
   dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
 
-  local expected_message=".*$dependency_target"
+  local expected_message="$dependency_target.*$test_target"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--strict_java_deps=warn" "ne"
 }

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -178,7 +178,7 @@ test_scala_library_expect_failure_on_missing_direct_java() {
   dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
 
-  expected_message=".*$test_target"
+  expected_message=".*$dependency_target"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--strict_java_deps=error"
 }
@@ -192,7 +192,7 @@ test_scala_library_expect_failure_on_java_in_src_jar_when_disabled() {
 }
 
 test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules() {
-  transitive_target='.*transitive_dependency_ijar.jar'
+  transitive_target='.*transitive_dependency-ijar.jar'
   direct_target='//test_expect_failure/missing_direct_deps/internal_deps:direct_java_provider_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:dependent_on_some_java_provider'
 
@@ -203,10 +203,9 @@ test_scala_library_expect_better_failure_message_on_missing_transitive_dependenc
 
 test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java() {
   dependency_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
-  dependency_file='test_expect_failure/missing_direct_deps/internal_deps/transitive_dependency_ijar.jar'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency_java_user'
 
-  local expected_message="$dependency_file.*$test_target"
+  local expected_message=".*$dependency_target"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--strict_java_deps=warn" "ne"
 }


### PR DESCRIPTION
here is a supported function to run ijar:

https://docs.bazel.build/versions/master/skylark/lib/java_common.html#run_ijar

I don't know at the moment when it was introduced because bazel docs are sadly unversioned. It does allow us to delete a fair amount of code, so I think it is worth it.

cc @ittaiz @ianoc 