### PR TITLE
Fix scala rules if scala compiler plugins provided 

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -203,3 +203,17 @@ scala_maven_import_external(
         "@org_springframework_spring_core"
     ]
 )
+
+## deps for tests of compiler plugin
+scala_maven_import_external(
+    name = "org_spire_math_kind_projector",
+    artifact = scala_mvn_artifact(
+        "org.spire-math:kind-projector:0.9.10",
+        default_scala_major_version(),
+    ),
+    fetch_sources = False,
+    licenses = ["notice"],
+    server_urls = [
+        "https://repo.maven.apache.org/maven2/",
+    ],
+)

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -123,7 +123,7 @@ def _collect_plugin_paths(plugins):
         if hasattr(p, "path"):
             paths.append(p)
         elif hasattr(p, "scala"):
-            paths.append(p.scala.outputs.jar)
+            paths.extend([j.class_jar for j in p.java.outputs.jars])
         elif hasattr(p, "java"):
             paths.extend([j.class_jar for j in p.java.outputs.jars])
             # support http_file pointed at a jar. http_jar uses ijar,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -123,7 +123,7 @@ def _collect_plugin_paths(plugins):
         if hasattr(p, "path"):
             paths.append(p)
         elif hasattr(p, "scala"):
-            paths.extend([j.class_jar for j in p.java.outputs.jars])
+            paths.extend([j.class_jar for j in p.scala.outputs.jars])
         elif hasattr(p, "java"):
             paths.extend([j.class_jar for j in p.java.outputs.jars])
             # support http_file pointed at a jar. http_jar uses ijar,

--- a/test/src/main/scala/scalarules/test/compiler_plugin/BUILD.bazel
+++ b/test/src/main/scala/scalarules/test/compiler_plugin/BUILD.bazel
@@ -1,0 +1,7 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "compiler_plugin",
+    srcs = [ "KindProjected.scala" ],
+    plugins = ["@org_spire_math_kind_projector//jar"]
+)

--- a/test/src/main/scala/scalarules/test/compiler_plugin/KindProjected.scala
+++ b/test/src/main/scala/scalarules/test/compiler_plugin/KindProjected.scala
@@ -1,0 +1,6 @@
+package scalarules.test.src.main.scala.scalarules.test.compiler_plugin
+
+import scala.language.higherKinds
+
+class HKT[F[_]]
+class KKTImpl extends HKT[Either[String, ?]]

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -711,6 +711,14 @@ test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_depe
   set -e
 }
 
+test_scala_library_support_compiler_plugins() {
+  bazel build test/src/main/scala/scalarules/test/compiler_plugin:compiler_plugin
+  if [ $? -ne 0 ]; then
+    echo "'bazel build test/src/main/scala/scalarules/test/compiler_plugin:compiler_plugin' failed"
+    exit 1
+  fi
+}
+
 test_scala_library_expect_no_recompilation_on_internal_change_of_java_dependency() {
   test_scala_library_expect_no_recompilation_of_target_on_internal_change_of_dependency "C.java" "s/System.out.println(\"orig\")/System.out.println(\"altered\")/"
 }
@@ -995,6 +1003,7 @@ $runner test_unused_dependency_checker_mode_set_in_rule
 $runner test_unused_dependency_checker_mode_override_toolchain
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_dependency
 $runner test_multi_service_manifest
+$runner test_scala_library_support_compiler_plugins
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_scala_dependency
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_java_dependency
 $runner test_scala_library_expect_no_java_recompilation_on_internal_change_of_scala_sibling

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -711,14 +711,6 @@ test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_depe
   set -e
 }
 
-test_scala_library_support_compiler_plugins() {
-  bazel build test/src/main/scala/scalarules/test/compiler_plugin:compiler_plugin
-  if [ $? -ne 0 ]; then
-    echo "'bazel build test/src/main/scala/scalarules/test/compiler_plugin:compiler_plugin' failed"
-    exit 1
-  fi
-}
-
 test_scala_library_expect_no_recompilation_on_internal_change_of_java_dependency() {
   test_scala_library_expect_no_recompilation_of_target_on_internal_change_of_dependency "C.java" "s/System.out.println(\"orig\")/System.out.println(\"altered\")/"
 }
@@ -1003,7 +995,6 @@ $runner test_unused_dependency_checker_mode_set_in_rule
 $runner test_unused_dependency_checker_mode_override_toolchain
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_dependency
 $runner test_multi_service_manifest
-$runner test_scala_library_support_compiler_plugins
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_scala_dependency
 $runner test_scala_library_expect_no_recompilation_on_internal_change_of_java_dependency
 $runner test_scala_library_expect_no_java_recompilation_on_internal_change_of_scala_sibling


### PR DESCRIPTION
In BUILD.bazel if you have:
scala_library(
name = "testapp",
plugins = ["@org_spire_math_kind_projector_2_12"]
)

It fails with following error:
File "..../io_bazel_rules_scala/scala/private/rule_impls.bzl", line 123, in paths.append
p.scala.outputs.jar
'struct' object has no attribute 'jar'

Seems like jar attributed has been changed to jars some time ago. This pull request fixes this problem. 