### PR TITLE
Make jarcreator compile with older java versions

### DIFF
--- a/src/java/io/bazel/rulesscala/jar/JarCreator.java
+++ b/src/java/io/bazel/rulesscala/jar/JarCreator.java
@@ -110,7 +110,7 @@ public class JarCreator extends JarHelper {
    *
    * @param directory the directory to add to the jar
    */
-  public void addDirectory(Path directory) {
+  public void addDirectory(final Path directory) {
     if (!Files.exists(directory)) {
       throw new IllegalArgumentException("directory does not exist: " + directory);
     }


### PR DESCRIPTION
I was updating a repo that was using an older 2.12 branch to the newest rules_scala and our CI failed with:
```
...
io_bazel_rules_scala/src/java/io/bazel/rulesscala/jar/JarCreator.java:125: error: local variable directory is accessed from within inner class; needs to be declared final
              if (!path.equals(directory)) {
                               ^
``` 

`JarCreator.java` compiles only with java 1.8 (and effectively final), this PR makes it work for older versions as well.

The alternative is to add
```
    javacopts = [
        "-source 1.8",
        "-target 1.8",
    ],
```
to the targets in `src/java/io/bazel/rulesscala/jar/BUILD`

