### PR TITLE
Add scala-xml and scala-parser-combinators jars individually

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -259,7 +259,7 @@ scala_repl = rule(
 
 def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
   _scala_maven_import_external(
-      name = "scala_library",
+      name = "io_bazel_rules_scala_scala_library",
       artifact = "org.scala-lang:scala-library:2.11.12",
       jar_sha256 =
       "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
@@ -267,7 +267,7 @@ def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
       server_urls = maven_servers,
   )
   _scala_maven_import_external(
-      name = "scala_compiler",
+      name = "io_bazel_rules_scala_scala_compiler",
       artifact = "org.scala-lang:scala-compiler:2.11.12",
       jar_sha256 =
       "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
@@ -275,7 +275,7 @@ def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
       server_urls = maven_servers,
   )
   _scala_maven_import_external(
-      name = "scala_reflect",
+      name = "io_bazel_rules_scala_scala_reflect",
       artifact = "org.scala-lang:scala-reflect:2.11.12",
       jar_sha256 =
       "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
@@ -283,7 +283,7 @@ def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
       server_urls = maven_servers,
   )
   _scala_maven_import_external(
-      name = "scalatest",
+      name = "io_bazel_rules_scala_scalatest",
       artifact = "org.scalatest:scalatest_2.11:2.2.6",
       jar_sha256 =
       "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
@@ -292,7 +292,7 @@ def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
   )
 
   _scala_maven_import_external(
-      name = "scala_xml",
+      name = "io_bazel_rules_scala_scala_xml",
       artifact = "org.scala-lang.modules:scala-xml_2.11:1.0.5",
       jar_sha256 =
       "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
@@ -301,7 +301,7 @@ def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
   )
 
   _scala_maven_import_external(
-      name = "scala_parser_combinators",
+      name = "io_bazel_rules_scala_scala_parser_combinators",
       artifact = "org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4",
       jar_sha256 =
       "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
@@ -357,27 +357,27 @@ def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_compiler",
-      actual = "@scala_compiler")
+      actual = "@io_bazel_rules_scala_scala_compiler")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_library",
-      actual = "@scala_library")
+      actual = "@io_bazel_rules_scala_scala_library")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_reflect",
-      actual = "@scala_reflect")
+      actual = "@io_bazel_rules_scala_scala_reflect")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_xml",
-      actual = "@scala_xml")
+      actual = "@io_bazel_rules_scala_scala_xml")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/parser_combinators",
-      actual = "@scala_parser_combinators")
+      actual = "@io_bazel_rules_scala_scala_parser_combinators")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scalatest/scalatest",
-      actual = "@scalatest")
+      actual = "@io_bazel_rules_scala_scalatest")
 
 def _sanitize_string_for_usage(s):
   res_array = []

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -14,6 +14,10 @@ load(
     "@io_bazel_rules_scala//specs2:specs2_junit.bzl",
     _specs2_junit_dependencies = "specs2_junit_dependencies")
 
