### PR TITLE
Portable classpath in stub template

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -618,7 +618,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper, use_jacoco):
             template = template,
             output = ctx.outputs.executable,
             substitutions = {
-                "%classpath%": classpath,
+                "%classpath%": "\"%s\"" % classpath,
                 "%javabin%": javabin,
                 "%jarbin%": _jar_path_based_on_java_bin(ctx),
                 "%jvm_flags%": jvm_flags,
@@ -644,7 +644,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper, use_jacoco):
             template = template,
             output = ctx.outputs.executable,
             substitutions = {
-                "%classpath%": classpath,
+                "%classpath%": "\"%s\"" % classpath,
                 "%java_start_class%": main_class,
                 "%javabin%": javabin,
                 "%jarbin%": _jar_path_based_on_java_bin(ctx),

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -603,7 +603,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper, use_jacoco):
     )
 
     if use_jacoco and _coverage_replacements_provider.is_enabled(ctx):
-        classpath = ":".join(
+        classpath = ctx.configuration.host_path_separator.join(
             ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list() + ctx.files._jacocorunner + ctx.files._lcov_merger],
         )
         jacoco_metadata_file = ctx.actions.declare_file(
@@ -637,7 +637,7 @@ def _write_executable(ctx, rjars, main_class, jvm_flags, wrapper, use_jacoco):
     else:
         # RUNPATH is defined here:
         # https://github.com/bazelbuild/bazel/blob/0.4.5/src/main/java/com/google/devtools/build/lib/bazel/rules/java/java_stub_template.txt#L227
-        classpath = ":".join(
+        classpath = ctx.configuration.host_path_separator.join(
             ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list()],
         )
         ctx.actions.expand_template(


### PR DESCRIPTION
Change to use the platform-specific path separator. The stub template script already sets `IFS=';'` on Windows so having colons in `CLASSPATH` means it doesn't get split properly.