### PR TITLE
pending test: import-only deps are not reported as used

### DIFF
--- a/third_party/unused_dependency_checker/src/test/io/bazel/rulesscala/dependencyanalyzer/UnusedDependencyCheckerTest.scala
+++ b/third_party/unused_dependency_checker/src/test/io/bazel/rulesscala/dependencyanalyzer/UnusedDependencyCheckerTest.scala
@@ -59,4 +59,19 @@ class UnusedDependencyCheckerTest extends FunSuite {
     val errorMessages = compileWithUnusedDependencyChecker(testCode, withDirect = direct)
     assert(errorMessages.isEmpty)
   }
+
+  test("do not error on used direct import-only dependency") {
+    val testCode =
+      """object Foo {
+        |  import org.apache.commons.lang3.ArrayUtils
+        |}
+      """.stripMargin
+
+    val commonsTarget = "commonsTarget"
+
+    val direct = List(apacheCommonsClasspath -> commonsTarget)
+
+    val errorMessages = compileWithUnusedDependencyChecker(testCode, withDirect = direct)
+    assert(errorMessages.isEmpty)
+  }
 }


### PR DESCRIPTION
this is a known limitation of the classpath-shrinker approach. the
underlying reason is that imports are lazily resolved upon first access
for a simple identifier (e.g. ArrayUtils in the test case)