### PR TITLE
Better way to fetch sources

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -71,6 +71,7 @@ scala_maven_import_external(
     artifact = "com.google.guava:guava:21.0",
     jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     fetch_sources = True,
+    srcjar_sha256 = "b186965c9af0a714632fe49b33378c9670f8f074797ab466f49a67e918e116ea",
     server_urls = [
         "https://repo.maven.apache.org/maven2/"
     ],

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,7 @@ workspace(name = "io_bazel_rules_scala")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//scala:scala.bzl", "scala_repositories")
+load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
 
 scala_repositories()
 
@@ -62,6 +63,18 @@ maven_jar(
     name = "com_google_guava_guava_21_0_with_file",
     artifact = "com.google.guava:guava:21.0",
     sha1 = "3a3d111be1be1b745edfa7d91678a12d7ed38709",
+)
+
+# test of import external
+scala_maven_import_external(
+    name = "com_google_guava_guava_21_0_external",
+    artifact = "com.google.guava:guava:21.0",
+    jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    fetch_sources = True,
+    server_urls = [
+        "https://repo.maven.apache.org/maven2/"
+    ],
+    licenses = ["notice"]
 )
 
 maven_jar(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,9 +2,10 @@ workspace(name = "io_bazel_rules_scala")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//scala:scala.bzl", "scala_repositories")
-load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
 
 scala_repositories()
+
+load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
 
 load("//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge", "scrooge_scala_library")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -6,7 +6,6 @@ load("//scala:scala.bzl", "scala_repositories")
 scala_repositories()
 
 load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
-
 load("//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge", "scrooge_scala_library")
 
 twitter_scrooge()
@@ -70,13 +69,13 @@ maven_jar(
 scala_maven_import_external(
     name = "com_google_guava_guava_21_0_external",
     artifact = "com.google.guava:guava:21.0",
-    jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     fetch_sources = True,
-    srcjar_sha256 = "b186965c9af0a714632fe49b33378c9670f8f074797ab466f49a67e918e116ea",
+    jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    licenses = ["notice"],
     server_urls = [
-        "https://repo.maven.apache.org/maven2/"
+        "https://repo.maven.apache.org/maven2/",
     ],
-    licenses = ["notice"]
+    srcjar_sha256 = "b186965c9af0a714632fe49b33378c9670f8f074797ab466f49a67e918e116ea",
 )
 
 maven_jar(

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -24,7 +24,7 @@ def _scala_import_impl(ctx):
                     ),
       providers = [
           _create_provider(current_jars, transitive_runtime_jars, jars, exports,
-                           ctx.attr.neverlink, intellij_metadata),
+                           ctx.attr.neverlink, ctx.file.srcjar, intellij_metadata),
           DefaultInfo(files = current_jars,
                      ),
           JarsToLabelsInfo(jars_to_labels = jars2labels),
@@ -32,7 +32,7 @@ def _scala_import_impl(ctx):
   )
 
 def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
-                     exports, neverlink, intellij_metadata):
+                     exports, neverlink, source_jar, intellij_metadata):
 
   transitive_runtime_jars = [
       transitive_runtime_jars, jars.transitive_runtime_jars,
@@ -44,10 +44,10 @@ def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
 
   source_jars = []
 
-  for metadata in intellij_metadata:
-    if metadata.source_jar:
-      source_jars.append(metadata.source_jar)
-    elif metadata.source_jars:
+  if source_jar:
+    source_jars.append(source_jar)
+  else:
+    for metadata in intellij_metadata:
       source_jars.extend(metadata.source_jars)
 
   return java_common.create_provider(

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -4,7 +4,7 @@ load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 #if you change make sure to manually re-import an intellij project and see imports
 #are resolved (not red) and clickable
 def _scala_import_impl(ctx):
-  target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars, ctx.attr.srcjar)
+  target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars, ctx.file.srcjar)
   (current_target_compile_jars,
    intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
   current_jars = depset(current_target_compile_jars)
@@ -46,7 +46,7 @@ def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
 
   for metadata in intellij_metadata:
     if metadata.source_jar:
-      source_jars.extend(metadata.source_jar.files.to_list())
+      source_jars.append(metadata.source_jar)
     elif metadata.source_jars:
       source_jars.extend(metadata.source_jars)
 
@@ -142,6 +142,6 @@ scala_import = rule(
         "runtime_deps": attr.label_list(),
         "exports": attr.label_list(),
         "neverlink": attr.bool(),
-        "srcjar": attr.label(allow_files = True),
+        "srcjar": attr.label(allow_single_file = True),
     },
 )

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -24,7 +24,7 @@ def _scala_import_impl(ctx):
                     ),
       providers = [
           _create_provider(current_jars, transitive_runtime_jars, jars, exports,
-                           ctx.attr.neverlink),
+                           ctx.attr.neverlink, intellij_metadata),
           DefaultInfo(files = current_jars,
                      ),
           JarsToLabelsInfo(jars_to_labels = jars2labels),
@@ -32,7 +32,7 @@ def _scala_import_impl(ctx):
   )
 
 def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
