### PR TITLE
changed explicit references of external workspaces to bind

### DIFF
--- a/scala/BUILD
+++ b/scala/BUILD
@@ -44,17 +44,17 @@ java_import(
 _declare_scalac_provider(
     name = "scala_default",
     default_classpath = [
-        "@io_bazel_rules_scala_scala_library",
-        "@io_bazel_rules_scala_scala_reflect",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
     ],
     default_macro_classpath = [
-        "@io_bazel_rules_scala_scala_library",
-        "@io_bazel_rules_scala_scala_reflect",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
     ],
     default_repl_classpath = [
-        "@io_bazel_rules_scala_scala_library",
-        "@io_bazel_rules_scala_scala_reflect",
-        "@io_bazel_rules_scala_scala_compiler",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
     ],
     scalac = "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac",
     visibility = ["//visibility:public"],

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -13,10 +13,10 @@ java_binary(
         "@io_bazel_rules_scala//src/java/com/google/devtools/build/lib:worker",
         "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/jar",
         "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/worker",
-        "@io_bazel_rules_scala_scala_compiler",
-        "@io_bazel_rules_scala_scala_library",
-        "@io_bazel_rules_scala_scala_reflect",
-        "@scalac_rules_commons_io//jar",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
+        "//external:io_bazel_rules_scala/dependency/commons_io/commons_io",
     ],
 )
 

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -10,13 +10,13 @@ java_binary(
     main_class = "io.bazel.rulesscala.scalac.ScalaCInvoker",
     visibility = ["//visibility:public"],
     deps = [
+        "//external:io_bazel_rules_scala/dependency/commons_io/commons_io",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
         "@io_bazel_rules_scala//src/java/com/google/devtools/build/lib:worker",
         "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/jar",
         "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/worker",
-        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
-        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
-        "//external:io_bazel_rules_scala/dependency/commons_io/commons_io",
     ],
 )
 


### PR DESCRIPTION
@johnynek @jhnj I'm trying to upgrade to the latest rules_scala and am encountering some difficulties.
We are using our own custom versions of dependencies and so don't call `scala_repositories`. 
What  we've been doing up until now is `bind` to the required points by rules_scala.

After applying the below changes the project compiles. 
I'm not certain they should be merged into master since my gut tells me we're trying to phase out the `bind`s in favor of the `declare_scalac_provider` but I'm not sure we're there.
1. Do we want to phase out `bind`s in favor of custom scalac_provider/scala_provider?
2. How can one declare their own scalac_provider? Currently it's a private attribute
3. Sounds like `//src/java/io/bazel/rulesscala/scalac` needs to change one way or another. Use `bind`s or  somehow depend on the `scalac_provider` and take from it the `default_repl_classpath` (need to decide what to do about commons_io).

Would really appreciate your help on this,
Ittai