### PR TITLE
Updated java_stub_template in scala_repositories

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,15 +2,6 @@ workspace(name = "io_bazel_rules_scala")
 
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-#used to test what happens when classpath is too large
-#until https://github.com/bazelbuild/bazel/issues/6955 is resolved
-http_archive(
-    name = "java_stub_template",
-    sha256 = "1859a37dccaee8c56b98869bf1f22f6f5b909606aff74ddcfd59e9757a038dd5",
-    urls = ["https://github.com/bazelbuild/rules_scala/archive/8b8271e3ee5709e1340b19790d0b396a0ff3dd0f.tar.gz"],
-    strip_prefix = "rules_scala-8b8271e3ee5709e1340b19790d0b396a0ff3dd0f/java_stub_template",
-)
-
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("//scala:scala.bzl", "scala_repositories")
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -12,7 +12,7 @@ load(
     "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
-load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file", "http_archive")
 load(
     "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
     _scala_maven_import_external = "scala_maven_import_external",

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -487,24 +487,16 @@ def scala_repositories(
         licenses = ["notice"],
         server_urls = maven_servers,
     )
-
-    # Template for binary launcher
-    BAZEL_JAVA_LAUNCHER_VERSION = "0.17.1"
-    java_stub_template_url = (
-        "raw.githubusercontent.com/bazelbuild/bazel/" +
-        BAZEL_JAVA_LAUNCHER_VERSION +
-        "/src/main/java/com/google/devtools/build/lib/bazel/rules/java/" +
-        "java_stub_template.txt"
-    )
-    http_file(
-        name = "java_stub_template",
-        sha256 =
-            "39097bdc47407232e0fe7eed4f2c175c067b7eda95873cb76ffa76f1b4c18895",
-        urls = [
-            "https://mirror.bazel.build/%s" % java_stub_template_url,
-            "https://%s" % java_stub_template_url,
-        ],
-    )
+    
+    # Using this and not the bazel regular one due to issue when classpath is too long
+    # until https://github.com/bazelbuild/bazel/issues/6955 is resolved
+    if native.existing_rule("java_stub_template") == None:
+      http_archive(
+                name = "java_stub_template",
+                sha256 = "1859a37dccaee8c56b98869bf1f22f6f5b909606aff74ddcfd59e9757a038dd5",
+                urls = ["https://github.com/bazelbuild/rules_scala/archive/8b8271e3ee5709e1340b19790d0b396a0ff3dd0f.tar.gz"],
+                strip_prefix = "rules_scala-8b8271e3ee5709e1340b19790d0b396a0ff3dd0f/java_stub_template",
+      )
 
     native.bind(
         name = "io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",


### PR DESCRIPTION
adding it to the WORKSPACE was wrong since now each user needs to do the same action (and we have two contradicting declarations)