### PR TITLE
Fix and run barethriftslib test

### DIFF
--- a/test/src/main/scala/scalarules/test/twitter_scrooge/BUILD
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/BUILD
@@ -205,7 +205,7 @@ scala_library(
 scala_binary(
     name = "barethrifts",
     main_class = "scalarules.test.twitter_scrooge.BareThrifts",
-    deps = [":bare_thrift_scrooge"],
+    deps = [":barethriftslib"],
 )
 
 sh_test(

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -807,6 +807,7 @@ $runner bazel build "test/... --strict_java_deps=ERROR"
 #$runner bazel build "test/... --strict_java_deps=ERROR --all_incompatible_changes"
 $runner bazel test "test/... --strict_java_deps=ERROR"
 $runner bazel run test/src/main/scala/scalarules/test/twitter_scrooge:justscrooges
+$runner bazel run test/src/main/scala/scalarules/test/twitter_scrooge:barethrifts
 $runner bazel run test:JavaBinary
 $runner bazel run test:JavaBinary2
 $runner bazel run test:JavaOnlySources

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -808,6 +808,8 @@ $runner bazel build "test/... --strict_java_deps=ERROR"
 $runner bazel test "test/... --strict_java_deps=ERROR"
 $runner bazel run test/src/main/scala/scalarules/test/twitter_scrooge:justscrooges
 $runner bazel run test/src/main/scala/scalarules/test/twitter_scrooge:barethrifts
+$runner bazel run test/src/main/scala/scalarules/test/twitter_scrooge:twodeep_binary
+$runner bazel run test/src/main/scala/scalarules/test/twitter_scrooge:justscrooge2b_binary
 $runner bazel run test:JavaBinary
 $runner bazel run test:JavaBinary2
 $runner bazel run test:JavaOnlySources


### PR DESCRIPTION
Noticed that the test `barethriftslib` is not working and never run. Currently it fails with: `Error: Could not find or load main class scalarules.test.twitter_scrooge.BareThrifts`

And it's not run anywhere:
```sh
$ bazel query "rdeps(//test/..., //test/src/main/scala/scalarules/test/twitter_scrooge:barethrifts)"
//test/src/main/scala/scalarules/test/twitter_scrooge:barethrifts

$ git grep barethrifts
test/src/main/scala/scalarules/test/twitter_scrooge/BUILD:    name = "barethriftslib",
test/src/main/scala/scalarules/test/twitter_scrooge/BUILD:    name = "barethrifts",
```

This fixes the test and runs it from `test_rules_scala.sh`

Also added 2 other scrooge tests that were never run (as far as I could tell) to `test_rules_scala.sh`