### PR TITLE
remove unused-deps attr from scala_macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,21 +91,15 @@ for an example workspace using another scala version.
 [scala]: http://www.scala-lang.org/
 
 <a name="scala_library"></a>
-## scala\_library / scala\_macro_library
+## scala\_library
 
 ```python
 scala_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags, scalac_jvm_flags, javac_jvm_flags, unused_dependency_checker_mode)
-scala_macro_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags, scalac_jvm_flags, javac_jvm_flags, unused_dependency_checker_mode)
 ```
 
 `scala_library` generates a `.jar` file from `.scala` source files. This rule
 also creates an interface jar to avoid recompiling downstream targets unless
 their interface changes.
-
-`scala_macro_library` generates a `.jar` file from `.scala` source files when
-they contain macros. For macros, there are no interface jars because the macro
-code is executed at compile time. For best performance, you want very granular
-targets until such time as the zinc incremental compiler can be supported.
 
 In order to make a java rule use this jar file, use the `java_import` rule.
 
@@ -253,6 +247,160 @@ In order to make a java rule use this jar file, use the `java_import` rule.
         <p>
           Enable unused dependency checking (see <a href="https://github.com/bazelbuild/rules_scala#experimental-unused-dependency-checking">Unused dependency checking</a>).
           Possible values are: <code>off</code>, <code>warn</code> and <code>error</code>.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>
+
+<a name="scala_macro_library"></a>
+## scala\_macro_library
+
+```python
+scala_macro_library(name, srcs, deps, runtime_deps, exports, data, main_class, resources, resource_strip_prefix, scalacopts, jvm_flags, scalac_jvm_flags, javac_jvm_flags)
+```
+
+`scala_macro_library` generates a `.jar` file from `.scala` source files when
+they contain macros. For macros, there are no interface jars because the macro
+code is executed at compile time. For best performance, you want very granular
+targets until such time as the zinc incremental compiler can be supported.
+
+In order to make a java rule use this jar file, use the `java_import` rule.
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>name</code></td>
+      <td>
+        <p><code>Name, required</code></p>
+        <p>A unique name for this target</p>
+      </td>
+    </tr>
+      <td><code>srcs</code></td>
+      <td>
+        <p><code>List of labels, required</code></p>
+        <p>List of Scala <code>.scala</code> source files used to build the
+        library. These may be .srcjar jar files that contain source code.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>deps</code></td>
+      <td>
+        <p><code>List of labels, optional</code></p>
+        <p>List of other libraries to linked to this library target.
+        These must be jvm targets (scala_library, java_library, java_import, etc...)</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>runtime_deps</code></td>
+      <td>
+        <p><code>List of labels, optional</code></p>
+        <p>List of other libraries to put on the classpath only at runtime. This is rarely needed in Scala.
+        These must be jvm targets (scala_library, java_library, java_import, etc...)</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>exports</code></td>
+      <td>
+        <p><code>List of labels, optional</code></p>
+        <p>List of targets to add to the dependencies of those that depend on this target. Similar
+        to the `java_library` parameter of the same name. Use this sparingly as it weakens the
+        precision of the build graph.
+        These must be jvm targets (scala_library, java_library, java_import, etc...)</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>data</code></td>
+      <td>
+        <p><code>List of labels, optional</code></p>
+        <p>List of files needed by this rule at runtime.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>main_class</code></td>
+      <td>
+        <p><code>String, optional</code></p>
+        <p>Name of class with main() method to use as an entry point</p>
+        <p>
+          The value of this attribute is a class name, not a source file. The
+          class must be available at runtime: it may be compiled by this rule
+          (from <code>srcs</code>) or provided by direct or transitive
+          dependencies (through <code>deps</code>). If the class is unavailable,
+          the binary will fail at runtime; there is no build-time check.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resources</code></td>
+      <td>
+        <p><code>List of labels; optional</code></p>
+        <p>A list of data files to be included in the JAR.</p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>resource_strip_prefix</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>
+          The path prefix to strip from Java resources. If specified,
+          this path prefix is stripped from every file in the `resources` attribute.
+          It is an error for a resource file not to be under this directory.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>scalacopts</code></td>
+      <td>
+        <p><code>List of strings; optional</code></p>
+        <p>
+          Extra compiler options for this library to be passed to scalac. Subject to
+          <a href="http://bazel.io/docs/be/make-variables.html">Make variable
+          substitution</a> and
+          <a href="http://bazel.io/docs/be/common-definitions.html#borne-shell-tokenization">Bourne shell tokenization.</a>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>jvm_flags</code></td>
+      <td>
+        <p><code>List of strings; optional; deprecated</code></p>
+        <p>
+          Deprecated, superseded by scalac_jvm_flags and javac_jvm_flags. Is not used and is kept as backwards compatibility for the near future. Effectively jvm_flags is now an executable target attribute only.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>scalac_jvm_flags</code></td>
+      <td>
+        <p><code>List of strings; optional</code></p>
+        <p>
+          List of JVM flags to be passed to scalac after the
+          <code>scalacopts</code>. Subject to
+          <a href="http://bazel.io/docs/be/make-variables.html">Make variable
+          substitution</a> and
+          <a href="http://bazel.io/docs/be/common-definitions.html#borne-shell-tokenization">Bourne shell tokenization.</a>
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>javac_jvm_flags</code></td>
+      <td>
+        <p><code>List of strings; optional</code></p>
+        <p>
+          List of JVM flags to be passed to javac after the
+          <code>javacopts</code>. Subject to
+          <a href="http://bazel.io/docs/be/make-variables.html">Make variable
+          substitution</a> and
+          <a href="http://bazel.io/docs/be/common-definitions.html#borne-shell-tokenization">Bourne shell tokenization.</a>
         </p>
       </td>
     </tr>

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -671,13 +671,12 @@ def scala_library_for_plugin_bootstrapping_impl(ctx):
 
 def scala_macro_library_impl(ctx):
   scalac_provider = ctx.attr._scala_provider[_ScalacProvider]
