### PR TITLE
Windows support

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -67,6 +67,11 @@ _implicit_deps = {
             "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac",
         ),
     ),
+    "_exe": attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/exe:exe"),
+    ),
 }
 
 # Single dep to allow IDEs to pickup all the implicit dependencies.
@@ -473,6 +478,14 @@ def scala_repositories(
     )
 
     _scala_maven_import_external(
+        name = "io_bazel_rules_scala_guava",
+        artifact = "com.google.guava:guava:21.0",
+        jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+        licenses = ["notice"],
+        server_urls = maven_servers,
+    )
+
+    _scala_maven_import_external(
         name = "io_bazel_rules_scala_org_jacoco_org_jacoco_core",
         artifact = "org.jacoco:org.jacoco.core:0.7.5.201505241946",
         jar_sha256 = "ecf1ad8192926438d0748bfcc3f09bebc7387d2a4184bb3a171a26084677e808",
@@ -487,7 +500,7 @@ def scala_repositories(
         licenses = ["notice"],
         server_urls = maven_servers,
     )
-    
+
     # Using this and not the bazel regular one due to issue when classpath is too long
     # until https://github.com/bazelbuild/bazel/issues/6955 is resolved
     if native.existing_rule("java_stub_template") == None:
@@ -536,6 +549,11 @@ def scala_repositories(
     native.bind(
         name = "io_bazel_rules_scala/dependency/scala/parser_combinators",
         actual = "@io_bazel_rules_scala_scala_parser_combinators",
+    )
+
+    native.bind(
+        name = "io_bazel_rules_scala/dependency/scala/guava",
+        actual = "@io_bazel_rules_scala_guava",
     )
 
 def _sanitize_string_for_usage(s):

--- a/src/java/io/bazel/rulesscala/exe/BUILD
+++ b/src/java/io/bazel/rulesscala/exe/BUILD
@@ -1,0 +1,24 @@
+java_library(
+    name = "exe-lib",
+    srcs = [
+        "LauncherFileWriter.java",
+        "LaunchInfo.java",
+    ],
+    deps = [
+        "@bazel_tools//tools/java/runfiles:runfiles",
+        "//external:io_bazel_rules_scala/dependency/scala/guava",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+java_binary(
+    name = "exe",
+    main_class = "io.bazel.rulesscala.exe.LauncherFileWriter",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        ":exe-lib",
+    ],
+    data = [
+        "@bazel_tools//tools/launcher:launcher",
+    ],
+)

--- a/src/java/io/bazel/rulesscala/exe/LaunchInfo.java
+++ b/src/java/io/bazel/rulesscala/exe/LaunchInfo.java
@@ -1,0 +1,170 @@
+// Copyright 2017 The Bazel Authors. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package io.bazel.rulesscala.exe;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+
+
+/**
+ * Metadata that describes the payload of the native launcher binary.
+ *
+ * <p>This object constructs the binary metadata lazily, to save memory.
+ */
+public final class LaunchInfo {
+
+  private final ImmutableList<Entry> entries;
+
+  private LaunchInfo(ImmutableList<Entry> entries) {
+    this.entries = entries;
+  }
+
+  /** Creates a new {@link Builder}. */
+  public static Builder builder() {
+    return new Builder();
+  }
+
+  /** Writes this object's entries to {@code out}, returns the total written amount in bytes. */
+  @VisibleForTesting
+  long write(OutputStream out) throws IOException {
+    long len = 0;
+    for (Entry e : entries) {
+      len += e.write(out);
+      out.write('\0');
+      ++len;
+    }
+    return len;
+  }
+
+  /** Writes {@code s} to {@code out} encoded as UTF-8, returns the written length in bytes. */
+  private static long writeString(String s, OutputStream out) throws IOException {
+    byte[] b = s.getBytes(StandardCharsets.UTF_8);
+    out.write(b);
+    return b.length;
+  }
+
+  /** Represents one entry in {@link LaunchInfo.entries}. */
+  private static interface Entry {
+    /** Writes this entry to {@code out}, returns the written length in bytes. */
+    long write(OutputStream out) throws IOException;
+  }
+
+  /** A key-value pair entry. */
+  private static final class KeyValuePair implements Entry {
+    private final String key;
+    private final String value;
+
+    public KeyValuePair(String key, String value) {
+      this.key = Preconditions.checkNotNull(key);
+      this.value = value;
+    }
+
+    @Override
+    public long write(OutputStream out) throws IOException {
+      long len = writeString(key, out);
+      len += writeString("=", out);
+      if (value != null && !value.isEmpty()) {
+        len += writeString(value, out);
+      }
+      return len;
+    }
+  }
+
+  /** A pair of a key and a delimiter-joined list of values. */
+  private static final class JoinedValues implements Entry {
+    private final String key;
+    private final String delimiter;
+    private final Iterable<String> values;
+
+    public JoinedValues(String key, String delimiter, Iterable<String> values) {
+      this.key = Preconditions.checkNotNull(key);
+      this.delimiter = Preconditions.checkNotNull(delimiter);
+      this.values = values;
+    }
+
+    @Override
+    public long write(OutputStream out) throws IOException {
+      long len = writeString(key, out);
+      len += writeString("=", out);
+      if (values != null) {
+        boolean first = true;
+        for (String v : values) {
+          if (first) {
+            first = false;
+          } else {
+            len += writeString(delimiter, out);
+          }
+          len += writeString(v, out);
+        }
+      }
+      return len;
+    }
+  }
+
+  /** Builder for {@link LaunchInfo} instances. */
+  public static final class Builder {
+    private ImmutableList.Builder<Entry> entries = ImmutableList.builder();
+
+    /** Builds a {@link LaunchInfo} from this builder. This builder may be reused. */
+    public LaunchInfo build() {
+      return new LaunchInfo(entries.build());
+    }
+
+    /**
+     * Adds a key-value pair entry.
+     *
+     * <p>Examples:
+     *
+     * <ul>
+     *   <li>{@code key} is "foo" and {@code value} is "bar", the written value is "foo=bar\0"
+     *   <li>{@code key} is "foo" and {@code value} is null or empty, the written value is
+     *       "foo=\0"
+     * </ul>
+     */
+    public Builder addKeyValuePair(String key, String value) {
+      Preconditions.checkNotNull(key);
+      if (!key.isEmpty()) {
+        entries.add(new KeyValuePair(key, value));
+      }
+      return this;
+    }
+
+    /**
+     * Adds a key and list of lazily-joined values.
+     *
+     * <p>Examples:
+     *
+     * <ul>
+     *   <li>{@code key} is "foo", {@code delimiter} is ";", {@code values} is ["bar", "baz",
+     *       "qux"], the written value is "foo=bar;baz;qux\0"
+     *   <li>{@code key} is "foo", {@code delimiter} is irrelevant, {@code value} is null or
+     *       empty, the written value is "foo=\0"
+     * </ul>
+     */
+    public Builder addJoinedValues(
+        String key, String delimiter, Iterable<String> values) {
+      Preconditions.checkNotNull(key);
+      Preconditions.checkNotNull(delimiter);
+      if (!key.isEmpty()) {
+        entries.add(new JoinedValues(key, delimiter, values));
+      }
+      return this;
+    }
+  }
+}

--- a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+++ b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
@@ -1,0 +1,56 @@
+package io.bazel.rulesscala.exe;
+
+import com.google.common.base.Preconditions;
+import com.google.common.io.ByteStreams;
+import com.google.devtools.build.runfiles.Runfiles;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import java.nio.file.*;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.util.Arrays;
+import java.util.List;
+
+
+public class LauncherFileWriter {
+  public static void main(String[] args) throws IOException {
+    Preconditions.checkArgument(args.length == 6);
+
+    final String location = args[0];
+    final String workspaceName = args[1];
+    final String javaBinPath = args[2];
+    final String jarBinPath = javaBinPath.substring(0, javaBinPath.lastIndexOf('/')) + "/jar.exe";
+    final String javaStartClass = args[3];
+    final String classpath = args[4];
+    final List<String> jvmFlags = Arrays.asList(args[5].split(";"));
+
+    LaunchInfo launchInfo =
+        LaunchInfo.builder()
+            .addKeyValuePair("binary_type", "Java")
+            .addKeyValuePair("workspace_name", workspaceName)
+            .addKeyValuePair("symlink_runfiles_enabled", "0")
+            .addKeyValuePair("java_bin_path", javaBinPath)
+            .addKeyValuePair("jar_bin_path", jarBinPath)
+            .addKeyValuePair("java_start_class", javaStartClass)
+            .addKeyValuePair("classpath", classpath)
+            .addJoinedValues("jvm_flags", " ", jvmFlags)
+            .build();
+
+    Path launcher = Paths.get(Runfiles.create().rlocation("bazel_tools/tools/launcher/launcher.exe"));
+    Path outPath = Paths.get(location);
+
+    try (InputStream in = Files.newInputStream(launcher); OutputStream out = Files.newOutputStream(outPath)) {
+      ByteStreams.copy(in, out);
+
+      long dataLength = launchInfo.write(out);
+      ByteBuffer buffer = ByteBuffer.allocate(Long.BYTES);
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
+      buffer.putLong(dataLength);
+      out.write(buffer.array());
+
+      out.flush();
+    }
+  }
+}

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -87,7 +87,11 @@ object BenchmarkGenerator {
   }
 
   private def collectClassesFromJar(root: Path): List[Path] = {
-    val uri = new URI("jar:file", null, root.toFile.getAbsolutePath, null)
+    val path = if (System.getProperty("os.name").toLowerCase().contains("windows"))
+      "/" + root.toFile.getAbsolutePath.replaceAll("\\\\", "/")
+    else
+      root.toFile.getAbsolutePath
+    val uri = new URI("jar:file", null, path, null)
     val fs = FileSystems.newFileSystem(uri, Map.empty[String, String].asJava)
     fs.getRootDirectories.asScala.toList.flatMap { rootDir =>
       listFilesRecursively(rootDir) { (path: Path) =>

--- a/third_party/unused_dependency_checker/src/main/io/bazel/rulesscala/unuseddependencychecker/UnusedDependencyChecker.scala
+++ b/third_party/unused_dependency_checker/src/main/io/bazel/rulesscala/unuseddependencychecker/UnusedDependencyChecker.scala
@@ -16,6 +16,8 @@ class UnusedDependencyChecker(val global: Global) extends Plugin { self =>
   var analyzerMode: AnalyzerMode = Error
   var currentTarget: String = "NA"
 
+  val isWindows: Boolean = System.getProperty("os.name").toLowerCase.contains("windows")
+
   override def init(options: List[String], error: (String) => Unit): Boolean = {
     var directJars: Seq[String] = Seq.empty
     var directTargets: Seq[String] = Seq.empty
@@ -66,7 +68,7 @@ class UnusedDependencyChecker(val global: Global) extends Plugin { self =>
       private def unusedDependenciesFound: Set[String] = {
         val usedJars: Set[AbstractFile] = findUsedJars
         val directJarPaths = direct.keys.toSet
-        val usedJarPaths = usedJars.map(_.path)
+        val usedJarPaths = if (!isWindows) usedJars.map(_.path) else usedJars.map(_.path.replaceAll("\\\\", "/"))
 
         val usedTargets = usedJarPaths
           .map(direct.get)


### PR DESCRIPTION
This resolves 2 issues I raised for running `rules_scala` on Windows, that is:
- https://github.com/bazelbuild/rules_scala/issues/641 (`%1 is not a valid Win32 application`)
- https://github.com/bazelbuild/rules_scala/issues/642 (valid dependencies reported as usused on Windows)

Main change is a port of Bazel's exe launcher from java rules to scala rules. Without it Bazel attempts to execute a bash script (generated from `java_stub_template`) as Bazel's executable, which fails on Windows. 

See https://github.com/bazelbuild/bazel/blob/8ac46c157c5da63e97a5825316ce6f0c3290e189/src/main/java/com/google/devtools/build/lib/bazel/rules/java/BazelJavaSemantics.java#L411 for how it's done in java rules.


The `UnusedDependencyChecker` is fixed by normalizing Windows paths, replacing backslashes with slashes. Without it all targets report unused deps on Windows.