### PR TITLE
Unify protobuf-java versions

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -97,13 +97,6 @@ http_archive(
     strip_prefix = "protobuf-3.6.1.3",
 )
 
-http_archive(
-    name = "com_google_protobuf_java",
-    sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
-    strip_prefix = "protobuf-3.6.1.3",
-)
-
 new_local_repository(
     name = "test_new_local_repo",
     build_file_content =

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -441,14 +441,6 @@ def scala_repositories(
         server_urls = maven_servers,
     )
 
-    _scala_maven_import_external(
-        name = "scalac_rules_protobuf_java",
-        artifact = "com.google.protobuf:protobuf-java:3.1.0",
-        jar_sha256 = "8d7ec605ca105747653e002bfe67bddba90ab964da697aaa5daa1060923585db",
-        licenses = ["notice"],
-        server_urls = maven_servers,
-    )
-
     # used by ScalacProcessor
     _scala_maven_import_external(
         name = "scalac_rules_commons_io",
@@ -478,7 +470,7 @@ def scala_repositories(
 
     native.bind(
         name = "io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
-        actual = "@scalac_rules_protobuf_java//jar",
+        actual = "@com_google_protobuf//:protobuf_java",
     )
 
     native.bind(

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -37,7 +37,7 @@ scala_register_unused_deps_toolchains()
 
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "118ac276be0db540ff2a89cecc5dfb9606d4d16e91cc4ea8883ae8160acb5163",
-    strip_prefix = "protobuf-0456e269ee6505766474aa8d7b8bba7ac047f457",
-    urls = ["https://github.com/google/protobuf/archive/0456e269ee6505766474aa8d7b8bba7ac047f457.zip"],
+    sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
+    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
+    strip_prefix = "protobuf-3.6.1.3",
 )


### PR DESCRIPTION
Looks like there are two versions of `protobuf-java`. One comes from `@com_google_protobuf//:protobuf_java` version `3.6.1.3` and another one from `_scala_maven_import_external` version `3.1.0`. There are warnings which comes from `protobuf-java 3.1.0` although `3.6.1.3` should be used.