-  unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
   return _lib(
       ctx,
       scalac_provider.default_macro_classpath,
       False,  # don't build the ijar for macros
-      unused_dependency_checker_mode,
-      ctx.attr.unused_dependency_checker_ignored_targets)
+      unused_dependency_checker_mode = "off",
+      unused_dependency_checker_ignored_targets = ctx.attr.unused_dependency_checker_ignored_targets)
 
 # Common code shared by all scala binary implementations.
 def _scala_binary_common(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -133,6 +133,10 @@ _common_attrs.update({
         ),
         allow_files = [".jar"],
         mandatory = False),
+})
+
+_unused_deps_checker_attrs = {}
+_unused_deps_checker_attrs.update({
     "unused_dependency_checker_mode": attr.string(
         values = ["warn", "error", "off", ""],
         mandatory = False,
@@ -164,6 +168,7 @@ _library_outputs.update(_common_outputs)
 _scala_library_attrs = {}
 _scala_library_attrs.update(_implicit_deps)
 _scala_library_attrs.update(_common_attrs)
+_scala_library_attrs.update(_unused_deps_checker_attrs)
 _scala_library_attrs.update(_library_attrs)
 _scala_library_attrs.update(_resolve_deps)
 
@@ -215,6 +220,7 @@ _scala_binary_attrs = {
 _scala_binary_attrs.update(_launcher_template)
 _scala_binary_attrs.update(_implicit_deps)
 _scala_binary_attrs.update(_common_attrs)
+_scala_binary_attrs.update(_unused_deps_checker_attrs)
 _scala_binary_attrs.update(_resolve_deps)
 scala_binary = rule(
     implementation = _scala_binary_impl,
@@ -243,6 +249,7 @@ _scala_test_attrs = {
 _scala_test_attrs.update(_launcher_template)
 _scala_test_attrs.update(_implicit_deps)
 _scala_test_attrs.update(_common_attrs)
+_scala_test_attrs.update(_unused_deps_checker_attrs)
 _scala_test_attrs.update(_test_resolve_deps)
 scala_test = rule(
     implementation = _scala_test_impl,
@@ -258,6 +265,7 @@ _scala_repl_attrs = {}
 _scala_repl_attrs.update(_launcher_template)
 _scala_repl_attrs.update(_implicit_deps)
 _scala_repl_attrs.update(_common_attrs)
+_scala_repl_attrs.update(_unused_deps_checker_attrs)
 _scala_repl_attrs.update(_resolve_deps)
 scala_repl = rule(
     implementation = _scala_repl_impl,
@@ -509,6 +517,7 @@ _scala_junit_test_attrs = {
 _scala_junit_test_attrs.update(_launcher_template)
 _scala_junit_test_attrs.update(_implicit_deps)
 _scala_junit_test_attrs.update(_common_attrs)
+_scala_junit_test_attrs.update(_unused_deps_checker_attrs)
 _scala_junit_test_attrs.update(_junit_resolve_deps)
 scala_junit_test = rule(
     implementation = _scala_junit_test_impl,


### PR DESCRIPTION
Set `unused_dependency_checker_mode = "off"` for all `scala_macro` rules.

As discussed internally with @johnynek, any dependency can be used by macro targets at compile time. This PR removes the ability to set `unused_dependency_checker_mode` for scala_macro rules. Also updates the README to match this.

Another option would be to set `unused_dependency_checker_mode` to default to `"off"` for scala_macro_library