### PR TITLE
suppressing external libraries source fetching based on an env-var

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -129,7 +129,10 @@ scala_maven_import_external(
     srcjar_sha256 = "b7ffb578b2bd6445c958356e308d1c46c9ea6fb868fc9444bc8bda3a41875a1b",
     fetch_sources = True,
     licenses = ["notice"],  # Apache 2.0
-    server_urls = ["https://mirror.bazel.build/repo1.maven.org/maven2"],
+    server_urls = [
+        "https://repo1.maven.org/maven2/",
+        "https://mirror.bazel.build/repo1.maven.org/maven2",
+        ],
 )
 
 # bazel's java_import_external has been altered in rules_scala to be a macro based on jvm_import_external

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,6 +126,8 @@ scala_maven_import_external(
     name = "com_google_guava_guava_21_0",
     artifact = "com.google.guava:guava:21.0",
     jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    srcjar_sha256 = "b7ffb578b2bd6445c958356e308d1c46c9ea6fb868fc9444bc8bda3a41875a1b",
+    fetch_sources = True,
     licenses = ["notice"],  # Apache 2.0
     server_urls = ["https://mirror.bazel.build/repo1.maven.org/maven2"],
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -126,7 +126,7 @@ scala_maven_import_external(
     name = "com_google_guava_guava_21_0",
     artifact = "com.google.guava:guava:21.0",
     jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
-    srcjar_sha256 = "b7ffb578b2bd6445c958356e308d1c46c9ea6fb868fc9444bc8bda3a41875a1b",
+    srcjar_sha256 = "b186965c9af0a714632fe49b33378c9670f8f074797ab466f49a67e918e116ea",
     fetch_sources = True,
     licenses = ["notice"],  # Apache 2.0
     server_urls = [

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -127,7 +127,7 @@ def _jvm_import_external(repository_ctx):
 
 def _should_fetch_sources_in_current_env(repository_ctx):
     env_bazel_jvm_fetch_sources = repository_ctx.os.environ.get(_FETCH_SOURCES_ENV_VAR_NAME)
-    return (not env_bazel_jvm_fetch_sources) or (env_bazel_jvm_fetch_sources == "True")
+    return (not env_bazel_jvm_fetch_sources) or (env_bazel_jvm_fetch_sources.lower() == "true")
 
 def _decode_maven_coordinates(artifact):
     parts = artifact.split(":")

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -46,6 +46,8 @@ _PASS_PROPS = (
     "tags",
 )
 
+_FETCH_SOURCES_ENV_VAR_NAME = "BAZEL_JVM_FETCH_SOURCES"
+
 def _jvm_import_external(repository_ctx):
     """Implementation of `java_import_external` rule."""
     if (repository_ctx.attr.generated_linkable_rule_name and
@@ -106,7 +108,7 @@ def _jvm_import_external(repository_ctx):
         if not extra.endswith("\n"):
             lines.append("")
     repository_ctx.download(urls, path, sha)
-    if srcurls:
+    if srcurls and _should_fetch_sources_in_current_env(repository_ctx):
         repository_ctx.download(srcurls, srcpath, srcsha)
     repository_ctx.file("BUILD", "\n".join(lines))
     repository_ctx.file("jar/BUILD", "\n".join([
@@ -122,6 +124,10 @@ def _jvm_import_external(repository_ctx):
         ")",
         "",
     ]))
+
+def _should_fetch_sources_in_current_env(repository_ctx):
+    env_bazel_jvm_fetch_sources = repository_ctx.os.environ.get(_FETCH_SOURCES_ENV_VAR_NAME)
+    return (not env_bazel_jvm_fetch_sources) or (env_bazel_jvm_fetch_sources == "True")
 
 def _decode_maven_coordinates(artifact):
     parts = artifact.split(":")
@@ -219,6 +225,7 @@ jvm_import_external = repository_rule(
         ),
         "extra_build_file_content": attr.string(),
     },
+    environ = [_FETCH_SOURCES_ENV_VAR_NAME]
 )
 
 def scala_maven_import_external(

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -126,8 +126,8 @@ def _jvm_import_external(repository_ctx):
     ]))
 
 def _should_fetch_sources_in_current_env(repository_ctx):
-    env_bazel_jvm_fetch_sources = repository_ctx.os.environ.get(_FETCH_SOURCES_ENV_VAR_NAME)
-    return (not env_bazel_jvm_fetch_sources) or (env_bazel_jvm_fetch_sources.lower() == "true")
+    env_bazel_jvm_fetch_sources = repository_ctx.os.environ.get(_FETCH_SOURCES_ENV_VAR_NAME, "true")
+    return env_bazel_jvm_fetch_sources.lower() == "true"
 
 def _decode_maven_coordinates(artifact):
     parts = artifact.split(":")

--- a/test/src/main/scala/scalarules/test/fetch_sources/BUILD
+++ b/test/src/main/scala/scalarules/test/fetch_sources/BUILD
@@ -1,8 +1,7 @@
-load("//scala:scala.bzl", "scala_binary")
+load("//scala:scala.bzl", "scala_library")
 
