### PR TITLE
Add targets that reproduce proto issues in 0.22.0 (and maybe earlier)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,10 @@ env:
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
   - V=0.17.1 TEST_SCRIPT=test_rules_scala.sh
-  - V=0.21.0 TEST_SCRIPT=test_rules_scala.sh
+  - V=0.22.0 TEST_SCRIPT=test_rules_scala.sh
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.17.1 TEST_SCRIPT=test_reproducibility.sh
-  - V=0.21.0 TEST_SCRIPT=test_reproducibility.sh
+  - V=0.22.0 TEST_SCRIPT=test_reproducibility.sh
 
 before_install:
   - |

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -391,13 +391,23 @@ def _retained_protos(inputs, blacklisted_proto_targets):
     blacklisted_protos_dict = dict(zip(blacklisted_protos, blacklisted_protos))
     return [f for f in inputs if blacklisted_protos_dict.get(f, None) == None]
 
+def _valid_proto_paths(transitive_proto_path):
+    """Build a list of valid paths to build the --proto_path arguments for the ScalaPB protobuf compiler
+    In particular, the '.' path needs to be stripped out. This mirrors a fix in the java proto rules:
+    https://github.com/bazelbuild/bazel/commit/af3605862047f7b553b7d2c19fa645714ea19bcf
+    This is explained in this issue: https://github.com/bazelbuild/rules_scala/issues/687
+    """
+    return depset([path for path in transitive_proto_path if path != "."])
+
 def _gen_proto_srcjar_impl(ctx):
     acc_imports = []
+    transitive_proto_paths = []
 
     jvm_deps = []
     for target in ctx.attr.deps:
         if hasattr(target, "proto"):
             acc_imports.append(target.proto.transitive_sources)
+            transitive_proto_paths.append(_valid_proto_paths(target.proto.transitive_proto_path))
         else:
             jvm_deps.append(target)
 
@@ -415,7 +425,8 @@ def _gen_proto_srcjar_impl(ctx):
         # Command line args to worker cannot be empty so using padding
         flags_arg = "-" + ",".join(ctx.attr.flags),
         # Command line args to worker cannot be empty so using padding
-        packages = "-",
+        packages = "-" +
+                   ":".join(depset(transitive = transitive_proto_paths).to_list()),
         # Pass inputs seprately because they doesn't always match to imports (ie blacklisted protos are excluded)
         inputs = ":".join(sorted([f.path for f in _retained_protos(acc_imports, ctx.attr.blacklisted_protos)]))
     )

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -393,13 +393,11 @@ def _retained_protos(inputs, blacklisted_proto_targets):
 
 def _gen_proto_srcjar_impl(ctx):
     acc_imports = []
-    transitive_proto_paths = []
 
     jvm_deps = []
     for target in ctx.attr.deps:
         if hasattr(target, "proto"):
             acc_imports.append(target.proto.transitive_sources)
-            transitive_proto_paths.append(target.proto.transitive_proto_path)
         else:
             jvm_deps.append(target)
 
@@ -417,8 +415,7 @@ def _gen_proto_srcjar_impl(ctx):
         # Command line args to worker cannot be empty so using padding
         flags_arg = "-" + ",".join(ctx.attr.flags),
         # Command line args to worker cannot be empty so using padding
-        packages = "-" +
-                   ":".join(depset(transitive = transitive_proto_paths).to_list()),
+        packages = "-",
         # Pass inputs seprately because they doesn't always match to imports (ie blacklisted protos are excluded)
         inputs = ":".join(sorted([f.path for f in _retained_protos(acc_imports, ctx.attr.blacklisted_protos)]))
     )

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -24,6 +24,21 @@ proto_library(
 )
 
 proto_library(
+    name = "test_external_dep_proto",
+    srcs = ["test_external_dep.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+scalapb_proto_library(
+    name = "test_external_dep",
+    visibility = ["//visibility:public"],
+    deps = [":test_external_dep_proto"],
+)
+
+proto_library(
     name = "test_service",
     srcs = ["test_service.proto"],
     visibility = ["//visibility:public"],

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -38,6 +38,20 @@ scalapb_proto_library(
     deps = [":test_external_dep_proto"],
 )
 
+# Test that the `proto_source_root` attribute is handled properly
+proto_library(
+    name = "proto_source_root",
+    proto_source_root = native.package_name(),
+    srcs = ["different_root.proto", "different_root2.proto"],
+    visibility = ["//visibility:public"],
+)
+
+scalapb_proto_library(
+    name = "test_proto_source_root",
+    visibility = ["//visibility:public"],
+    deps = [":proto_source_root"],
+)
+
 proto_library(
     name = "test_service",
     srcs = ["test_service.proto"],

--- a/test/proto/different_root.proto
+++ b/test/proto/different_root.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "different_root2.proto";
+
+message TestMessage {
+    TestMessage2 message = 1;
+}

--- a/test/proto/different_root2.proto
+++ b/test/proto/different_root2.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message TestMessage2 {
+    string message = 1;
+}

--- a/test/proto/test_external_dep.proto
+++ b/test/proto/test_external_dep.proto
@@ -1,0 +1,7 @@
+syntax = "proto3";
+
+import "google/protobuf/wrappers.proto";
+
+message TestMessage {
+    string message = 1;
+}


### PR DESCRIPTION
This reproduces an issue in bazel 0.22.0 that breaks `scalapb_proto_library`. Issue to follow.

It's expected that the build will fail.