### PR TITLE
Add additional substitutions

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -467,6 +467,8 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper):
           "%needs_runfiles%": "",
           "%runfiles_manifest_only%": "",
           "%set_jacoco_metadata%": "",
+          "%set_jacoco_main_class%": "",
+          "%set_jacoco_java_runfiles_root%": "",
           "%workspace_prefix%": ctx.workspace_name + "/",
       },
       is_executable = True,


### PR DESCRIPTION
the launcher in 0.14.1 has some additional jacoco variables. With these unset, things build, but you get a bash warning.

This fixes that.