### PR TITLE
Change scala_import rule neverlink attribute from int to bool

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -125,12 +125,6 @@ scala_import = rule(
         "deps": attr.label_list(),
         "runtime_deps": attr.label_list(),
         "exports": attr.label_list(),
-        "neverlink": attr.int(
-            default = 0,
-            values = [
-                0,
-                1,
-            ],
-        ),
+        "neverlink": attr.bool(),
     },
 )


### PR DESCRIPTION
Currently `scala_maven_import_external` declares `neverlink` as `bool` while `scala_import` expects `int`