### PR TITLE
Add blacklisted_protos to scala_proto_srcjar

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,16 +91,14 @@ maven_jar(
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "118ac276be0db540ff2a89cecc5dfb9606d4d16e91cc4ea8883ae8160acb5163",
-    strip_prefix = "protobuf-0456e269ee6505766474aa8d7b8bba7ac047f457",
-    urls = ["https://github.com/google/protobuf/archive/0456e269ee6505766474aa8d7b8bba7ac047f457.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
+    strip_prefix = "protobuf-3.6.1.3",
 )
 
 http_archive(
     name = "com_google_protobuf_java",
-    sha256 = "118ac276be0db540ff2a89cecc5dfb9606d4d16e91cc4ea8883ae8160acb5163",
-    strip_prefix = "protobuf-0456e269ee6505766474aa8d7b8bba7ac047f457",
-    urls = ["https://github.com/google/protobuf/archive/0456e269ee6505766474aa8d7b8bba7ac047f457.zip"],
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
+    strip_prefix = "protobuf-3.6.1.3",
 )
 
 new_local_repository(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -91,12 +91,14 @@ maven_jar(
 
 http_archive(
     name = "com_google_protobuf",
+    sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
     strip_prefix = "protobuf-3.6.1.3",
 )
 
 http_archive(
     name = "com_google_protobuf_java",
+    sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
     urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
     strip_prefix = "protobuf-3.6.1.3",
 )

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -386,6 +386,11 @@ def _colon_paths(data):
         for f in sorted(data)
     ])
 
+def _retained_protos(inputs, blacklisted_proto_targets):
+    blacklisted_protos = [dep for target in blacklisted_proto_targets for dep in target.proto.transitive_sources]
+    blacklisted_protos_dict = dict(zip(blacklisted_protos, blacklisted_protos))
+    return [f for f in inputs if blacklisted_protos_dict.get(f, None) == None]
+
 def _gen_proto_srcjar_impl(ctx):
     acc_imports = []
     transitive_proto_paths = []
@@ -406,10 +411,6 @@ def _gen_proto_srcjar_impl(ctx):
 
     deps_jars = collect_jars(jvm_deps)
 
-    blacklisted_protos = [dep for target in ctx.attr.blacklisted_protos for dep in target.proto.transitive_sources]
-    blacklisted_protos_dict = dict(zip(blacklisted_protos, blacklisted_protos))
-    inputs = [f.path for f in sorted(acc_imports) if blacklisted_protos_dict.get(f, None) == None]
-
     worker_content = "{output}\n{paths}\n{flags_arg}\n{packages}\n{inputs}".format(
         output = ctx.outputs.srcjar.path,
         paths = _colon_paths(acc_imports.to_list()),
@@ -418,7 +419,8 @@ def _gen_proto_srcjar_impl(ctx):
         # Command line args to worker cannot be empty so using padding
         packages = "-" +
                    ":".join(depset(transitive = transitive_proto_paths).to_list()),
-        inputs = ":".join(inputs)
+        # Pass inputs seprately because they doesn't always match to imports (ie blacklisted protos are excluded)
+        inputs = ":".join(sorted([f.path for f in _retained_protos(acc_imports, ctx.attr.blacklisted_protos)]))
     )
     argfile = ctx.actions.declare_file(
         "%s_worker_input" % ctx.label.name,

--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -26,7 +26,7 @@ object PBGenerateRequest {
     val imports = parsedProtoFiles.map { case (relPath, absolutePath) =>
       s"-I$relPath=$absolutePath"
     }
-    val protoFiles = parsedProtoFiles.map(_._2)
+    val protoFiles = args.get(4).split(':')
     val flagOpt = args.get(2) match {
       case "-" => None
       case s if s.charAt(0) == '-' => Some(s.tail) //drop padding character

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -1,6 +1,12 @@
 load(
     "//scala_proto:scala_proto.bzl",
     "scalapb_proto_library",
+    "scala_proto_srcjar"
+)
+
+load(
+    "//scala:scala.bzl",
+    "scala_library",
 )
 
 proto_library(
@@ -60,3 +66,24 @@ scalapb_proto_library(
     with_grpc = True,
     deps = [":test_service"],
 )
+
+scala_proto_srcjar(
+    name = "test1_proto_scala",
+    deps = ["//test/proto2:test"],
+    generator = "@io_bazel_rules_scala//src/scala/scripts:scalapb_generator")
+
+scala_proto_srcjar(
+    name = "test2_proto_scala",
+    deps = [":test2"],
+    blacklisted_protos = ["//test/proto2:test"],
+    generator = "@io_bazel_rules_scala//src/scala/scripts:scalapb_generator")
+
+scala_library(
+    name = "lib_scala",
+    srcs = [
+        ":test1_proto_scala",
+        ":test2_proto_scala"],
+    deps = [
+        "@com_google_protobuf//:protobuf_java",
+        "@scala_proto_rules_scalapb_lenses",
+        "@scala_proto_rules_scalapb_runtime"])

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -73,16 +73,16 @@ scala_proto_srcjar(
     generator = "@io_bazel_rules_scala//src/scala/scripts:scalapb_generator")
 
 scala_proto_srcjar(
-    name = "test2_proto_scala",
+    name = "test2_proto_scala_with_blacklisted_test1_proto_scala",
     deps = [":test2"],
     blacklisted_protos = ["//test/proto2:test"],
     generator = "@io_bazel_rules_scala//src/scala/scripts:scalapb_generator")
 
 scala_library(
-    name = "lib_scala",
+    name = "lib_scala_should_fail_on_duplicated_sources_unless_duplicates_are_blacklisted",
     srcs = [
         ":test1_proto_scala",
-        ":test2_proto_scala"],
+        ":test2_proto_scala_with_blacklisted_test1_proto_scala"],
     deps = [
         "@com_google_protobuf//:protobuf_java",
         "@scala_proto_rules_scalapb_lenses",


### PR DESCRIPTION
Resolves https://github.com/bazelbuild/rules_scala/issues/665

Had to change `com_google_protobuf` and `com_google_protobuf_java` targets in a WORKSPACE otherwise I couldn't run `bazel test //test/...`