### PR TITLE
wip - generate service provider configuration for `scala_library` targets

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -125,14 +125,9 @@ _common_attrs_for_plugin_bootstrapping = {
     "jvm_flags": attr.string_list(),
     "scalac_jvm_flags": attr.string_list(),
     "javac_jvm_flags": attr.string_list(),
-    "expect_java_output": attr.bool(
-        default = True,
-        mandatory = False,
-    ),
-    "print_compile_time": attr.bool(
-        default = False,
-        mandatory = False,
-    ),
+    "expect_java_output": attr.bool(default = True, mandatory = False),
+    "print_compile_time": attr.bool(default = False, mandatory = False),
+    "services": attr.string_list_dict(),
 }
 
 _common_attrs = {}

--- a/test/BUILD
+++ b/test/BUILD
@@ -588,6 +588,13 @@ scala_library(
     deps = ["//test/proto:test_proto"],
 )
 
+scala_library(
+    name = "lib_with_scala_services",
+    srcs = ["TestServer.scala"],
+    deps = ["//test/proto:test_proto"],
+    services = {"com.scala.test.service": ["com.scala.test.Service1","com.scala.test.Service2",],}
+)
+
 scala_binary(
     name = "test_scala_proto_server",
     main_class = "test.proto.TestServer",

--- a/test/example_jars/expected_services.txt
+++ b/test/example_jars/expected_services.txt
@@ -1,0 +1,2 @@
+com.scala.test.Service1
+com.scala.test.Service2

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -255,7 +255,17 @@ test_multi_service_manifest() {
   exit $RESPONSE_CODE
 }
 
-
+test_services() {
+  services_jar='lib_with_scala_services.jar'
+  services_file='META-INF/services/com.scala.test.service'
+  services_target="//test:lib_with_scala_services"
+  bazel build $services_target
+  unzip -p bazel-bin/test/$services_jar $services_file > services.txt
+  diff services.txt test/example_jars/expected_services.txt
+  RESPONSE_CODE=$?
+  rm services.txt
+  exit $RESPONSE_CODE
+}
 
 action_should_fail() {
   # runs the tests locally
@@ -1015,6 +1025,7 @@ $runner scala_junit_test_jar_is_exposed_in_build_event_protocol
 $runner test_scala_import_source_jar_should_be_fetched_when_fetch_sources_is_set_to_true
 $runner test_scala_import_source_jar_should_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_true
 $runner test_scala_import_source_jar_should_not_be_fetched_when_env_bazel_jvm_fetch_sources_is_set_to_non_true
+$runner test_services
 $runner test_unused_dependency_checker_mode_warn
 $runner test_override_javabin
 $runner test_compilation_succeeds_with_plus_one_deps_on


### PR DESCRIPTION
Add a `services` attribute to `scala_library` for this additional information. See #696 for details.