### PR TITLE
Add DefaultInfo provider to outputs of scala_import

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -22,7 +22,10 @@ def _scala_import_impl(ctx):
                     ),
       jars_to_labels = jars2labels,
       providers = [
-          _create_provider(current_jars, transitive_runtime_jars, jars, exports)
+          _create_provider(current_jars, transitive_runtime_jars, jars,
+                           exports),
+          DefaultInfo(files = current_jars,
+                     ),
       ],
   )
 


### PR DESCRIPTION
https://github.com/bazelbuild/rules_scala/pull/549 is blocked as using a `$(location)` expression with a target created using `scala_import` fails. As @ittaiz suspected this was due to `scala_import` not returning a `DefaultInfo` provider.

Tested with https://github.com/bazelbuild/rules_scala/pull/549 confirming that it fixes the problem.

