### PR TITLE
Fix root path for generated proto files

### DIFF
--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -14,7 +14,7 @@ object PBGenerateRequest {
       val file = if (root.isEmpty) {
         parsed(1)
       } else {
-        parsed(1).substring(root.length + 1)
+        parsed(1).substring(root.length).stripPrefix("/")
       }
       (file, Paths.get(root, file).toString)
     }

--- a/test/proto3/BUILD
+++ b/test/proto3/BUILD
@@ -1,0 +1,23 @@
+load(
+    "//scala_proto:scala_proto.bzl",
+    "scalapb_proto_library",
+)
+
+genrule(
+    name = "generated",
+    srcs = ["test.proto"],
+    outs = ["generated.proto"],
+    cmd = "cp $(SRCS) \"$@\""
+)
+
+proto_library(
+    name = "generated-proto-lib",
+    srcs = [":generated"],
+    visibility = ["//visibility:public"],
+)
+
+scalapb_proto_library(
+    name = "test_generated_proto",
+    visibility = ["//visibility:public"],
+    deps = [":generated-proto-lib"],
+)

--- a/test/proto3/test.proto
+++ b/test/proto3/test.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+option java_package = "test.proto";
+
+message TestRequest {
+  optional uint32 a = 1;
+  optional bool b = 2;
+}
+
+message TestMessage {
+  optional string foo = 1;
+}


### PR DESCRIPTION
The owner's workspace_root for proto files that are generated by a
genrule is empty. This means that the root path ends with a trailing
slash. PBGenerateRequest expects the root path to not end in a slash
and removes an additional character (see line 17) which is the expected
path separator after the workspace_root component of the path.
For generated files, this means that the first character of the proto
file path is cut off, and thus the scalapb compiler cannot read the
file.