### PR TITLE
hack for proto in case of many-repo with relative package

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,9 +19,9 @@ env:
   # See https://github.com/bazelbuild/rules_scala/pull/622
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
-  - V=0.16.1 TEST_SCRIPT=test_rules_scala.sh
+  - V=0.19.1 TEST_SCRIPT=test_rules_scala.sh
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.16.1 TEST_SCRIPT=test_reproducibility.sh
+  - V=0.19.1 TEST_SCRIPT=test_reproducibility.sh
 
 before_install:
   - |

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -83,6 +83,12 @@ scala_maven_import_external(
     srcjar_sha256 = "5e586357a289f5fe896f7b48759e1c16d9fa419333156b496696887e613d7a19",
 )
 
+# for testing of proto dependency in external repo under package
+local_repository(
+    name = "b_for_proto_test",
+    path = "test/proto/cross_repo/repo_b"
+)
+
 maven_jar(
     name = "org_apache_commons_commons_lang_3_5",
     artifact = "org.apache.commons:commons-lang3:3.5",

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -336,19 +336,20 @@ def _root_path(f, transitive_proto_paths):
   if f.is_source:
     print("f.path: " + f.path + ".  f.owner.workspace_root: "+ f.owner.workspace_root + ". f.root.path: " + f.root.path)
     if (f.owner.workspace_root):
-        start = len(f.owner.workspace_root)+1
+        start_of_relative_path = len(f.owner.workspace_root)+1
         # print("start index: {}".format(start))
         package_len = 0
         for package_set in transitive_proto_paths:
            for package in package_set.to_list():
-               if str(package) in f.path:
+               if f.path.startswith(f.owner.workspace_root + "/" + str(package)):
                   package_len = len(package)+1
-        relative_path=f.path[start+package_len:]
+        relative_path=f.path[start_of_relative_path+package_len:]
         print("relative_path: " + relative_path)
         return relative_path
     else:
         return f.owner.workspace_root
-  return '/'.join([f.root.path, f.owner.workspace_root])
+  path = '/'.join([f.root.path, f.owner.workspace_root])
+  return path
 
 def _colon_paths(data, transitive_proto_paths):
   return ':'.join([

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -332,7 +332,7 @@ def scala_proto_repositories(
       actual = '@scala_proto_rules_netty_handler_proxy//jar')
 
 def _root_path(f, transitive_proto_paths):
-  print("f.is_source is {}".format(f.is_source))
+#   print("f.is_source is {}".format(f.is_source))
   if f.is_source:
     print("f.path: " + f.path + ".  f.owner.workspace_root: "+ f.owner.workspace_root + ". f.root.path: " + f.root.path)
     if (f.owner.workspace_root):
@@ -342,16 +342,10 @@ def _root_path(f, transitive_proto_paths):
         for package_set in transitive_proto_paths:
            for package in package_set.to_list():
                if str(package) in f.path:
-                #   print(package)
                   package_len = len(package)+1
-                #   print(package_len)
-        if package_len > 1:
-            relative_path=f.path[start+package_len:]
-            print("relative_path: " + relative_path)
-            return relative_path
-        else:
-            print("no package was found")
-            return f.owner.workspace_root
+        relative_path=f.path[start+package_len:]
+        print("relative_path: " + relative_path)
+        return relative_path
     else:
         return f.owner.workspace_root
   return '/'.join([f.root.path, f.owner.workspace_root])

--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -10,13 +10,23 @@ object PBGenerateRequest {
     val jarOutput = args.get(0)
     val parsedProtoFiles = args.get(1).split(':').toList.map { rootAndFile =>
       val parsed = rootAndFile.split(',')
-      val root = parsed(0)
-      val file = if (root.isEmpty) {
-        parsed(1)
-      } else {
-        parsed(1).substring(root.length + 1)
+      if (parsed(1).contains("external")) {
+        println("parsed(0) is " + parsed(0))
+        println("parsed(1) is " + parsed(1))
+        (parsed(0), parsed(1))
       }
-      (file, Paths.get(root, file).toString)
+      else {
+        val root = parsed(0)
+        val file = if (root.isEmpty) {
+          parsed(1)
+        } else {
+          parsed(1).substring(root.length + 1)
+        }
+        println("Root is " + root)
+        println("parsed(1) is " + parsed(1))
+        println("file is " + file)
+        (file, Paths.get(root, file).toString)
+      }
     }
     // This will map the absolute path of a given proto file
     // to a relative path that does not contain the repo prefix.

--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -10,7 +10,7 @@ object PBGenerateRequest {
     val jarOutput = args.get(0)
     val parsedProtoFiles = args.get(1).split(':').toList.map { rootAndFile =>
       val parsed = rootAndFile.split(',')
-      if (parsed(1).contains("external")) {
+      if (parsed(1).startsWith("external")) {
         println("parsed(0) is " + parsed(0))
         println("parsed(1) is " + parsed(1))
         (parsed(0), parsed(1))

--- a/test/proto/cross_repo/repo_a/src/a_pkg/BUILD.bazel
+++ b/test/proto/cross_repo/repo_a/src/a_pkg/BUILD.bazel
@@ -1,0 +1,13 @@
+load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_srcjar", "scalapb_proto_library")
+
+proto_library(
+    name = "a_proto",
+    srcs = ["some_package/a.proto"],
+    deps = ["@b_for_proto_test//src/b_pkg:b_proto"],
+    proto_source_root = PACKAGE_NAME,
+    )
+
+scalapb_proto_library(
+      name = "a_scala_proto",
+      deps = [":a_proto"],
+  )

--- a/test/proto/cross_repo/repo_a/src/a_pkg/BUILD.bazel
+++ b/test/proto/cross_repo/repo_a/src/a_pkg/BUILD.bazel
@@ -3,7 +3,8 @@ load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_srcjar",
 proto_library(
     name = "a_proto",
     srcs = ["some_package/a.proto"],
-    deps = ["@b_for_proto_test//src/b_pkg:b_proto"],
+    deps = ["@b_for_proto_test//src/b_pkg:b_proto", 
+            "@com_google_protobuf//:descriptor_proto"],
     proto_source_root = PACKAGE_NAME,
     )
 

--- a/test/proto/cross_repo/repo_a/src/a_pkg/BUILD.bazel
+++ b/test/proto/cross_repo/repo_a/src/a_pkg/BUILD.bazel
@@ -5,7 +5,7 @@ proto_library(
     srcs = ["some_package/a.proto"],
     deps = ["@b_for_proto_test//src/b_pkg:b_proto", 
             "@com_google_protobuf//:descriptor_proto"],
-    proto_source_root = PACKAGE_NAME,
+    proto_source_root = package_name(),
     )
 
 scalapb_proto_library(

--- a/test/proto/cross_repo/repo_a/src/a_pkg/some_package/a.proto
+++ b/test/proto/cross_repo/repo_a/src/a_pkg/some_package/a.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "some_package2/b.proto";
+
+message Baz {
+  Foo foo3 = 1;
+}

--- a/test/proto/cross_repo/repo_a/src/a_pkg/some_package/a.proto
+++ b/test/proto/cross_repo/repo_a/src/a_pkg/some_package/a.proto
@@ -2,6 +2,15 @@ syntax = "proto3";
 
 import "some_package2/b.proto";
 
-message Baz {
-  Foo foo3 = 1;
+// use dependency with external in the middle of the file path 
+// (e.g. - 'external' in generated output: bazel-out/darwin-fastbuild/genfiles/external/com_google_protobuf/google/protobuf/descriptor.proto)
+import "google/protobuf/descriptor.proto";
+
+
+message Bar {
+  Foo foo = 1;
+}
+
+extend google.protobuf.MethodOptions {
+    Foo foo = 50301;
 }

--- a/test/proto/cross_repo/repo_b/WORKSPACE
+++ b/test/proto/cross_repo/repo_b/WORKSPACE
@@ -1,0 +1,1 @@
+workspace(name = "b")

--- a/test/proto/cross_repo/repo_b/src/b_pkg/BUILD.bazel
+++ b/test/proto/cross_repo/repo_b/src/b_pkg/BUILD.bazel
@@ -1,0 +1,7 @@
+package(default_visibility = ["//visibility:public"])
+
+proto_library(
+    name = "b_proto",
+    srcs = ["some_package2/b.proto"],
+    proto_source_root = PACKAGE_NAME,
+    )

--- a/test/proto/cross_repo/repo_b/src/b_pkg/BUILD.bazel
+++ b/test/proto/cross_repo/repo_b/src/b_pkg/BUILD.bazel
@@ -3,5 +3,5 @@ package(default_visibility = ["//visibility:public"])
 proto_library(
     name = "b_proto",
     srcs = ["some_package2/b.proto"],
-    proto_source_root = PACKAGE_NAME,
+    proto_source_root = package_name(),
     )

--- a/test/proto/cross_repo/repo_b/src/b_pkg/some_package2/b.proto
+++ b/test/proto/cross_repo/repo_b/src/b_pkg/some_package2/b.proto
@@ -1,5 +1,5 @@
 syntax = "proto3";
 
 message Foo {
-  string bar = 1;
+  string foo = 1;
 }

--- a/test/proto/cross_repo/repo_b/src/b_pkg/some_package2/b.proto
+++ b/test/proto/cross_repo/repo_b/src/b_pkg/some_package2/b.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message Foo {
+  string bar = 1;
+}


### PR DESCRIPTION
This hack solves an issue with proto_library target depending on proto_library from external repo.
`scalapb_proto_library` failed to find the proto from the external repo.

This hack can be reverted when https://github.com/bazelbuild/bazel/issues/4665 is resolved.