### PR TITLE
Handle experimental java coverage configuration

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -629,6 +629,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper, use_jacoco):
                 "%set_jacoco_metadata%": "export JACOCO_METADATA_JAR=\"$JAVA_RUNFILES/{}/{}\"".format(ctx.workspace_name, jacoco_metadata_file.short_path),
                 "%set_jacoco_main_class%": """export JACOCO_MAIN_CLASS={}""".format(main_class),
                 "%set_jacoco_java_runfiles_root%": """export JACOCO_JAVA_RUNFILES_ROOT=$JAVA_RUNFILES/{}/""".format(ctx.workspace_name),
+                "%set_java_coverage_new_implementation%": """export JAVA_COVERAGE_NEW_IMPLEMENTATION=YES""",
             },
             is_executable = True,
         )
@@ -654,6 +655,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper, use_jacoco):
                 "%set_jacoco_main_class%": "",
                 "%set_jacoco_java_runfiles_root%": "",
                 "%workspace_prefix%": ctx.workspace_name + "/",
+                "%set_java_coverage_new_implementation%": """export JAVA_COVERAGE_NEW_IMPLEMENTATION=NO""",
             },
             is_executable = True,
         )


### PR DESCRIPTION
Experimental java coverage was [added in Bazel 0.24.0](https://github.com/bazelbuild/bazel/commit/68c7e5a3c679be51f750d44aae146007f0f04b4d), which introduced a new template variable `%set_java_coverage_new_implementation%` to `java_stub_template.txt`. Not handling that substitution results in the following error on build:

```bash
/private/var/tmp/[...]: line 262: fg: no job control
```

This PR resolves the error by enabling the experimental coverage functionality if coverage is enabled, but disables it otherwise. This corresponds to the behaviour of the Java rules. I'm not complete sure if that is applicable for Scala as well.

