### PR TITLE
scala_proto should require JavaInfo provider and not specific rules

### DIFF
--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -450,12 +450,7 @@ scala_proto_srcjar = rule(
     attrs = {
         "deps": attr.label_list(
             mandatory = True,
-            allow_rules = [
-                "proto_library",
-                "java_proto_library",
-                "java_library",
-                "scala_library",
-            ],
+            providers = [["proto"],[JavaInfo]],
         ),
         "flags": attr.string_list(default = []),
         "generator": attr.label(

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -394,10 +394,7 @@ def _gen_proto_srcjar_impl(ctx):
     for target in ctx.attr.deps:
         if hasattr(target, "proto"):
             acc_imports.append(target.proto.transitive_sources)
-
-            #inline this if after 0.12.0 is the oldest supported version
-            if hasattr(target.proto, "transitive_proto_path"):
-                transitive_proto_paths.append(target.proto.transitive_proto_path)
+            transitive_proto_paths.append(target.proto.transitive_proto_path)
         else:
             jvm_deps.append(target)
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -575,6 +575,15 @@ scalapb_proto_library(
     ],
 )
 
+scalapb_proto_library(
+    name = "test_proto_scala_import_dep",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_jnr_jffi_native",
+        "//test/proto:test2",
+    ],
+)
+
 scala_library(
     name = "java_uses_scala_std_lib",
     srcs = ["JavaUsesScalaStdLib.java"],


### PR DESCRIPTION
subj.
drive-by: removed old conditional.
@laurentlb @dslomov I really wanted to use `ProtoSourcesProvider` and not `"proto"` like the [docs say](https://docs.bazel.build/versions/master/skylark/rules.html#migrating-from-legacy-providers) but as far as I can see `ProtoSourcesProvider` isn't defined as a symbol. Also see https://github.com/bazelbuild/bazel/issues/3701 and https://github.com/bazelbuild/bazel/issues/3527
Can anyone help us move to the correct pattern?