### PR TITLE
Prevent test runner hang in case of exception thrown from specs2

### DIFF
--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -40,7 +40,9 @@ class Specs2PrefixSuffixTestDiscoveringSuite(suite: Class[Any], runnerBuilder: R
       .collect {
         case r: FilteredSpecs2ClassRunner if r.matchesFilter => Some(new SafeSpecs2Runner(r))
         case _: FilteredSpecs2ClassRunner => None
-        case other => Some(new SafeSpecs2Runner(other).asInstanceOf[Runner])
+        case other =>
+          val runner: Runner = new SafeSpecs2Runner(other)
+          Some(runner)
       }.flatten.asJava
   }
 }


### PR DESCRIPTION
This gracefully shuts down specs2 in case of an exception thrown from initialization. This fixes the bazel runner hanging indefinitely.