+load(
+    "@io_bazel_rules_scala//scala:scala_import.bzl",
+    _scala_import = "scala_import")
+
 _launcher_template = {
     "_java_stub_template": attr.label(
         default = Label("@java_stub_template//file")),
@@ -249,47 +253,67 @@ scala_repl = rule(
     toolchains = ['@io_bazel_rules_scala//scala:toolchain_type'],
 )
 
+def _scala_libraries_impl(repository_ctx):
+  repository_ctx.template(
+    "BUILD",
+    Label("@io_bazel_rules_scala//scala:BUILD.scala.bazel"),
+    executable = False,
+  )
+
+_scala_libraries = repository_rule(
+  implementation = _scala_libraries_impl
+)
+    
+
 def scala_repositories():
-  native.http_jar(
-      name = "scala_library",
+  native.http_file(
+      name = "scala_library_jar",
       url =
       "http://central.maven.org/maven2/org/scala-lang/scala-library/2.11.12/scala-library-2.11.12.jar",
       sha256 =
       "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
   )
-  native.http_jar(
-      name = "scala_compiler",
-      url = "http://central.maven.org/maven2/org/scala-lang/scala-compiler/2.11.12/scala-compiler-2.11.12.jar",
+
+  native.http_file(
+      name = "scala_compiler_jar",
+      url =
+      "http://central.maven.org/maven2/org/scala-lang/scala-compiler/2.11.12/scala-compiler-2.11.12.jar",
       sha256 =
       "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
   )
-  native.http_jar(
-      name = "scala_reflect",
+
+  native.http_file(
+      name = "scala_reflect_jar",
       url =
       "http://central.maven.org/maven2/org/scala-lang/scala-reflect/2.11.12/scala-reflect-2.11.12.jar",
       sha256 =
       "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
   )
+
   # scalatest has macros, note http_jar is invoking ijar
-  native.http_jar(
-      name = "scalatest",
+  native.http_file(
+      name = "scalatest_jar",
       url =
       "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
       sha256 =
       "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
   )
-  native.http_jar(
-      name = "scala_xml",
+
+  native.http_file(
+      name = "scala_xml_jar",
       url =
       "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.11/1.0.5/scala-xml_2.11-1.0.5.jar",
       sha256 = "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f"
   )
-  native.http_jar(
-      name = "scala_parser_combinators",
+
+  native.http_file(
+      name = "scala_parser_combinators_jar",
       url =
       "http://central.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar",
       sha256 = "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6"
   )
+
+  _scala_libraries(name = "scala")
 
   native.maven_server(
       name = "scalac_deps_maven_server",
@@ -339,27 +363,27 @@ def scala_repositories():
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_compiler",
-      actual = "@scala_compiler//jar")
+      actual = "@scala//:scala_compiler")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_library",
-      actual = "@scala_library//jar")
+      actual = "@scala//:scala_library")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_reflect",
-      actual = "@scala_reflect//jar")
+      actual = "@scala//:scala_reflect")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_xml",
-      actual = "@scala_xml//jar")
+      actual = "@scala//:scala_xml")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/parser_combinators",
-      actual = "@scala_parser_combinators//jar")
+      actual = "@scala//:scala_parser_combinators")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scalatest/scalatest",
-      actual = "@scalatest//jar")
+      actual = "@scala//:scalatest")
 
 def _sanitize_string_for_usage(s):
   res_array = []

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -249,37 +249,27 @@ scala_repl = rule(
     toolchains = ['@io_bazel_rules_scala//scala:toolchain_type'],
 )
 
-_SCALA_BUILD_FILE = """
-# scala.BUILD
-java_import(
-    name = "scala-library",
-    jars = ["lib/scala-library.jar"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
-    name = "scala-compiler",
-    jars = ["lib/scala-compiler.jar"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
-    name = "scala-reflect",
-    jars = ["lib/scala-reflect.jar"],
-    visibility = ["//visibility:public"],
-)
-"""
-
 def scala_repositories():
