### PR TITLE
use tools in run_shell

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -100,12 +100,13 @@ touch {statsfile}
   outs = [ctx.outputs.jar, ctx.outputs.statsfile]
 
   inputs = ctx.files.resources + [
-      ctx.outputs.manifest, ctx.executable._zipper, zipper_arg_path
+      ctx.outputs.manifest, zipper_arg_path
   ]
 
   ctx.actions.run_shell(
       inputs = inputs,
       outputs = outs,
+      tools = [ctx.executable._zipper],
       command = cmd,
       progress_message = "scala %s" % ctx.label,
       arguments = [])


### PR DESCRIPTION
closes #596 

The linting seems to be floating on head I guess and no longer works for me.

We really need to nail down all external dependencies onto shas so we don't break CI randomly....

ptal @ittaiz 