### PR TITLE
Fix duplicate key error with ignored unused dependencies on scala junit tests

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -569,7 +569,8 @@ def scala_specs2_junit_test(name, **kwargs):
     scala_junit_test(
         name = name,
         deps = _specs2_junit_dependencies() + kwargs.pop("deps", []),
-        unused_dependency_checker_ignored_targets = _specs2_junit_dependencies(),
+        unused_dependency_checker_ignored_targets =
+            _specs2_junit_dependencies() + kwargs.pop("unused_dependency_checker_ignored_targets", []),
         suite_label = Label(
             "//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery",
         ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -381,6 +381,19 @@ scala_specs2_junit_test(
     deps = [":JUnitCompileTimeDep"],
 )
 
+scala_specs2_junit_test(
+    name = "Specs2Tests_unused_dependency_checker",
+    size = "small",
+    srcs = ["src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala"],
+    unused_dependency_checker_mode = "error",
+    unused_dependency_checker_ignored_targets = [":JUnitRuntimeDep"],
+    suffixes = ["Test"],
+    deps = [
+        ":JUnitCompileTimeDep",
+        ":JUnitRuntimeDep",
+    ],
+)
+
 # Make sure scala_binary works in test environment
 [sh_test(
     name = "Run" + "".join([binary[idx] if binary[idx].isalnum() else "_" for idx in range(len(binary))]),


### PR DESCRIPTION
If you add `unused_dependency_checker_ignored_targets ` to your scala junit test target, analysis fails with message: 
```
duplicate keyword 'unused_dependency_checker_ignored_targets' in call to scala_junit_test
```
This PR fixes that by merging the ignored targets provided on the target with `_specs2_junit_dependencies`.