### PR TITLE
Improve persistent Scalac worker docs in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ You may wish to have these rules loaded by default using bazel's prelude. You ca
 To run with a persistent worker (much faster), you need to add
 ```
 build --strategy=Scalac=worker
+build --worker_sandboxing
 ```
 to your command line, or to enable by default for building/testing add it to your .bazelrc.
 

--- a/README.md
+++ b/README.md
@@ -57,7 +57,6 @@ You may wish to have these rules loaded by default using bazel's prelude. You ca
 To run with a persistent worker (much faster), you need to add
 ```
 build --strategy=Scalac=worker
-test --strategy=Scalac=worker
 ```
 to your command line, or to enable by default for building/testing add it to your .bazelrc.
 


### PR DESCRIPTION
### 1st Commit

`test` inherits from `build`, so the 2nd line is redundant. See: https://docs.bazel.build/versions/master/guide.html#bazelrc-syntax-and-semantics

### 2nd Commit

I'd say that, _generally_, sandboxing in Bazel is preferred. By default you get non-sandboxed workers in Bazel, so I've added the option that enables the sandboxing as an 'easy win'. 