-                     exports, neverlink):
+                     exports, neverlink, intellij_metadata):
 
   transitive_runtime_jars = [
       transitive_runtime_jars, jars.transitive_runtime_jars,
@@ -41,6 +41,14 @@ def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
 
   if not neverlink:
     transitive_runtime_jars.append(current_target_compile_jars)
+
+  source_jars = []
+
+  for metadata in intellij_metadata:
+    if metadata.source_jar:
+      source_jars.extend(metadata.source_jar.files.to_list())
+    elif metadata.source_jars:
+      source_jars.extend(metadata.source_jars)
 
   return java_common.create_provider(
       use_ijar = False,
@@ -51,6 +59,7 @@ def _create_provider(current_target_compile_jars, transitive_runtime_jars, jars,
           exports.transitive_compile_jars
       ]),
       transitive_runtime_jars = depset(transitive = transitive_runtime_jars),
+      source_jars = source_jars,
   )
 
 def _add_labels_of_current_code_jars(code_jars, label, jars2labels):

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -4,7 +4,8 @@ load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 #if you change make sure to manually re-import an intellij project and see imports
 #are resolved (not red) and clickable
 def _scala_import_impl(ctx):
-  target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars, ctx.file.srcjar)
+  target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars,
+                                                      ctx.file.srcjar)
   (current_target_compile_jars,
    intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
   current_jars = depset(current_target_compile_jars)
@@ -24,7 +25,8 @@ def _scala_import_impl(ctx):
                     ),
       providers = [
           _create_provider(current_jars, transitive_runtime_jars, jars, exports,
-                           ctx.attr.neverlink, ctx.file.srcjar, intellij_metadata),
+                           ctx.attr.neverlink, ctx.file.srcjar,
+                           intellij_metadata),
           DefaultInfo(files = current_jars,
                      ),
           JarsToLabelsInfo(jars_to_labels = jars2labels),
@@ -88,7 +90,7 @@ def _source_jars(jar, srcjar):
     return ([], srcjar)
   else:
     jar_source_jars = [
-      file for file in jar.files.to_list() if _is_source_jar(file)
+        file for file in jar.files.to_list() if _is_source_jar(file)
     ]
     return (jar_source_jars, None)
 

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -4,7 +4,7 @@ load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 #if you change make sure to manually re-import an intellij project and see imports
 #are resolved (not red) and clickable
 def _scala_import_impl(ctx):
-  target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars)
+  target_data = _code_jars_and_intellij_metadata_from(ctx.attr.jars, ctx.attr.srcjar)
   (current_target_compile_jars,
    intellij_metadata) = (target_data.code_jars, target_data.intellij_metadata)
   current_jars = depset(current_target_compile_jars)
@@ -57,24 +57,31 @@ def _add_labels_of_current_code_jars(code_jars, label, jars2labels):
   for jar in code_jars.to_list():
     jars2labels[jar.path] = label
 
-def _code_jars_and_intellij_metadata_from(jars):
+def _code_jars_and_intellij_metadata_from(jars, srcjar):
   code_jars = []
   intellij_metadata = []
   for jar in jars:
     current_jar_code_jars = _filter_out_non_code_jars(jar.files)
-    current_jar_source_jars = [
-        file for file in jar.files.to_list() if _is_source_jar(file)
-    ]
+    (current_jar_source_jars, src_jar) = _source_jars(jar, srcjar)
     code_jars += current_jar_code_jars
     for current_class_jar in current_jar_code_jars:  #intellij, untested
       intellij_metadata.append(
           struct(
               ijar = None,
               class_jar = current_class_jar,
-              source_jar = None,
+              source_jar = src_jar,
               source_jars = current_jar_source_jars,
           ))
   return struct(code_jars = code_jars, intellij_metadata = intellij_metadata)
+
+def _source_jars(jar, srcjar):
+  if srcjar:
+    return ([], srcjar)
+  else:
+    jar_source_jars = [
+      file for file in jar.files.to_list() if _is_source_jar(file)
+    ]
+    return (jar_source_jars, None)
 
 def _filter_out_non_code_jars(files):
   return [file for file in files.to_list() if not _is_source_jar(file)]
@@ -126,5 +133,6 @@ scala_import = rule(
         "runtime_deps": attr.label_list(),
         "exports": attr.label_list(),
         "neverlink": attr.bool(),
+        "srcjar": attr.label(allow_files = True),
     },
 )

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -131,8 +131,7 @@ def _decode_maven_coordinates(artifact):
       artifact_id = artifact_id,
       version = version,
       classifier = classifier,
-      packaging = packaging
-  )
+      packaging = packaging)
 
 def _convert_coordinates_to_urls(coordinates, server_urls):
   group_id = coordinates.group_id.replace(".", "/")
@@ -150,7 +149,6 @@ def _convert_coordinates_to_urls(coordinates, server_urls):
   for server_url in server_urls:
     urls.append(_concat_with_needed_slash(server_url, url_suffix))
   return urls
-
 
 def _concat_with_needed_slash(server_url, url_suffix):
   if server_url.endswith("/"):
