### PR TITLE
Don't test on Ubuntu 14.04

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,6 @@
 ---
 platforms:
-  ubuntu1404:
+  ubuntu1604:
     shell_commands:
     # Disable local disk caching on CI.
     - mv tools/bazel.rc.buildkite tools/bazel.rc
@@ -9,7 +9,7 @@ platforms:
     - "//test/..."
     test_targets:
     - "//test/..."
-  ubuntu1604:
+  ubuntu1804:
     shell_commands:
     # Disable local disk caching on CI.
     - mv tools/bazel.rc.buildkite tools/bazel.rc


### PR DESCRIPTION
Ubuntu 14.04 is about to be end-of-life and Bazel CI will stop supporting it shortly afterwards.

Context: https://groups.google.com/d/msg/bazel-dev/_D6XzfNkQQE/8TNKiNmsCAAJ