-  native.new_http_archive(
-      name = "scala",
-      strip_prefix = "scala-2.11.12",
+  native.http_jar(
+      name = "scala_library",
+      url =
+      "http://central.maven.org/maven2/org/scala-lang/scala-library/2.11.12/scala-library-2.11.12.jar",
       sha256 =
-      "b11d7d33699ca4f60bc3b2b6858fd953e3de2b8522c943f4cda4b674316196a8",
-      url = "http://downloads.lightbend.com/scala/2.11.12/scala-2.11.12.tgz",
-      build_file_content = _SCALA_BUILD_FILE,
+      "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
   )
-
+  native.http_jar(
+      name = "scala_compiler",
+      url = "http://central.maven.org/maven2/org/scala-lang/scala-compiler/2.11.12/scala-compiler-2.11.12.jar",
+      sha256 =
+      "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
+  )
+  native.http_jar(
+      name = "scala_reflect",
+      url =
+      "http://central.maven.org/maven2/org/scala-lang/scala-reflect/2.11.12/scala-reflect-2.11.12.jar",
+      sha256 =
+      "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
+  )
   # scalatest has macros, note http_jar is invoking ijar
   native.http_jar(
       name = "scalatest",
@@ -349,15 +339,15 @@ def scala_repositories():
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_compiler",
-      actual = "@scala//:scala-compiler")
+      actual = "@scala_compiler//jar")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_library",
-      actual = "@scala//:scala-library")
+      actual = "@scala_library//jar")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_reflect",
-      actual = "@scala//:scala-reflect")
+      actual = "@scala_reflect//jar")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_xml",

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -9,6 +9,9 @@ load(
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+ 
+load("@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
+     _scala_maven_import_external = "scala_maven_import_external")
 
 load(
     "@io_bazel_rules_scala//specs2:specs2_junit.bzl",
@@ -252,68 +255,53 @@ scala_repl = rule(
     fragments = ["java"],
     toolchains = ['@io_bazel_rules_scala//scala:toolchain_type'],
 )
-
-def _scala_libraries_impl(repository_ctx):
-  repository_ctx.template(
-    "BUILD",
-    Label("@io_bazel_rules_scala//scala:BUILD.scala.bazel"),
-    executable = False,
-  )
-
-_scala_libraries = repository_rule(
-  implementation = _scala_libraries_impl
-)
     
 
 def scala_repositories():
-  native.http_file(
-      name = "scala_library_jar",
-      url =
-      "http://central.maven.org/maven2/org/scala-lang/scala-library/2.11.12/scala-library-2.11.12.jar",
-      sha256 =
-      "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
+  _scala_maven_import_external(
+    name = "scala_library",
+    artifact = "org.scala-lang:scala-library:2.11.12",
+    jar_sha256 = "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
+    licenses = ["notice"],
+    server_urls = ["https://central.maven.org/maven2"],
+  )
+  _scala_maven_import_external(
+    name = "scala_compiler",
+    artifact = "org.scala-lang:scala-compiler:2.11.12",
+    jar_sha256 = "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
+    licenses = ["notice"],
+    server_urls = ["https://central.maven.org/maven2"],
+  )
+  _scala_maven_import_external(
+    name = "scala_reflect",
+    artifact = "org.scala-lang:scala-reflect:2.11.12",
+    jar_sha256 = "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
+    licenses = ["notice"],
+    server_urls = ["https://central.maven.org/maven2"],
+  )
+  _scala_maven_import_external(
+    name = "scalatest",
+    artifact = "org.scalatest:scalatest_2.11:2.2.6",
+    jar_sha256 = "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
+    licenses = ["notice"],
+    server_urls = ["https://central.maven.org/maven2"],
   )
 
-  native.http_file(
-      name = "scala_compiler_jar",
-      url =
-      "http://central.maven.org/maven2/org/scala-lang/scala-compiler/2.11.12/scala-compiler-2.11.12.jar",
-      sha256 =
-      "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
+  _scala_maven_import_external(
+    name = "scala_xml",
+    artifact = "org.scala-lang:scala-xml_2.11:1.0.5",
+    jar_sha256 = "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
+    licenses = ["notice"],
+    server_urls = ["https://central.maven.org/maven2"],
   )
 
-  native.http_file(
-      name = "scala_reflect_jar",
-      url =
-      "http://central.maven.org/maven2/org/scala-lang/scala-reflect/2.11.12/scala-reflect-2.11.12.jar",
-      sha256 =
-      "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
+  _scala_maven_import_external(
+    name = "scala_parser_combinators",
+    artifact = "org.scala-lang:scala-parser-combinators.11:1.0.4",
+    jar_sha256 = "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
+    licenses = ["notice"],
+    server_urls = ["https://central.maven.org/maven2"],
   )
-
-  # scalatest has macros, note http_jar is invoking ijar
-  native.http_file(
-      name = "scalatest_jar",
-      url =
-      "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
-      sha256 =
-      "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
-  )
-
-  native.http_file(
-      name = "scala_xml_jar",
-      url =
-      "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.11/1.0.5/scala-xml_2.11-1.0.5.jar",
-      sha256 = "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f"
-  )
-
-  native.http_file(
-      name = "scala_parser_combinators_jar",
-      url =
-      "http://central.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar",
-      sha256 = "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6"
-  )
-
-  _scala_libraries(name = "scala")
 
   native.maven_server(
       name = "scalac_deps_maven_server",
@@ -363,27 +351,27 @@ def scala_repositories():
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_compiler",
-      actual = "@scala//:scala_compiler")
+      actual = "@scala_compiler")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_library",
-      actual = "@scala//:scala_library")
+      actual = "@scala_library")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_reflect",
-      actual = "@scala//:scala_reflect")
+      actual = "@scala_reflect")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_xml",
-      actual = "@scala//:scala_xml")
+      actual = "@scala_xml")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/parser_combinators",
-      actual = "@scala//:scala_parser_combinators")
+      actual = "@scala_parser_combinators")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scalatest/scalatest",
-      actual = "@scala//:scalatest")
+      actual = "@scalatest")
 
 def _sanitize_string_for_usage(s):
   res_array = []

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -252,18 +252,6 @@ scala_repl = rule(
 _SCALA_BUILD_FILE = """
 # scala.BUILD
 java_import(
-    name = "scala-xml",
-    jars = ["lib/scala-xml_2.11-1.0.5.jar"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
-    name = "scala-parser-combinators",
-    jars = ["lib/scala-parser-combinators_2.11-1.0.4.jar"],
-    visibility = ["//visibility:public"],
-)
-
-java_import(
     name = "scala-library",
     jars = ["lib/scala-library.jar"],
     visibility = ["//visibility:public"],
@@ -299,6 +287,18 @@ def scala_repositories():
       "https://mirror.bazel.build/oss.sonatype.org/content/groups/public/org/scalatest/scalatest_2.11/2.2.6/scalatest_2.11-2.2.6.jar",
       sha256 =
       "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
+  )
+  native.http_jar(
+      name = "scala_xml",
+      url =
+      "http://central.maven.org/maven2/org/scala-lang/modules/scala-xml_2.11/1.0.5/scala-xml_2.11-1.0.5.jar",
+      sha256 = "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f"
+  )
+  native.http_jar(
+      name = "scala_parser_combinators",
+      url =
+      "http://central.maven.org/maven2/org/scala-lang/modules/scala-parser-combinators_2.11/1.0.4/scala-parser-combinators_2.11-1.0.4.jar",
+      sha256 = "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6"
   )
 
   native.maven_server(
@@ -348,10 +348,6 @@ def scala_repositories():
       actual = "@scalac_rules_commons_io//jar")
 
   native.bind(
-      name = "io_bazel_rules_scala/dependency/scala/parser_combinators",
-      actual = "@scala//:scala-parser-combinators")
-
-  native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_compiler",
       actual = "@scala//:scala-compiler")
 
@@ -365,7 +361,11 @@ def scala_repositories():
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scala/scala_xml",
-      actual = "@scala//:scala-xml")
+      actual = "@scala_xml//jar")
+
+  native.bind(
+      name = "io_bazel_rules_scala/dependency/scala/parser_combinators",
+      actual = "@scala_parser_combinators//jar")
 
   native.bind(
       name = "io_bazel_rules_scala/dependency/scalatest/scalatest",

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -257,14 +257,14 @@ scala_repl = rule(
     toolchains = ['@io_bazel_rules_scala//scala:toolchain_type'],
 )
 
-def scala_repositories():
+def scala_repositories(maven_servers = ["http://central.maven.org/maven2"]):
   _scala_maven_import_external(
       name = "scala_library",
       artifact = "org.scala-lang:scala-library:2.11.12",
       jar_sha256 =
       "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
       licenses = ["notice"],
-      server_urls = ["http://central.maven.org/maven2"],
+      server_urls = maven_servers,
   )
   _scala_maven_import_external(
       name = "scala_compiler",
@@ -272,7 +272,7 @@ def scala_repositories():
       jar_sha256 =
       "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
       licenses = ["notice"],
-      server_urls = ["http://central.maven.org/maven2"],
+      server_urls = maven_servers,
   )
   _scala_maven_import_external(
       name = "scala_reflect",
@@ -280,7 +280,7 @@ def scala_repositories():
       jar_sha256 =
       "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
       licenses = ["notice"],
-      server_urls = ["http://central.maven.org/maven2"],
+      server_urls = maven_servers,
   )
   _scala_maven_import_external(
       name = "scalatest",
@@ -288,7 +288,7 @@ def scala_repositories():
       jar_sha256 =
       "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
       licenses = ["notice"],
-      server_urls = ["http://central.maven.org/maven2"],
+      server_urls = maven_servers,
   )
 
   _scala_maven_import_external(
@@ -297,7 +297,7 @@ def scala_repositories():
       jar_sha256 =
       "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
       licenses = ["notice"],
-      server_urls = ["http://central.maven.org/maven2"],
+      server_urls = maven_servers,
   )
 
   _scala_maven_import_external(
@@ -306,7 +306,7 @@ def scala_repositories():
       jar_sha256 =
       "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
       licenses = ["notice"],
-      server_urls = ["http://central.maven.org/maven2"],
+      server_urls = maven_servers,
   )
 
   native.maven_server(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -264,7 +264,7 @@ def scala_repositories():
       jar_sha256 =
       "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
       licenses = ["notice"],
-      server_urls = ["https://central.maven.org/maven2"],
+      server_urls = ["http://central.maven.org/maven2"],
   )
   _scala_maven_import_external(
       name = "scala_compiler",
@@ -272,7 +272,7 @@ def scala_repositories():
       jar_sha256 =
       "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
       licenses = ["notice"],
-      server_urls = ["https://central.maven.org/maven2"],
+      server_urls = ["http://central.maven.org/maven2"],
   )
   _scala_maven_import_external(
       name = "scala_reflect",
@@ -280,7 +280,7 @@ def scala_repositories():
       jar_sha256 =
       "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
       licenses = ["notice"],
-      server_urls = ["https://central.maven.org/maven2"],
+      server_urls = ["http://central.maven.org/maven2"],
   )
   _scala_maven_import_external(
       name = "scalatest",
@@ -288,7 +288,7 @@ def scala_repositories():
       jar_sha256 =
       "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
       licenses = ["notice"],
-      server_urls = ["https://central.maven.org/maven2"],
+      server_urls = ["http://central.maven.org/maven2"],
   )
 
   _scala_maven_import_external(
@@ -297,7 +297,7 @@ def scala_repositories():
       jar_sha256 =
       "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
       licenses = ["notice"],
-      server_urls = ["https://central.maven.org/maven2"],
+      server_urls = ["http://central.maven.org/maven2"],
   )
 
   _scala_maven_import_external(
@@ -306,7 +306,7 @@ def scala_repositories():
       jar_sha256 =
       "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
       licenses = ["notice"],
-      server_urls = ["https://central.maven.org/maven2"],
+      server_urls = ["http://central.maven.org/maven2"],
   )
 
   native.maven_server(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -9,9 +9,10 @@ load(
 )
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
- 
-load("@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
-     _scala_maven_import_external = "scala_maven_import_external")
+
+load(
+    "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
+    _scala_maven_import_external = "scala_maven_import_external")
 
 load(
     "@io_bazel_rules_scala//specs2:specs2_junit.bzl",
@@ -255,52 +256,57 @@ scala_repl = rule(
     fragments = ["java"],
     toolchains = ['@io_bazel_rules_scala//scala:toolchain_type'],
 )
-    
 
 def scala_repositories():
   _scala_maven_import_external(
-    name = "scala_library",
-    artifact = "org.scala-lang:scala-library:2.11.12",
-    jar_sha256 = "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
-    licenses = ["notice"],
-    server_urls = ["https://central.maven.org/maven2"],
+      name = "scala_library",
+      artifact = "org.scala-lang:scala-library:2.11.12",
+      jar_sha256 =
+      "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
+      licenses = ["notice"],
+      server_urls = ["https://central.maven.org/maven2"],
   )
   _scala_maven_import_external(
-    name = "scala_compiler",
-    artifact = "org.scala-lang:scala-compiler:2.11.12",
-    jar_sha256 = "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
-    licenses = ["notice"],
-    server_urls = ["https://central.maven.org/maven2"],
+      name = "scala_compiler",
+      artifact = "org.scala-lang:scala-compiler:2.11.12",
+      jar_sha256 =
+      "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
+      licenses = ["notice"],
+      server_urls = ["https://central.maven.org/maven2"],
   )
   _scala_maven_import_external(
-    name = "scala_reflect",
-    artifact = "org.scala-lang:scala-reflect:2.11.12",
-    jar_sha256 = "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
-    licenses = ["notice"],
-    server_urls = ["https://central.maven.org/maven2"],
+      name = "scala_reflect",
+      artifact = "org.scala-lang:scala-reflect:2.11.12",
+      jar_sha256 =
+      "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
+      licenses = ["notice"],
+      server_urls = ["https://central.maven.org/maven2"],
   )
   _scala_maven_import_external(
-    name = "scalatest",
-    artifact = "org.scalatest:scalatest_2.11:2.2.6",
-    jar_sha256 = "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
-    licenses = ["notice"],
-    server_urls = ["https://central.maven.org/maven2"],
-  )
-
-  _scala_maven_import_external(
-    name = "scala_xml",
-    artifact = "org.scala-lang:scala-xml_2.11:1.0.5",
-    jar_sha256 = "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
-    licenses = ["notice"],
-    server_urls = ["https://central.maven.org/maven2"],
+      name = "scalatest",
+      artifact = "org.scalatest:scalatest_2.11:2.2.6",
+      jar_sha256 =
+      "f198967436a5e7a69cfd182902adcfbcb9f2e41b349e1a5c8881a2407f615962",
+      licenses = ["notice"],
+      server_urls = ["https://central.maven.org/maven2"],
   )
 
   _scala_maven_import_external(
-    name = "scala_parser_combinators",
-    artifact = "org.scala-lang:scala-parser-combinators.11:1.0.4",
-    jar_sha256 = "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
-    licenses = ["notice"],
-    server_urls = ["https://central.maven.org/maven2"],
+      name = "scala_xml",
+      artifact = "org.scala-lang:scala-xml_2.11:1.0.5",
+      jar_sha256 =
+      "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
+      licenses = ["notice"],
+      server_urls = ["https://central.maven.org/maven2"],
+  )
+
+  _scala_maven_import_external(
+      name = "scala_parser_combinators",
+      artifact = "org.scala-lang:scala-parser-combinators.11:1.0.4",
+      jar_sha256 =
+      "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
+      licenses = ["notice"],
+      server_urls = ["https://central.maven.org/maven2"],
   )
 
   native.maven_server(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -293,7 +293,7 @@ def scala_repositories():
 
   _scala_maven_import_external(
       name = "scala_xml",
-      artifact = "org.scala-lang:scala-xml_2.11:1.0.5",
+      artifact = "org.scala-lang.modules:scala-xml_2.11:1.0.5",
       jar_sha256 =
       "767e11f33eddcd506980f0ff213f9d553a6a21802e3be1330345f62f7ee3d50f",
       licenses = ["notice"],
@@ -302,7 +302,7 @@ def scala_repositories():
 
   _scala_maven_import_external(
       name = "scala_parser_combinators",
-      artifact = "org.scala-lang:scala-parser-combinators.11:1.0.4",
+      artifact = "org.scala-lang.modules:scala-parser-combinators_2.11:1.0.4",
       jar_sha256 =
       "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
       licenses = ["notice"],

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -22,7 +22,10 @@ def _scala_import_impl(ctx):
                     ),
       jars_to_labels = jars2labels,
       providers = [
-          _create_provider(current_jars, transitive_runtime_jars, jars, exports)
+          _create_provider(current_jars, transitive_runtime_jars, jars,
+                           exports),
+          DefaultInfo(files = current_jars,
+                     ),
       ],
   )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -26,7 +26,7 @@ java_binary(
     main_class = "scalarules.test.JavaBinary",
     runtime_deps = [
         ":OtherJavaLib",
-        "@scala_library//jar",
+        "@scala//:scala_library",
     ],
     deps = [
         ":Exported",

--- a/test/BUILD
+++ b/test/BUILD
@@ -26,7 +26,7 @@ java_binary(
     main_class = "scalarules.test.JavaBinary",
     runtime_deps = [
         ":OtherJavaLib",
-        "@scala//:scala-library",
+        "@scala_library//jar",
     ],
     deps = [
         ":Exported",

--- a/test/BUILD
+++ b/test/BUILD
@@ -26,7 +26,7 @@ java_binary(
     main_class = "scalarules.test.JavaBinary",
     runtime_deps = [
         ":OtherJavaLib",
-        "@scala_library//jar",
+        "@io_bazel_rules_scala_scala_library//jar",
     ],
     deps = [
         ":Exported",

--- a/test/BUILD
+++ b/test/BUILD
@@ -26,7 +26,7 @@ java_binary(
     main_class = "scalarules.test.JavaBinary",
     runtime_deps = [
         ":OtherJavaLib",
-        "@scala//:scala_library",
+        "@scala_library//jar",
     ],
     deps = [
         ":Exported",

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -23,30 +23,30 @@ def _rule_impl(ctx):
   expected_deps = {
       "scala_library": [
           "//test/aspect:scala_library",
-          "@scala_library//jar:jar",
+          "@scala//:scala_library",
       ],
       "scala_test": [
           "//test/aspect:scala_test",
-          "@scala_library//jar:jar",
-          "@scalatest//jar:jar",
+          "@scala//:scala_library",
+          "@scala//:scalatest",
       ],
       "scala_junit_test": [
           "//test/aspect:scala_junit_test",
-          "@scala_library//jar:jar",
+          "@scala//:scala_library",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
       ],
       "scala_specs2_junit_test": [
           "//test/aspect:scala_specs2_junit_test",
-          "@scala_library//jar:jar",
+          "@scala//:scala_library",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
           # From specs2/specs2.bzl:specs2_dependencies()
           "@io_bazel_rules_scala//specs2:specs2",
-          "@scala_xml//jar:jar",
-          "@scala_parser_combinators//jar:jar",
-          "@scala_library//jar:jar",
-          "@scala_reflect//jar:jar",
+          "@scala//:scala_xml",
+          "@scala//:scala_parser_combinators",
+          "@scala//:scala_library",
+          "@scala//:scala_reflect",
           # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
           "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
       ],

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -23,30 +23,30 @@ def _rule_impl(ctx):
   expected_deps = {
       "scala_library": [
           "//test/aspect:scala_library",
-          "@scala_library//:scala_library",
+          "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library",
       ],
       "scala_test": [
           "//test/aspect:scala_test",
-          "@scala_library//:scala_library",
-          "@scalatest//:scalatest",
+          "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library",
+          "@io_bazel_rules_scala_scalatest//:io_bazel_rules_scala_scalatest",
       ],
       "scala_junit_test": [
           "//test/aspect:scala_junit_test",
-          "@scala_library//:scala_library",
+          "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
       ],
       "scala_specs2_junit_test": [
           "//test/aspect:scala_specs2_junit_test",
-          "@scala_library//:scala_library",
+          "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
           # From specs2/specs2.bzl:specs2_dependencies()
           "@io_bazel_rules_scala//specs2:specs2",
-          "@scala_xml//:scala_xml",
-          "@scala_parser_combinators//:scala_parser_combinators",
-          "@scala_library//:scala_library",
-          "@scala_reflect//:scala_reflect",
+          "@io_bazel_rules_scala_scala_xml//:io_bazel_rules_scala_scala_xml",
+          "@io_bazel_rules_scala_scala_parser_combinators//:io_bazel_rules_scala_scala_parser_combinators",
+          "@io_bazel_rules_scala_scala_library//:io_bazel_rules_scala_scala_library",
+          "@io_bazel_rules_scala_scala_reflect//:io_bazel_rules_scala_scala_reflect",
           # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
           "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
       ],

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -43,8 +43,8 @@ def _rule_impl(ctx):
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
           # From specs2/specs2.bzl:specs2_dependencies()
           "@io_bazel_rules_scala//specs2:specs2",
-          "@scala//:scala-xml",
-          "@scala//:scala-parser-combinators",
+          "@scala_xml//jar:jar",
+          "@scala_parser_combinators//jar:jar",
           "@scala//:scala-library",
           "@scala//:scala-reflect",
           # From specs2/specs2_junit.bzl:specs2_junit_dependencies()

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -23,30 +23,30 @@ def _rule_impl(ctx):
   expected_deps = {
       "scala_library": [
           "//test/aspect:scala_library",
-          "@scala//:scala-library",
+          "@scala_library//jar:jar",
       ],
       "scala_test": [
           "//test/aspect:scala_test",
-          "@scala//:scala-library",
+          "@scala_library//jar:jar",
           "@scalatest//jar:jar",
       ],
       "scala_junit_test": [
           "//test/aspect:scala_junit_test",
-          "@scala//:scala-library",
+          "@scala_library//jar:jar",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
       ],
       "scala_specs2_junit_test": [
           "//test/aspect:scala_specs2_junit_test",
-          "@scala//:scala-library",
+          "@scala_library//jar:jar",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
           # From specs2/specs2.bzl:specs2_dependencies()
           "@io_bazel_rules_scala//specs2:specs2",
           "@scala_xml//jar:jar",
           "@scala_parser_combinators//jar:jar",
-          "@scala//:scala-library",
-          "@scala//:scala-reflect",
+          "@scala_library//jar:jar",
+          "@scala_reflect//jar:jar",
           # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
           "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
       ],

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -23,30 +23,30 @@ def _rule_impl(ctx):
   expected_deps = {
       "scala_library": [
           "//test/aspect:scala_library",
-          "@scala//:scala_library",
+          "@scala_library//:scala_library",
       ],
       "scala_test": [
           "//test/aspect:scala_test",
-          "@scala//:scala_library",
-          "@scala//:scalatest",
+          "@scala_library//:scala_library",
+          "@scalatest//:scalatest",
       ],
       "scala_junit_test": [
           "//test/aspect:scala_junit_test",
-          "@scala//:scala_library",
+          "@scala_library//:scala_library",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
       ],
       "scala_specs2_junit_test": [
           "//test/aspect:scala_specs2_junit_test",
-          "@scala//:scala_library",
+          "@scala_library//:scala_library",
           "@io_bazel_rules_scala_junit_junit//jar:jar",
           "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar:jar",
           # From specs2/specs2.bzl:specs2_dependencies()
           "@io_bazel_rules_scala//specs2:specs2",
-          "@scala//:scala_xml",
-          "@scala//:scala_parser_combinators",
-          "@scala//:scala_library",
-          "@scala//:scala_reflect",
+          "@scala_xml//:scala_xml",
+          "@scala_parser_combinators//:scala_parser_combinators",
+          "@scala_library//:scala_library",
+          "@scala_reflect//:scala_reflect",
           # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
           "@io_bazel_rules_scala_org_specs2_specs2_junit_2_11//jar:jar",
       ],


### PR DESCRIPTION
As part of a larger PR (https://github.com/bazelbuild/rules_scala/pull/544) for adding support for selecting scala versions I separated `scala-xml` and `scala-parser-combinators` to be imported individually using `native.http_jar`. @johnynek suggested making o separate PR for this smaller change so here it is.

The motivation behind the change is that the versions of `scala-xml` and `scala-parser-combinators` that are downloaded as part of the main `{scala_version}.tgz` differ between minor scala versions and this way we can select specific versions (https://github.com/bazelbuild/rules_scala/pull/544 would allow users to select any 2.11/2.12 minor version)