### PR TITLE
repro of bug with java_common.compile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -121,3 +121,11 @@ java_import_external(
 load("//private:format.bzl", "format_repositories")
 
 format_repositories()
+load("@io_bazel_rules_scala//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
+scala_maven_import_external(
+          name = "org_scala_lang_scala_library",
+          artifact = "org.scala-lang:scala-library:2.11.12",
+          licenses = ["notice"],  # Apache 2.0
+          jar_sha256 = "17824fcee4d3f46cfaa4da84ebad4f58496426c2b9bc9e341f812ab23a667d5d",
+          server_urls = ["https://repo.maven.apache.org/maven2/"],
+      )

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -263,6 +263,9 @@ def try_to_compile_java_jar(ctx, scala_output, all_srcjars, java_srcs,
   providers_of_dependencies = collect_java_providers_of(ctx.attr.deps)
   providers_of_dependencies += collect_java_providers_of(
       implicit_junit_deps_needed_for_java_compilation)
+# if we add scalalib on the compile classpath of java compilation the issue goes away
+#  providers_of_dependencies += collect_java_providers_of(
+#      [ctx.attr._scalalib, ctx.attr._scalareflect])
   scala_sources_java_provider = _interim_java_provider_for_java_compilation(
       scala_output)
   providers_of_dependencies += [scala_sources_java_provider]

--- a/test/BUILD
+++ b/test/BUILD
@@ -531,6 +531,24 @@ scalapb_proto_library(
     ],
 )
 
+#import is needed since then it's part of the transitive compile dependencies
+scala_library(
+    name = "import",
+    deps = ["@org_scala_lang_scala_library//jar"]
+)
+scala_library(
+    name = "foo",
+    srcs = ["ScalaCase.scala", "JavaClass.java"],
+    deps = [":import"]
+)
+
+#not sure why but when building foo this doesn't happen, only when building foo_dep
+scala_library(
+    name = "foo_dep",
+    srcs = ["Dep.java"],
+    deps = [":foo"]
+)
+
 load(":check_statsfile.bzl", "check_statsfile")
 
 check_statsfile("ScalaBinary")

--- a/test/Dep.java
+++ b/test/Dep.java
@@ -1,0 +1,3 @@
+public class Dep {
+	
+}

--- a/test/JavaClass.java
+++ b/test/JavaClass.java
@@ -1,0 +1,13 @@
+package scalarules.test;
+
+//import scala.Option; //having an import isn't sufficient
+import scalarules.test.ScalaCase; //must, if we just have a usage (commented out below) doesn't reproduce
+
+public class JavaClass {
+
+  public static void foo(scala.Option scalaType) {
+    //scala.Option.empty(); //this usage of scala type doesn't show the issue, only in method signature
+    //new ScalaCase();  //this usage of ScalaCase doesn't show the issue
+  }
+
+}

--- a/test/ScalaCase.scala
+++ b/test/ScalaCase.scala
@@ -1,0 +1,3 @@
+package scalarules.test
+
+class ScalaCase()


### PR DESCRIPTION
repro of bug with java_common.compile and buildozer commands adding a self edge
@iirina @cushon I'd really appreciate your help with this issue.
I wanted to create an isolated repro but didn't manage to.
Essentially there are scenarios where java_common.compile emits buildozer commands with self edge.
To see:
`bazel build --strict_java_deps=warn //test:foo_dep`
you'll get:
```
INFO: From Compiling Java headers test/foo_java-hjar.jar (1 files):
test/JavaClass.java:8: error: package scala does not exist
test/JavaClass.java:4: warning: [strict] Using type scalarules.test.ScalaCase from an indirect dependency (TOOL_INFO: "//test:foo"). See command below **
test/JavaClass.java:4: warning: [strict] Using type scalarules.test.ScalaCase from an indirect dependency (TOOL_INFO: "//test:foo"). See command below **
 ** Please add the following dependencies:
r 196a2c3 WIP
repro of bug with java_common.compile and buildozer commands adding a self edg
  //test:foo to //test:foo
 ** You can use the following buildozer command:
buildozer 'add deps //test:foo' //test:foo

 ** Please add the following dependencies:
  //test:foo to //test:foo
 ** You can use the following buildozer command:
repro of bug with java_common.compile and buildozer commands adding a self edgbuildozer 'add deps //test:foo' //test:foo
```
where `buildozer 'add deps //test:foo' //test:foo` is the important part
For now I'm adding scala std lib as direct dependency of java targets but I don't think that's the root cause