### PR TITLE
Reuse @com_google_protobuf//:protoc when generating scala from proto

### DIFF
--- a/src/scala/scripts/BUILD
+++ b/src/scala/scripts/BUILD
@@ -37,7 +37,6 @@ scala_library(
     ],
     deps = [
         ":scala_proto_request_extractor",
-        "//external:io_bazel_rules_scala/dependency/proto/protoc",
         "//external:io_bazel_rules_scala/dependency/proto/protoc_bridge",
         "//external:io_bazel_rules_scala/dependency/proto/scalapb_plugin",
         "//external:io_bazel_rules_scala/dependency/proto/scalapbc",

--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -2,7 +2,7 @@ package scripts
 
 import java.nio.file.{Files, Path, Paths}
 
-class PBGenerateRequest(val jarOutput: String, val scalaPBOutput: Path, val scalaPBArgs: List[String], val protoc: String)
+class PBGenerateRequest(val jarOutput: String, val scalaPBOutput: Path, val scalaPBArgs: List[String], val protoc: Path)
 
 object PBGenerateRequest {
 
@@ -42,7 +42,7 @@ object PBGenerateRequest {
     val scalaPBOutput = Files.createTempDirectory(tmp, "bazelscalapb")
     val flagPrefix = flagOpt.fold("")(_ + ":")
     val scalaPBArgs = s"--scala_out=$flagPrefix$scalaPBOutput" :: (padWithProtoPathPrefix(transitiveProtoPaths) ++ imports ++ protoFiles)
-    val protoc = args.get(5)
+    val protoc = Paths.get(args.get(5))
     new PBGenerateRequest(jarOutput, scalaPBOutput, scalaPBArgs, protoc)
   }
 

--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -2,7 +2,7 @@ package scripts
 
 import java.nio.file.{Files, Path, Paths}
 
-class PBGenerateRequest(val jarOutput: String, val scalaPBOutput: Path, val scalaPBArgs: List[String])
+class PBGenerateRequest(val jarOutput: String, val scalaPBOutput: Path, val scalaPBArgs: List[String], val protoc: String)
 
 object PBGenerateRequest {
 
@@ -42,7 +42,8 @@ object PBGenerateRequest {
     val scalaPBOutput = Files.createTempDirectory(tmp, "bazelscalapb")
     val flagPrefix = flagOpt.fold("")(_ + ":")
     val scalaPBArgs = s"--scala_out=$flagPrefix$scalaPBOutput" :: (padWithProtoPathPrefix(transitiveProtoPaths) ++ imports ++ protoFiles)
-    new PBGenerateRequest(jarOutput, scalaPBOutput, scalaPBArgs)
+    val protoc = args.get(5)
+    new PBGenerateRequest(jarOutput, scalaPBOutput, scalaPBArgs, protoc)
   }
 
   private def padWithProtoPathPrefix(transitiveProtoPathFlags: List[String]) =

--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -56,6 +56,6 @@ class ScalaPBGenerator extends Processor {
     }
   }
 
-  private def exec(protoc: String): Seq[String] => Int = (args: Seq[String]) =>
-    new ProcessBuilder(protoc +: args: _*).inheritIO().start().waitFor()
+  private def exec(protoc: Path): Seq[String] => Int = (args: Seq[String]) =>
+    new ProcessBuilder(protoc.toString +: args: _*).inheritIO().start().waitFor()
 }

--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -3,12 +3,11 @@ package scripts
 import java.io.PrintStream
 import java.nio.file.Path
 
-import com.trueaccord.scalapb.{ScalaPBC, ScalaPbcException}
 import io.bazel.rulesscala.io_utils.DeleteRecursively
 import io.bazel.rulesscala.jar.JarCreator
 import io.bazel.rulesscala.worker.{GenericWorker, Processor}
 import protocbridge.ProtocBridge
-import scalapb.ScalaPbCodeGenerator
+import scalapb.{ScalaPBC, ScalaPbCodeGenerator, ScalaPbcException}
 
 object ScalaPBWorker extends GenericWorker(new ScalaPBGenerator) {
 


### PR DESCRIPTION
Remove `protoc-jar` which brings own versions of `protoc`