### PR TITLE
Fixes resource_strip_prefix on Windows

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -291,11 +291,11 @@ class ScalacProcessor implements Processor {
         dstr = resource.destination;
       }
 
-      if (dstr.charAt(0) == '/') {
+      if (dstr.charAt(0) == '/' || dstr.charAt(0) == '\\') {
         // we don't want to copy to an absolute destination
         dstr = dstr.substring(1);
       }
-      if (dstr.startsWith("../")) {
+      if (dstr.startsWith("../") || dstr.startsWith("..\\")) {
         // paths to external repositories, for some reason, start with a leading ../
         // we don't want to copy the resource out of our temporary directory, so
         // instead we replace ../ with external/

--- a/test/resource_strip_prefix/BUILD
+++ b/test/resource_strip_prefix/BUILD
@@ -1,0 +1,10 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "test-lib",
+    srcs = glob(
+        ["src/test/scala/**/*.scala"],
+    ),
+    resource_strip_prefix = "test/resource_strip_prefix/src/test/resources",
+    resources = ["src/test/resources/resource.txt"],
+)

--- a/test/resource_strip_prefix/src/test/scala/RootResources.scala
+++ b/test/resource_strip_prefix/src/test/scala/RootResources.scala
@@ -1,0 +1,3 @@
+object RootResources {
+
+}


### PR DESCRIPTION
This introduces a build/test case which fails on Windows (with `resource_strip_prefix` used leaving `/` as first char) with:
```
PS C:\Users\...\rules_scala> bazel build //test/resource_strip_prefix/...
INFO: Analysed target //test/resource_strip_prefix:test-lib (1 packages loaded, 3 targets configured).
INFO: Found 1 target...
ERROR: C:/users/.../rules_scala/test/resource_strip_prefix/BUILD:3:1: scala //test/resource_strip_prefix:test-lib failed (Exit 1)
java.nio.file.AccessDeniedException: test\resource_strip_prefix\src\test\resources\resource.txt -> \resource.txt
        at sun.nio.fs.WindowsException.translateToIOException(WindowsException.java:83)
        at sun.nio.fs.WindowsException.rethrowAsIOException(WindowsException.java:97)
        at sun.nio.fs.WindowsFileCopy.copy(WindowsFileCopy.java:205)
        at sun.nio.fs.WindowsFileSystemProvider.copy(WindowsFileSystemProvider.java:278)
        at java.nio.file.Files.copy(Files.java:1274)
        at io.bazel.rulesscala.scalac.ScalacProcessor.copyResources(ScalacProcessor.java:309)
        at io.bazel.rulesscala.scalac.ScalacProcessor.processRequest(ScalacProcessor.java:73)
        at io.bazel.rulesscala.worker.GenericWorker.run(GenericWorker.java:114)
        at io.bazel.rulesscala.scalac.ScalaCInvoker.main(ScalaCInvoker.java:41)
Target //test/resource_strip_prefix:test-lib failed to build
Use --verbose_failures to see the command lines of failed build steps.
INFO: Elapsed time: 4.016s, Critical Path: 2.98s
INFO: 0 processes.
FAILED: Build did NOT complete successfully
```

and fixes it in `ScalacProcessor.java`