### PR TITLE
add arg  to _jvm_import_external to align with bazel repo version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -77,7 +77,7 @@ scala_maven_import_external(
     name = "com_github_jnr_jffi_native",
     artifact = "com.github.jnr:jffi:jar:native:1.2.17",
     fetch_sources = True,
-    jar_sha256 = "4eb582bc99d96c8df92fc6f0f608fd123d278223982555ba16219bf8be9f75a9",
+    artifact_sha256 = "4eb582bc99d96c8df92fc6f0f608fd123d278223982555ba16219bf8be9f75a9",
     licenses = ["notice"],
     server_urls = [
         "https://repo.maven.apache.org/maven2/",
@@ -124,7 +124,7 @@ load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external", "
 scala_maven_import_external(
     name = "com_google_guava_guava_21_0",
     artifact = "com.google.guava:guava:21.0",
-    jar_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    artifact_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     srcjar_sha256 = "b186965c9af0a714632fe49b33378c9670f8f074797ab466f49a67e918e116ea",
     fetch_sources = True,
     licenses = ["notice"],  # Apache 2.0
@@ -183,7 +183,7 @@ git_repository(
 scala_maven_import_external(
     name = "org_springframework_spring_core",
     artifact = "org.springframework:spring-core:5.1.5.RELEASE",
-    jar_sha256 = "f771b605019eb9d2cf8f60c25c050233e39487ff54d74c93d687ea8de8b7285a",
+    artifact_sha256 = "f771b605019eb9d2cf8f60c25c050233e39487ff54d74c93d687ea8de8b7285a",
     licenses = ["notice"],  # Apache 2.0
     server_urls = [
         "https://repo1.maven.org/maven2/",
@@ -194,7 +194,7 @@ scala_maven_import_external(
 scala_maven_import_external(
     name = "org_springframework_spring_tx",
     artifact = "org.springframework:spring-tx:5.1.5.RELEASE",
-    jar_sha256 = "666f72b73c7e6b34e5bb92a0d77a14cdeef491c00fcb07a1e89eb62b08500135",
+    artifact_sha256 = "666f72b73c7e6b34e5bb92a0d77a14cdeef491c00fcb07a1e89eb62b08500135",
     licenses = ["notice"],  # Apache 2.0
     server_urls = [
         "https://repo1.maven.org/maven2/",

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -210,7 +210,7 @@ jvm_import_external = repository_rule(
         "rule_name": attr.string(mandatory = True),
         "licenses": attr.string_list(mandatory = True, allow_empty = False),
         "jar_urls": attr.string_list(mandatory = True, allow_empty = False),
-        "jar_sha256": attr.string(default = None, doc = "'jar_sha256' is deprecated. Please use 'artifact_sha256'"),
+        "jar_sha256": attr.string(doc = "'jar_sha256' is deprecated. Please use 'artifact_sha256'"),
         "artifact_sha256": attr.string(),
         "rule_load": attr.string(),
         "additional_rule_attrs": attr.string_dict(),

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -55,6 +55,8 @@ def _jvm_import_external(repository_ctx):
         fail("Only use generated_linkable_rule_name if neverlink is set")
     name = repository_ctx.attr.generated_rule_name or repository_ctx.name
     urls = repository_ctx.attr.jar_urls
+    if repository_ctx.attr.jar_sha256:
+        print("'jar_sha256' is deprecated. Please use 'artifact_sha256'")
     sha = repository_ctx.attr.jar_sha256 or repository_ctx.attr.artifact_sha256
     path = repository_ctx.name + ".jar"
     for url in urls:
@@ -208,7 +210,7 @@ jvm_import_external = repository_rule(
         "rule_name": attr.string(mandatory = True),
         "licenses": attr.string_list(mandatory = True, allow_empty = False),
         "jar_urls": attr.string_list(mandatory = True, allow_empty = False),
-        "jar_sha256": attr.string(doc = "'jar_sha256' is deprecated. Please use 'artifact_sha256'"),
+        "jar_sha256": attr.string(default = None, doc = "'jar_sha256' is deprecated. Please use 'artifact_sha256'"),
         "artifact_sha256": attr.string(),
         "rule_load": attr.string(),
         "additional_rule_attrs": attr.string_dict(),

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -55,7 +55,7 @@ def _jvm_import_external(repository_ctx):
         fail("Only use generated_linkable_rule_name if neverlink is set")
     name = repository_ctx.attr.generated_rule_name or repository_ctx.name
     urls = repository_ctx.attr.jar_urls
-    sha = repository_ctx.attr.jar_sha256
+    sha = repository_ctx.attr.jar_sha256 or repository_ctx.attr.artifact_sha256
     path = repository_ctx.name + ".jar"
     for url in urls:
         if url.endswith(".jar"):
@@ -209,6 +209,7 @@ jvm_import_external = repository_rule(
         "licenses": attr.string_list(mandatory = True, allow_empty = False),
         "jar_urls": attr.string_list(mandatory = True, allow_empty = False),
         "jar_sha256": attr.string(),
+        "artifact_sha256": attr.string(),
         "rule_load": attr.string(),
         "additional_rule_attrs": attr.string_dict(),
         "srcjar_urls": attr.string_list(),

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -208,7 +208,7 @@ jvm_import_external = repository_rule(
         "rule_name": attr.string(mandatory = True),
         "licenses": attr.string_list(mandatory = True, allow_empty = False),
         "jar_urls": attr.string_list(mandatory = True, allow_empty = False),
-        "jar_sha256": attr.string(),
+        "jar_sha256": attr.string(doc = "'jar_sha256' is deprecated. Please use 'artifact_sha256'"),
         "artifact_sha256": attr.string(),
         "rule_load": attr.string(),
         "additional_rule_attrs": attr.string_dict(),


### PR DESCRIPTION
bazel repo has [artifact_sha256](https://github.com/bazelbuild/bazel/blob/d8ffad56129e2c358c5b208edb62918c8ed1220c/tools/build_defs/repo/jvm.bzl#L56) arg:
This change aligns rules_scala version of `jvm_import_external` to also have this arg.
See https://github.com/bazelbuild/rules_scala/issues/737