### PR TITLE
Add support and test for custom generator

### DIFF
--- a/scala_proto/private/proto_to_scala_src.bzl
+++ b/scala_proto/private/proto_to_scala_src.bzl
@@ -19,8 +19,12 @@ def _colon_paths(data):
     ])
 
 
-def proto_to_scala_src(ctx, label, code_generator, compile_proto, include_proto, transitive_proto_paths, flags, jar_output):
-    worker_content = "{output}\n{included_proto}\n{flags_arg}\n{transitive_proto_paths}\n{inputs}\n{protoc}".format(
+def encode_named_generators(named_generators):
+    return ",".join([k + "=" + v for (k, v) in named_generators.items()])
+
+
+def proto_to_scala_src(ctx, label, code_generator, compile_proto, include_proto, transitive_proto_paths, flags, jar_output, named_generators, extra_generator_jars):
+    worker_content = "{output}\n{included_proto}\n{flags_arg}\n{transitive_proto_paths}\n{inputs}\n{protoc}\n{extra_generator_pairs}\n{extra_cp_entries}".format(
         output = jar_output.path,
         included_proto = "-" + ":".join(sorted(["%s,%s" % (f.root.path, f.path) for f in include_proto])),
         # Command line args to worker cannot be empty so using padding
@@ -29,7 +33,9 @@ def proto_to_scala_src(ctx, label, code_generator, compile_proto, include_proto,
         # Command line args to worker cannot be empty so using padding
         # Pass inputs seprately because they doesn't always match to imports (ie blacklisted protos are excluded)
         inputs = _colon_paths(compile_proto),
-        protoc = ctx.executable._protoc.path
+        protoc = ctx.executable._protoc.path,
+        extra_generator_pairs= "-" + encode_named_generators(named_generators),
+        extra_cp_entries = "-" + _colon_paths(extra_generator_jars)
     )
     argfile = ctx.actions.declare_file(
         "%s_worker_input" % label.name,
@@ -38,7 +44,7 @@ def proto_to_scala_src(ctx, label, code_generator, compile_proto, include_proto,
     ctx.actions.write(output = argfile, content = worker_content)
     ctx.actions.run(
         executable = code_generator.files_to_run,
-        inputs = compile_proto + include_proto + [argfile, ctx.executable._protoc],
+        inputs = compile_proto + include_proto + [argfile, ctx.executable._protoc] + extra_generator_jars,
         outputs = [jar_output],
         mnemonic = "ProtoScalaPBRule",
         progress_message = "creating scalapb files %s" % ctx.label,

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -153,6 +153,11 @@ def _scalapb_aspect_impl(target, ctx):
         if toolchain.with_single_line_to_string:
             flags.append("single_line_to_proto_string")
 
+        extra_generator_jars = []
+        for generator_dep in toolchain.extra_generator_dependencies:
+            jinfo = generator_dep[JavaInfo]
+            extra_generator_jars.extend(jinfo.transitive_runtime_jars.to_list())
+
         # This feels rather hacky and odd, but we can't compare the labels to ignore a target easily
         # since the @ or // forms seem to not have good equality :( , so we aim to make them absolute
         #
@@ -181,6 +186,8 @@ def _scalapb_aspect_impl(target, ctx):
                 target_ti.transitive_proto_path.to_list(),
                 flags,
                 scalapb_file,
+                toolchain.named_generators,
+                sorted(extra_generator_jars)
             )
 
             src_jars = depset([scalapb_file])

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -9,7 +9,9 @@ def _scala_proto_toolchain_impl(ctx):
         code_generator = ctx.attr.code_generator,
         grpc_deps=ctx.attr.grpc_deps,
         implicit_compile_deps=ctx.attr.implicit_compile_deps,
+        extra_generator_dependencies = ctx.attr.extra_generator_dependencies,
         scalac=ctx.attr.scalac,
+        named_generators = ctx.attr.named_generators,
     )
     return [toolchain]
 
@@ -32,6 +34,10 @@ scala_proto_toolchain = rule(
             cfg = "host",
             default = Label("@io_bazel_rules_scala//src/scala/scripts:scalapb_generator"),
             allow_files=True
+        ),
+        "named_generators": attr.string_dict(),
+        "extra_generator_dependencies": attr.label_list(
+            providers = [JavaInfo]
         ),
         "grpc_deps": attr.label_list(
             providers = [JavaInfo],

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -24,6 +24,12 @@ scala_proto_toolchain(
     with_flat_package = False,
     with_grpc = True,
     with_single_line_to_string = True,
+    named_generators = {
+        'jvm_extra_protobuf_generator': 'scalarules.test.extra_protobuf_generator.ExtraProtobufGenerator',
+    },
+    extra_generator_dependencies = [
+        "//test/src/main/scala/scalarules/test/extra_protobuf_generator",
+    ],
 )
 
 toolchain(
@@ -142,5 +148,16 @@ scala_test(
     ],
     deps = [
         ":test_proto",
+    ],
+)
+
+
+scala_test(
+    name = "test_custom_object_exists",
+    srcs = [
+        "CustomGeneratedObjectTest.scala",
+    ],
+    deps = [
+        ":test_external_dep",
     ],
 )

--- a/test/proto/CustomGeneratedObjectTest.scala
+++ b/test/proto/CustomGeneratedObjectTest.scala
@@ -1,0 +1,11 @@
+import org.scalatest.FlatSpec
+import scala.util.Try
+
+class CustomGeneratedObjectTest extends FlatSpec {
+
+  "Looking for the custom generated class" should "succeed" in {
+    test_external_dep.CustomTestMessage
+    assert(
+      Try(Class.forName("test_external_dep.CustomTestMessage$")).isSuccess)
+  }
+}

--- a/test/src/main/scala/scalarules/test/extra_protobuf_generator/BUILD
+++ b/test/src/main/scala/scalarules/test/extra_protobuf_generator/BUILD
@@ -1,0 +1,15 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "extra_protobuf_generator",
+    srcs = ["ExtraProtobufGenerator.scala"],
+    deps = [
+            "//external:io_bazel_rules_scala/dependency/proto/protoc_bridge",
+        "//external:io_bazel_rules_scala/dependency/proto/scalapb_plugin",
+            "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
+
+    ],
+        visibility = ["//visibility:public"],
+
+
+)

--- a/test/src/main/scala/scalarules/test/extra_protobuf_generator/ExtraProtobufGenerator.scala
+++ b/test/src/main/scala/scalarules/test/extra_protobuf_generator/ExtraProtobufGenerator.scala
@@ -1,0 +1,83 @@
+package scalarules.test.extra_protobuf_generator
+
+import com.google.protobuf.ExtensionRegistry
+import com.google.protobuf.compiler.PluginProtos.{CodeGeneratorRequest, CodeGeneratorResponse}
+import com.google.protobuf.Descriptors._
+import scalapb.compiler.{ProtobufGenerator, DescriptorImplicits, ProtoValidation, GeneratorException, GeneratorParams, FunctionalPrinter}
+import scalapb.options.compiler.Scalapb
+import protocbridge.{ProtocCodeGenerator, Artifact}
+import scala.collection.JavaConverters._
+
+class CustomProtobufGenerator(
+    params: GeneratorParams,
+    implicits: DescriptorImplicits
+) extends ProtobufGenerator(params, implicits) {
+  import implicits._
+  import ProtobufGenerator._
+
+  def printCustomMessage(printer: FunctionalPrinter, message: Descriptor): FunctionalPrinter = {
+    printer
+      .add(s"final case object Custom${message.nameSymbol}{}")
+  }
+
+  override def generateSingleScalaFileForFileDescriptor(
+      file: FileDescriptor
+  ): Seq[CodeGeneratorResponse.File] = {
+    val code =
+      scalaFileHeader(
+        file,
+        false
+      ).print(file.getMessageTypes.asScala)(printCustomMessage)
+        .result()
+
+    val b = CodeGeneratorResponse.File.newBuilder()
+    b.setName(file.scalaDirectory + "/Custom" + file.fileDescriptorObjectName + ".scala")
+    b.setContent(code)
+    List(b.build)
+  }
+
+}
+
+
+object ExtraProtobufGenerator extends ProtocCodeGenerator {
+   override def run(req: Array[Byte]): Array[Byte] = {
+    val registry = ExtensionRegistry.newInstance()
+    Scalapb.registerAllExtensions(registry)
+    val request = CodeGeneratorRequest.parseFrom(req)
+    handleCodeGeneratorRequest(request).toByteArray
+  }
+
+    def handleCodeGeneratorRequest(request: CodeGeneratorRequest): CodeGeneratorResponse = {
+    val b = CodeGeneratorResponse.newBuilder
+    ProtobufGenerator.parseParameters(request.getParameter) match {
+      case Right(params) =>
+        try {
+          val filesByName: Map[String, FileDescriptor] =
+            request.getProtoFileList.asScala.foldLeft[Map[String, FileDescriptor]](Map.empty) {
+              case (acc, fp) =>
+                val deps = fp.getDependencyList.asScala.map(acc)
+                acc + (fp.getName -> FileDescriptor.buildFrom(fp, deps.toArray))
+            }
+
+          val implicits = new DescriptorImplicits(params, filesByName.values.toVector)
+          val generator = new CustomProtobufGenerator(params, implicits)
+          val validator = new ProtoValidation(implicits)
+          validator.validateFiles(filesByName.values.toSeq)
+          import implicits.FileDescriptorPimp
+          request.getFileToGenerateList.asScala.foreach { name =>
+            val file = filesByName(name)
+            val responseFiles =
+                generator.generateSingleScalaFileForFileDescriptor(file)
+            b.addAllFile(responseFiles.asJava)
+          }
+        } catch {
+          case e: GeneratorException =>
+            b.setError(e.message)
+        }
+      case Left(error) =>
+        b.setError(error)
+    }
+    b.build
+  }
+
+}


### PR DESCRIPTION
This allows adding more generators to scalapb to run within the toolchain. 

Use case here is that i want to generate service definitions that are friendly to twitter's util/futures rather than scala futures. So want to make it extensible to add more scala code generators into the output.

Thoughts @johnynek and @ittaiz ?