### PR TITLE
Allow alternatively discovering junit tests from a separate target

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -1110,8 +1110,8 @@ def scala_junit_test_impl(ctx):
             unused_dependency_checker_ignored_targets,
     )
 
-    if ctx.attr.alternatively_discover_tests_from:
-        archives = _get_test_archive_jars(ctx, ctx.attr.alternatively_discover_tests_from)
+    if ctx.attr.tests_from:
+        archives = _get_test_archive_jars(ctx, ctx.attr.tests_from)
     else:
         archives = [archive.class_jar for archive in out.scala.outputs.jars]
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -554,7 +554,7 @@ _scala_junit_test_attrs.update(_implicit_deps)
 _scala_junit_test_attrs.update(_common_attrs)
 _scala_junit_test_attrs.update(_junit_resolve_deps)
 _scala_junit_test_attrs.update({
-    "discover_tests_additionally_from": attr.label_list(providers = [[JavaInfo]]),
+    "alternatively_discover_tests_from": attr.label_list(providers = [[JavaInfo]]),
 })
 scala_junit_test = rule(
     implementation = _scala_junit_test_impl,

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -554,7 +554,7 @@ _scala_junit_test_attrs.update(_implicit_deps)
 _scala_junit_test_attrs.update(_common_attrs)
 _scala_junit_test_attrs.update(_junit_resolve_deps)
 _scala_junit_test_attrs.update({
-    "alternatively_discover_tests_from": attr.label_list(providers = [[JavaInfo]]),
+    "tests_from": attr.label_list(providers = [[JavaInfo]]),
 })
 scala_junit_test = rule(
     implementation = _scala_junit_test_impl,

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -553,6 +553,9 @@ _scala_junit_test_attrs.update(_launcher_template)
 _scala_junit_test_attrs.update(_implicit_deps)
 _scala_junit_test_attrs.update(_common_attrs)
 _scala_junit_test_attrs.update(_junit_resolve_deps)
+_scala_junit_test_attrs.update({
+    "discover_tests_additionally_from": attr.label_list(providers = [[JavaInfo]]),
+})
 scala_junit_test = rule(
     implementation = _scala_junit_test_impl,
     attrs = _scala_junit_test_attrs,

--- a/scripts/ij.bazelproject
+++ b/scripts/ij.bazelproject
@@ -20,3 +20,5 @@ targets:
 
 additional_languages:
   scala
+
+bazel_binary: /usr/local/bin/bazel

--- a/test/BUILD
+++ b/test/BUILD
@@ -607,7 +607,7 @@ scala_junit_test(
     size = "small",
     suffixes = ["Test"],
     runtime_deps = [":JunitSeparateTarget"],
-    alternatively_discover_tests_from = [":JunitSeparateTarget"],
+    tests_from = [":JunitSeparateTarget"],
 
 )
 
@@ -622,7 +622,7 @@ scala_junit_test(
     size = "small",
     suffixes = ["Test"],
     runtime_deps = [":JunitJavaSeparateTarget"],
-    alternatively_discover_tests_from = [":JunitJavaSeparateTarget"],
+    tests_from = [":JunitJavaSeparateTarget"],
 
 )
 
@@ -644,7 +644,7 @@ scala_junit_test(
     size = "small",
     suffixes = ["Test"],
     runtime_deps = [":JunitSeparateTargetWithDependencyOnTest"],
-    alternatively_discover_tests_from = [":JunitSeparateTargetWithDependencyOnTest"],
+    tests_from = [":JunitSeparateTargetWithDependencyOnTest"],
 
 )
 
@@ -660,7 +660,7 @@ scala_junit_test(
     size = "small",
     suffixes = ["Test"],
     runtime_deps = [":JunitSeparateJavaTargetWithDependencyOnTest"],
-    alternatively_discover_tests_from = [":JunitSeparateJavaTargetWithDependencyOnTest"],
+    tests_from = [":JunitSeparateJavaTargetWithDependencyOnTest"],
 
 )
 
@@ -677,6 +677,6 @@ scala_junit_test(
     size = "small",
     suffixes = ["Test"],
     runtime_deps = [":JunitMixedSeparateTarget"],
-    alternatively_discover_tests_from = [":JunitMixedSeparateTarget"],
+    tests_from = [":JunitMixedSeparateTarget"],
 
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -594,3 +594,19 @@ load(":check_statsfile.bzl", "check_statsfile")
 check_statsfile("ScalaBinary")
 
 check_statsfile("ScalaLibBinary")
+
+scala_library(
+    name = "JunitSeparateTarget",
+    srcs = ["src/main/scala/scalarules/test/junit/JunitSeparateTarget.scala"],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+)
+
+scala_junit_test(
+    name = "JunitSeparateTarget_test_runner",
+    size = "small",
+    suffixes = ["Test"],
+    runtime_deps = [":JunitSeparateTarget"],
+    test_archives = [":JunitSeparateTarget"],
+
+)
+

--- a/test/BUILD
+++ b/test/BUILD
@@ -595,9 +595,10 @@ check_statsfile("ScalaBinary")
 
 check_statsfile("ScalaLibBinary")
 
+#discovering tests from a separate target
 scala_library(
     name = "JunitSeparateTarget",
-    srcs = ["src/main/scala/scalarules/test/junit/JunitSeparateTarget.scala"],
+    srcs = ["src/main/scala/scalarules/test/junit/separate_target/JunitSeparateTargetTest.scala"],
     deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
 )
 
@@ -606,7 +607,76 @@ scala_junit_test(
     size = "small",
     suffixes = ["Test"],
     runtime_deps = [":JunitSeparateTarget"],
-    test_archives = [":JunitSeparateTarget"],
+    alternatively_discover_tests_from = [":JunitSeparateTarget"],
 
 )
 
+java_library(
+    name = "JunitJavaSeparateTarget",
+    srcs = ["src/main/scala/scalarules/test/junit/separate_target/JunitJavaSeparateTargetTest.java"],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+)
+
+scala_junit_test(
+    name = "JunitJavaSeparateTarget_test_runner",
+    size = "small",
+    suffixes = ["Test"],
+    runtime_deps = [":JunitJavaSeparateTarget"],
+    alternatively_discover_tests_from = [":JunitJavaSeparateTarget"],
+
+)
+
+scala_library(
+    name = "TargetWithTestThatShouldNotRun",
+    srcs = ["src/main/scala/scalarules/test/junit/separate_target/FailingTest.scala"],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+)
+
+scala_library(
+    name = "JunitSeparateTargetWithDependencyOnTest",
+    srcs = ["src/main/scala/scalarules/test/junit/separate_target/JunitSeparateTargetTest.scala"],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+    runtime_deps = [":TargetWithTestThatShouldNotRun"],
+)
+
+scala_junit_test(
+    name = "JunitSeparateTargetTransitiveDependencyShouldNotRun_test_runner",
+    size = "small",
+    suffixes = ["Test"],
+    runtime_deps = [":JunitSeparateTargetWithDependencyOnTest"],
+    alternatively_discover_tests_from = [":JunitSeparateTargetWithDependencyOnTest"],
+
+)
+
+java_library(
+    name = "JunitSeparateJavaTargetWithDependencyOnTest",
+    srcs = ["src/main/scala/scalarules/test/junit/separate_target/JunitJavaSeparateTargetTest.java"],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+    runtime_deps = [":TargetWithTestThatShouldNotRun"],
+)
+
+scala_junit_test(
+    name = "JunitSeparateJavaTargetTransitiveDependencyShouldNotRun_test_runner",
+    size = "small",
+    suffixes = ["Test"],
+    runtime_deps = [":JunitSeparateJavaTargetWithDependencyOnTest"],
+    alternatively_discover_tests_from = [":JunitSeparateJavaTargetWithDependencyOnTest"],
+
+)
+
+scala_library(
+    name = "JunitMixedSeparateTarget",
+    srcs = ["src/main/scala/scalarules/test/junit/separate_target/SomeScalaClass.scala",
+            "src/main/scala/scalarules/test/junit/separate_target/JunitJavaSeparateTargetTest.java"
+            ],
+    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+)
+
+scala_junit_test(
+    name = "JunitMixedSeparateTarget_test_runner",
+    size = "small",
+    suffixes = ["Test"],
+    runtime_deps = [":JunitMixedSeparateTarget"],
+    alternatively_discover_tests_from = [":JunitMixedSeparateTarget"],
+
+)

--- a/test/src/main/scala/scalarules/test/junit/JunitSeparateTarget.scala
+++ b/test/src/main/scala/scalarules/test/junit/JunitSeparateTarget.scala
@@ -1,0 +1,12 @@
+package scalarules.test.junit
+
+import org.junit.Test
+
+class JunitSeparateTargetTest {
+
+  @Test
+  def someTest: Unit = {
+  }
+
+}
+

--- a/test/src/main/scala/scalarules/test/junit/separate_target/FailingTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/separate_target/FailingTest.scala
@@ -1,0 +1,13 @@
+package scalarules.test.junit.separate_target
+
+import org.junit.Test
+
+class FailingTest {
+
+  @Test
+  def someFailingTest(): Unit = {
+    throw new RuntimeException("boom! should not run")
+  }
+
+}
+

--- a/test/src/main/scala/scalarules/test/junit/separate_target/JunitJavaSeparateTargetTest.java
+++ b/test/src/main/scala/scalarules/test/junit/separate_target/JunitJavaSeparateTargetTest.java
@@ -1,0 +1,11 @@
+package scalarules.test.junit.separate_target;
+
+import org.junit.Test;
+
+public class JunitJavaSeparateTargetTest {
+
+  @Test
+  public void someTest() {
+
+  }
+}

--- a/test/src/main/scala/scalarules/test/junit/separate_target/JunitSeparateTargetTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/separate_target/JunitSeparateTargetTest.scala
@@ -1,11 +1,11 @@
-package scalarules.test.junit
+package scalarules.test.junit.separate_target
 
 import org.junit.Test
 
 class JunitSeparateTargetTest {
 
   @Test
-  def someTest: Unit = {
+  def someTest(): Unit = {
   }
 
 }

--- a/test/src/main/scala/scalarules/test/junit/separate_target/SomeScalaClass.scala
+++ b/test/src/main/scala/scalarules/test/junit/separate_target/SomeScalaClass.scala
@@ -1,0 +1,5 @@
+package scalarules.test.junit.separate_target
+
+class SomeScalaClass {
+
+}


### PR DESCRIPTION
if `alternatively_discover_tests_from` is set then test discovery is attempted from a different target.
This is in preparation for the introduction of `trim_test_configuration` in bazel which will mean that `scala_library` (even with `testonly = 1`) can't depend on a `scala_junit_test`.
For us (Wix) this will be a problem since often `scala_junit_test` targets contain tests and a bit of test support code which other test support targets (`scala_library`) sometimes depend on.
Additionally such separation can serve us since we can segment compilation rules to test rules and have different worker pools (in remote execution) for the different usage