-scala_binary(
+scala_library(
     name = "fetch_sources",
     srcs = [ "FetchSources.scala" ],
-    main_class = "scalarules.test.src.main.scala.scalarules.test.fetch_sources.FetchSources",
     deps = [ "@com_google_guava_guava_21_0//jar" ]
 )

--- a/test/src/main/scala/scalarules/test/fetch_sources/BUILD
+++ b/test/src/main/scala/scalarules/test/fetch_sources/BUILD
@@ -1,15 +1,8 @@
 load("//scala:scala.bzl", "scala_binary")
-load("//scala:scala_import.bzl", "scala_import")
-#load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
 
 scala_binary(
     name = "fetch_sources",
     srcs = [ "FetchSources.scala" ],
     main_class = "scalarules.test.src.main.scala.scalarules.test.fetch_sources.FetchSources",
-    deps = [ ":guava" ]
-)
-
-scala_import(
-    name = "guava",
-    jars = ["@com_google_guava_guava_21_0//jar"],
+    deps = [ "@com_google_guava_guava_21_0//jar" ]
 )

--- a/test/src/main/scala/scalarules/test/fetch_sources/BUILD
+++ b/test/src/main/scala/scalarules/test/fetch_sources/BUILD
@@ -1,0 +1,15 @@
+load("//scala:scala.bzl", "scala_binary")
+load("//scala:scala_import.bzl", "scala_import")
+#load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
+
+scala_binary(
+    name = "fetch_sources",
+    srcs = [ "FetchSources.scala" ],
+    main_class = "scalarules.test.src.main.scala.scalarules.test.fetch_sources.FetchSources",
+    deps = [ ":guava" ]
+)
+
+scala_import(
+    name = "guava",
+    jars = ["@com_google_guava_guava_21_0//jar"],
+)

--- a/test/src/main/scala/scalarules/test/fetch_sources/FetchSources.scala
+++ b/test/src/main/scala/scalarules/test/fetch_sources/FetchSources.scala
@@ -1,0 +1,6 @@
+package scalarules.test.src.main.scala.scalarules.test.fetch_sources
+
+/* This file's only purpose is to materialize the dependency in guava and be built! */
+object FetchSources extends App {
+  println(classOf[com.google.common.cache.Cache[_, _]])
+}

--- a/test/src/main/scala/scalarules/test/fetch_sources/FetchSources.scala
+++ b/test/src/main/scala/scalarules/test/fetch_sources/FetchSources.scala
@@ -1,6 +1,6 @@
 package scalarules.test.src.main.scala.scalarules.test.fetch_sources
 
 /* This file's only purpose is to materialize the dependency in guava and be built! */
-object FetchSources extends App {
+class FetchSources {
   println(classOf[com.google.common.cache.Cache[_, _]])
 }

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -811,22 +811,23 @@ test_scala_import_source_jar_should_be_fetched_when_fetch_sources_is_set_to_true
 }
 
 test_scala_import_source_jar_should_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_true() {
-  test_scala_import_fetch_sources_with_env_bazel_jvm_fetch_sources "True"
+  test_scala_import_fetch_sources_with_env_bazel_jvm_fetch_sources_set_to "TruE" # as implied, the value is case insensitive
 }
 
-test_scala_import_source_jar_should_not_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_false() {
-  test_scala_import_fetch_sources_with_env_bazel_jvm_fetch_sources "False"
+test_scala_import_source_jar_should_not_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_non_true() {
+  test_scala_import_fetch_sources_with_env_bazel_jvm_fetch_sources_set_to "false" "and expect no source jars"
 }
 
-test_scala_import_fetch_sources_with_env_bazel_jvm_fetch_sources() {
+test_scala_import_fetch_sources_with_env_bazel_jvm_fetch_sources_set_to() {
   # the existence of the env var should cause the import repository rule to re-fetch the dependency
   # and therefore the order of tests is not expected to matter
   export BAZEL_JVM_FETCH_SOURCES=$1
+  local expect_failure=$2
 
-  if [[ $1 = "True" ]]; then
-    test_scala_import_fetch_sources
-  else
+  if [[ ${expect_failure} ]]; then
     action_should_fail test_scala_import_fetch_sources
+  else
+    test_scala_import_fetch_sources
   fi
 
   unset BAZEL_JVM_FETCH_SOURCES
@@ -930,4 +931,4 @@ $runner scala_test_jar_is_exposed_in_build_event_protocol
 $runner scala_junit_test_jar_is_exposed_in_build_event_protocol
 $runner test_scala_import_source_jar_should_be_fetched_when_fetch_sources_is_set_to_true
 $runner test_scala_import_source_jar_should_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_true
-$runner test_scala_import_source_jar_should_not_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_false
+$runner test_scala_import_source_jar_should_not_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_non_true

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -837,7 +837,9 @@ test_scala_import_fetch_sources() {
   local srcjar_name="guava-21.0-src.jar"
   local bazel_out_external_guava_21=$(bazel info output_base)/external/com_google_guava_guava_21_0
 
+  set -e
   bazel build //test/src/main/scala/scalarules/test/fetch_sources/...
+  set +e
 
   assert_file_exists $bazel_out_external_guava_21/$srcjar_name
 }


### PR DESCRIPTION
This PR is a proposed solution for issue #652 

The decision regarding whether or not to download source jars are implemented in a repository rule that declares dependency in the environment variable, so changes in the environment variable, will force a reload, which is desired in this case.