@@ -237,15 +235,11 @@ def jvm_maven_import_external(artifact,
         artifact_id = coordinates.artifact_id,
         version = coordinates.version,
         classifier = "sources",
-        packaging = "jar"
-    )
+        packaging = "jar")
 
     srcjar_urls = _convert_coordinates_to_urls(src_coordinates, server_urls)
 
-  jvm_import_external(
-      jar_urls = jar_urls,
-      srcjar_urls = srcjar_urls,
-      **kwargs)
+  jvm_import_external(jar_urls = jar_urls, srcjar_urls = srcjar_urls, **kwargs)
 
 def scala_import_external(
     rule_load = "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")",

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -111,27 +111,46 @@ def _jvm_import_external(repository_ctx):
       "",
   ]))
 
-def _convert_to_url(artifact, server_urls):
+def _decode_maven_coordinates(artifact):
   parts = artifact.split(":")
-  group_id_part = parts[0].replace(".", "/")
+  group_id = parts[0]
   artifact_id = parts[1]
   version = parts[2]
   packaging = "jar"
-  classifier_part = ""
+  classifier = None
   if len(parts) == 4:
     packaging = parts[2]
     version = parts[3]
   elif len(parts) == 5:
     packaging = parts[2]
-    classifier_part = "-" + parts[3]
+    classifier_part = parts[3]
     version = parts[4]
 
-  final_name = artifact_id + "-" + version + classifier_part + "." + packaging
-  url_suffix = group_id_part + "/" + artifact_id + "/" + version + "/" + final_name
+  return struct(
+      group_id = group_id,
+      artifact_id = artifact_id,
+      version = version,
+      classifier = classifier,
+      packaging = packaging
+  )
+
+def _convert_coordinates_to_urls(coordinates, server_urls):
+  group_id = coordinates.group_id.replace(".", "/")
+  classifier = coordinates.classifier
+
+  if classifier:
+    classifier = "-" + classifier
+  else:
+    classifier = ""
+
+  final_name = coordinates.artifact_id + "-" + coordinates.version + classifier + "." + coordinates.packaging
+  url_suffix = group_id + "/" + coordinates.artifact_id + "/" + coordinates.version + "/" + final_name
+
   urls = []
   for server_url in server_urls:
     urls.append(_concat_with_needed_slash(server_url, url_suffix))
   return urls
+
 
 def _concat_with_needed_slash(server_url, url_suffix):
   if server_url.endswith("/"):
@@ -187,32 +206,44 @@ def scala_maven_import_external(
     artifact,
     server_urls,
     rule_load = "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")",
-    src_artifact = None,
+    fetch_sources = False,
     **kwargs):
   jvm_maven_import_external(
       rule_name = "scala_import",
       rule_load = rule_load,
       artifact = artifact,
       server_urls = server_urls,
-      src_artifact = src_artifact,
+      fetch_sources = fetch_sources,
       #additional string attributes' values have to be escaped in order to accomodate non-string types
       #    additional_rule_attrs = {"foo": "'bar'"},
       **kwargs)
 
 def jvm_maven_import_external(artifact,
                               server_urls,
-                              src_artifact = None,
+                              fetch_sources = False,
                               **kwargs):
-  if kwargs.get("srcjar_urls") and src_artifact:
-    fail("Either use srcjar_urls or src_artifcat but not both")
+  if kwargs.get("srcjar_urls") and fetch_sources:
+    fail("Either use srcjar_urls or fetch_sources but not both")
+
+  coordinates = _decode_maven_coordinates(artifact)
+
+  jar_urls = _convert_coordinates_to_urls(coordinates, server_urls)
 
   srcjar_urls = kwargs.pop("srcjar_urls", None)
 
-  if src_artifact:
-    srcjar_urls = _convert_to_url(src_artifact, server_urls)
+  if fetch_sources:
+    src_coordinates = struct(
+        group_id = coordinates.group_id,
+        artifact_id = coordinates.artifact_id,
+        version = coordinates.version,
+        classifier = "sources",
+        packaging = "jar"
+    )
+
+    srcjar_urls = _convert_coordinates_to_urls(src_coordinates, server_urls)
 
   jvm_import_external(
-      jar_urls = _convert_to_url(artifact, server_urls),
+      jar_urls = jar_urls,
       srcjar_urls = srcjar_urls,
       **kwargs)
 

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -13,7 +13,7 @@ scala_import(
 scala_import(
     name = "guava_external",
     jars = [
-        "@com_google_guava_guava_21_0_external//jar"
+        "@com_google_guava_guava_21_0_external//jar",
     ],
 )
 

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -10,6 +10,13 @@ scala_import(
     ],
 )
 
+scala_import(
+    name = "guava_external",
+    jars = [
+        "@com_google_guava_guava_21_0_external//jar"
+    ],
+)
+
 # Jars as files
 scala_import(
     name = "relate",


### PR DESCRIPTION
This is a better approach to fetch sources following: #623. This also includes a usage example for `scala_maven_import_external` (which fails since `scala_import` has no `srcjar` attribute) 