### PR TITLE
scala_macro_library unused deps checker default off

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -200,6 +200,13 @@ _scala_macro_library_attrs.update(_implicit_deps)
 _scala_macro_library_attrs.update(_common_attrs)
 _scala_macro_library_attrs.update(_library_attrs)
 _scala_macro_library_attrs.update(_resolve_deps)
+# Set unused_dependency_checker_mode default to off for scala_macro_library
+_scala_macro_library_attrs["unused_dependency_checker_mode"] = attr.string(
+    default = "off",
+    values = ["warn", "error", "off", ""],
+    mandatory = False,
+)
+
 scala_macro_library = rule(
     implementation = _scala_macro_library_impl,
     attrs = _scala_macro_library_attrs,


### PR DESCRIPTION
Set `unused_dependency_checker_mode = "off"` as default for `scala_macro_library`.

As discussed internally with @johnynek, any dependency can be used by macro targets at compile time so we want this as default for most cases.