### PR TITLE
Explicitly re-export symbols

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -1,7 +1,4 @@
-load("//scala:scala.bzl", _scala_binary = "scala_binary", _scala_library = "scala_library")
-
-scala_library = _scala_library
-scala_binary = _scala_binary
+load("//scala:scala.bzl", "scala_binary", "scala_library")
 
 def jmh_repositories():
     native.maven_jar(

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -1,4 +1,7 @@
-load("//scala:scala.bzl", "scala_binary", "scala_library")
+load("//scala:scala.bzl", _scala_binary = "scala_binary", _scala_library = "scala_library")
+
+scala_library = _scala_library
+scala_binary = _scala_binary
 
 def jmh_repositories():
     native.maven_jar(

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,4 +1,5 @@
-load("//jmh:jmh.bzl", "scala_library", "scala_benchmark_jmh")
+load("//scala:scala.bzl", "scala_library")
+load("//jmh:jmh.bzl", "scala_benchmark_jmh")
 
 java_library(
     name = "java_type",


### PR DESCRIPTION
This is needed for a future change in Bazel
(`--incompatible_no_transitive_loads`).

Tested:
  `bazel test //scala:all //test/... --all_incompatible_changes --incompatible_disallow_legacy_javainfo=false --incompatible_disable_deprecated_attr_params=false`