### PR TITLE
Ignore JMH in reproducibility tests

### DIFF
--- a/test_reproducibility.sh
+++ b/test_reproducibility.sh
@@ -16,6 +16,7 @@ non_deploy_jar_md5_sum() {
 }
 
 test_build_is_identical() {
+    printf "\\n/test/jmh\\n" >> .bazelignore
     bazel build test/...
     non_deploy_jar_md5_sum > hash1
     bazel clean

--- a/test_reproducibility.sh
+++ b/test_reproducibility.sh
@@ -16,6 +16,8 @@ non_deploy_jar_md5_sum() {
 }
 
 test_build_is_identical() {
+    cp .bazelignore .bazelignore.bak
+    trap 'mv .bazelignore.bak .bazelignore' EXIT
     printf "\\n/test/jmh\\n" >> .bazelignore
     bazel build test/...
     non_deploy_jar_md5_sum > hash1


### PR DESCRIPTION
Uses .bazelignore to ignore the JMH paths during the reproducibility test.

This solution was quick and easy. Alternatively, you could perhaps filter targets by tags (and add tags on the jmh targets).