### PR TITLE
/bin/bash does not exist on certain systems

### DIFF
--- a/lint.sh
+++ b/lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 # Copyright 2018 The Bazel Authors. All rights reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -493,7 +493,7 @@ def _write_java_wrapper(ctx, args = "", wrapper_preamble = ""):
   wrapper = ctx.actions.declare_file(ctx.label.name + "_wrapper.sh")
   ctx.actions.write(
       output = wrapper,
-      content = """#!/bin/bash
+      content = """#!/usr/bin/env bash
 {preamble}
 
 {exec_str}{javabin} "$@" {args}

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -362,7 +362,7 @@ def scala_repositories(
   )
 
   # Template for binary launcher
-  BAZEL_JAVA_LAUNCHER_VERSION = "0.14.1"
+  BAZEL_JAVA_LAUNCHER_VERSION = "0.17.1"
   java_stub_template_url = (
       "raw.githubusercontent.com/bazelbuild/bazel/" +
       BAZEL_JAVA_LAUNCHER_VERSION +
@@ -375,7 +375,7 @@ def scala_repositories(
           "https://%s" % java_stub_template_url
       ],
       sha256 =
-      "2cbba7c512e400df0e7d4376e667724a38d1155db5baaa81b72ad785c6d761d1",
+      "39097bdc47407232e0fe7eed4f2c175c067b7eda95873cb76ffa76f1b4c18895",
   )
 
   native.bind(

--- a/test/test_binary.sh
+++ b/test/test_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Executing: " $@
 $@

--- a/test_all.sh
+++ b/test_all.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -euo pipefail
 

--- a/test_intellij_aspect.sh
+++ b/test_intellij_aspect.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test the IntelliJ aspect. Override intellij's rules_scala with this one for an
 # integration test. See https://github.com/bazelbuild/rules_scala/issues/308.

--- a/test_lint.sh
+++ b/test_lint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -eou pipefail
 

--- a/test_reproducibility.sh
+++ b/test_reproducibility.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Test runner functions for rules_scala integration tests.
 

--- a/test_version.sh
+++ b/test_version.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/test_version/version_specific_tests_dir/test_binary.sh
+++ b/test_version/version_specific_tests_dir/test_binary.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 echo "Executing: " $@
 $@


### PR DESCRIPTION
closes #595

- Replaces occurrences of `#!/bin/bash` by `#!/usr/bin/env bash`, as `/bin/bash` does not exist on all systems. See issue #595.
- Fetches a more recent version of `java_stub_template.txt` from the bazel repository, in which `#!/bin/bash` was replaced by `#!/usr/bin/env bash`. See https://github.com/bazelbuild/bazel/pull/5979.