### PR TITLE
Fix transitive thrift symbol resolution in IntelliJ

### DIFF
--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -312,7 +312,7 @@ def _scrooge_aspect_impl(target, ctx):
 
         src_jars = depset([scrooge_file])
         output = _compiled_jar_file(ctx.actions, scrooge_file)
-        outs = depset([output])
+        outs = depset([output], transitive = [d[ScroogeAspectInfo].output_files for d in ctx.rule.attr.deps])
         java_info = _compile_scala(
             ctx,
             target.label,
@@ -325,7 +325,7 @@ def _scrooge_aspect_impl(target, ctx):
     else:
         # this target is only an aggregation target
         src_jars = depset()
-        outs = depset()
+        outs = depset(transitive = [d[ScroogeAspectInfo].output_files for d in ctx.rule.attr.deps])
         java_info = _empty_java_info(deps, imps)
 
     return [
@@ -412,10 +412,10 @@ def _create_scala_struct(ctx):
     output_jars = []
 
     for dep in ctx.attr.deps:
-        for j in dep[ScroogeAspectInfo].java_info.outputs.jars:
+        for j in dep[ScroogeAspectInfo].output_files:
             output_jars.append(
                 struct(
-                    class_jar = j.class_jar,
+                    class_jar = j,
                     ijar = None,
                     source_jar = None,
                     source_jars = [],


### PR DESCRIPTION
Currently, given the following build file structure:

scrooge_scala_library -> thrift_library -> thrift_library -> thrift_library -> ...

where "A -> B" means "A depends on B."

Only symbols in the leftmost `thrift_library` will resolve in IJ. This is because when the compiled scrooge jars are gathered up, transitive jars are not gathered. This fixes this behavior by adding transitive jars to the `ScroogeAspectInfo.output_files` depset.

I'm not sure the best way to test this. I've manually run this over some internal Stripe repos. Are there unit tests you can point me to? The last time I tried to add tests to the IJ plugin project I didn't get a response: https://github.com/bazelbuild/intellij/pull/366