### PR TITLE
Remove cfg = "data" no-op

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -108,7 +108,7 @@ _common_attrs_for_plugin_bootstrapping = {
     "deps": attr.label_list(),
     "plugins": attr.label_list(allow_files = [".jar"]),
     "runtime_deps": attr.label_list(providers = [[JavaInfo]]),
-    "data": attr.label_list(allow_files = True, cfg = "data"),
+    "data": attr.label_list(allow_files = True),
     "resources": attr.label_list(allow_files = True),
     "resource_strip_prefix": attr.string(),
     "resource_jars": attr.label_list(allow_files = True),


### PR DESCRIPTION
This removes the need to use --incompatible_disallow_data_transition