### PR TITLE
use latest version of java launcher stub

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -342,7 +342,7 @@ def scala_repositories():
           "https://%s" % java_stub_template_url
       ],
       sha256 =
-      "f09d06d55cd25168427a323eb29d32beca0ded43bec80d76fc6acd8199a24489",
+      "2cbba7c512e400df0e7d4376e667724a38d1155db5baaa81b72ad785c6d761d1",
   )
 
   native.bind(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -329,7 +329,7 @@ def scala_repositories():
   )
 
   # Template for binary launcher
-  BAZEL_JAVA_LAUNCHER_VERSION = "0.4.5"
+  BAZEL_JAVA_LAUNCHER_VERSION = "0.14.1"
   java_stub_template_url = (
       "raw.githubusercontent.com/bazelbuild/bazel/" +
       BAZEL_JAVA_LAUNCHER_VERSION +


### PR DESCRIPTION
the version we were on has a silent failure with large classpaths.

The version on master, has a bug with very large classpaths, but at least it is not a silent error.

https://github.com/bazelbuild/bazel/issues/5413

When that is fixed we should update.

Also, we should revisit the #471. It would be nice to have a supported `jvm_binary` that we could call, so really we only own scala_library.