### PR TITLE
VSCO adopts rules_scala

### DIFF
--- a/README.md
+++ b/README.md
@@ -750,5 +750,6 @@ Here's a (non-exhaustive) list of companies that use `rules_scala` in production
 * [Meetup](https://meetup.com/)
 * [Spotify](https://www.spotify.com/)
 * [Stripe](https://stripe.com/)
+* [VSCO](https://vsco.co)
 * [Wix](https://www.wix.com/)
 


### PR DESCRIPTION
Thanks for all of the hard work, [VSCO](https://vsco.co) uses rules_scala in production.