### PR TITLE
use the JAVA_BIN environmental variable to allow overriding the jdk at runtime

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -553,8 +553,8 @@ def _write_java_wrapper(ctx, args = "", wrapper_preamble = ""):
         content = """#!/usr/bin/env bash
 {preamble}
 DEFAULT_JAVABIN={javabin}
-JAVABIN=${{JAVABIN:-$DEFAULT_JAVABIN}}
-{exec_str}$JAVABIN "$@" {args}
+JAVA_EXEC_TO_USE=${{REAL_EXTERNAL_JAVA_BIN:-$DEFAULT_JAVABIN}}
+{exec_str}$JAVA_EXEC_TO_USE "$@" {args}
 """.format(
             preamble = wrapper_preamble,
             exec_str = exec_str,
@@ -582,7 +582,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper):
         substitutions = {
             "%classpath%": classpath,
             "%java_start_class%": main_class,
-            "%javabin%": "JAVABIN=%s/%s" % (
+            "%javabin%": "export REAL_EXTERNAL_JAVA_BIN=${JAVABIN};JAVABIN=%s/%s" % (
                 _runfiles_root(ctx),
                 wrapper.short_path,
             ),

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -552,8 +552,9 @@ def _write_java_wrapper(ctx, args = "", wrapper_preamble = ""):
         output = wrapper,
         content = """#!/usr/bin/env bash
 {preamble}
-
-{exec_str}{javabin} "$@" {args}
+DEFAULT_JAVABIN={javabin}
+JAVABIN=${{JAVABIN:-$DEFAULT_JAVABIN}}
+{exec_str}$JAVABIN "$@" {args}
 """.format(
             preamble = wrapper_preamble,
             exec_str = exec_str,

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -42,6 +42,11 @@ test_transitive_deps() {
   exit 0
 }
 
+test_override_javabin() {
+  # set the JAVABIN to nonsense
+  JAVABIN=/etc/basdf action_should_fail run test:ScalaBinary
+}
+
 test_scala_library_suite() {
   action_should_fail build test_expect_failure/scala_library_suite:library_suite_dep_on_children
 }
@@ -788,21 +793,21 @@ test_unused_dependency_checker_mode_warn() {
   bazel build \
     --strict_java_deps=warn \
     //test:UnusedDependencyCheckerWarn
-    
+
   local output
   output=$(bazel build \
     --strict_java_deps=off \
     //test:UnusedDependencyCheckerWarn 2>&1
   )
-  
+
   if [ $? -ne 0 ]; then
     echo "Target with unused dependency failed to build with status $?"
     echo "$output"
     exit 1
   fi
-  
+
   local expected="warning: Target '//test:UnusedLib' is specified as a dependency to //test:UnusedDependencyCheckerWarn but isn't used, please remove it from the deps."
-  
+
   echo "$output" | grep "$expected"
   if [ $? -ne 0 ]; then
     echo "Expected output:[$output] to contain [$expected]"
@@ -991,3 +996,4 @@ $runner test_scala_import_source_jar_should_be_fetched_when_fetch_sources_is_set
 $runner test_scala_import_source_jar_should_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_true
 $runner test_scala_import_source_jar_should_not_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_non_true
 $runner test_unused_dependency_checker_mode_warn
+$runner test_override_javabin

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -261,7 +261,7 @@ action_should_fail() {
   # runs the tests locally
   set +e
   TEST_ARG=$@
-  $(bazel $TEST_ARG)
+  DUMMY=$(bazel $TEST_ARG)
   RESPONSE_CODE=$?
   if [ $RESPONSE_CODE -eq 0 ]; then
     echo -e "${RED} \"bazel $TEST_ARG\" should have failed but passed. $NC"


### PR DESCRIPTION
Similar to the java_binary script we should allow users to override the version of java based on the environment rather than using the runfiles version.



