### PR TITLE
Fixed intellij metadata to include correct source_jars info for scala_import libraries

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -93,14 +93,13 @@ def _code_jars_and_intellij_metadata_from(jars, srcjar):
     intellij_metadata = []
     for jar in jars:
         current_jar_code_jars = _filter_out_non_code_jars(jar.files)
-        (current_jar_source_jars, src_jar) = _source_jars(jar, srcjar)
+        current_jar_source_jars = _source_jars(jar, srcjar)
         code_jars += current_jar_code_jars
         for current_class_jar in current_jar_code_jars:  #intellij, untested
             intellij_metadata.append(
                 struct(
                     ijar = None,
                     class_jar = current_class_jar,
-                    source_jar = src_jar,
                     source_jars = current_jar_source_jars,
                 ),
             )
@@ -108,14 +107,14 @@ def _code_jars_and_intellij_metadata_from(jars, srcjar):
 
 def _source_jars(jar, srcjar):
     if srcjar:
-        return ([], srcjar)
+        return [srcjar]
     else:
         jar_source_jars = [
             file
             for file in jar.files.to_list()
             if _is_source_jar(file)
         ]
-        return (jar_source_jars, None)
+        return jar_source_jars
 
 def _filter_out_non_code_jars(files):
     return [file for file in files.to_list() if not _is_source_jar(file)]


### PR DESCRIPTION
Fixed intellij metadata generated for `scala_import` to include the correct source jars information for intellij to be able properly show sources.

Since the attribute `source_jar` is marked deprecated in [intellij_ide_info.proto](https://github.com/bazelbuild/intellij/blob/02b148713798c71d86121e3c22ca5ef5470cb08b/proto/intellij_ide_info.proto#L36) I removed it from the metadata struct and used `source_jars` for all cases.

Tested manually on intellij 2018.3 and hopefully after this is merged, I will develop a test in the intellij bazel plugin project, to cover that.

We should probably do the corresponding cleanups in `aspect/intellij_info_impl.bzl`, just to keep it clean and avoid confusion.