### PR TITLE
Document scala_import

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ This project defines core build rules for [Scala](https://www.scala-lang.org/) t
 * [thrift_library](docs/thrift_library.md)
 * [scalapb_proto_library](docs/scalapb_proto_library.md)
 * [scala_toolchain](docs/scala_toolchain.md)
+* [scala_import](docs/scala_import.md)
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 ## Overview
 
-[Bazel](https://bazel.build/) is software for building and testing software, and can handle large,
+[Bazel](https://bazel.build/) is a tool for building and testing software and can handle large,
 multi-language projects at scale.
 
 This project defines core build rules for [Scala](https://www.scala-lang.org/) that can be used to build, test, and package Scala projects.

--- a/docs/scala_import.md
+++ b/docs/scala_import.md
@@ -1,0 +1,28 @@
+# scala_import
+
+```python
+scala_import(
+    name,
+    jars,
+    deps,
+    runtime_deps,
+    exports,
+    neverlink,
+    srcjar
+)
+```
+
+`scala_import` enables the use of precompiled Scala .jar files as dependencies for other Scala rules
+like `scala_library`, similar to `java_import` from Java rules.
+
+## Attributes
+
+| Attribute name        | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| name                  | `Name, required` <br> A unique name for this target.
+| jars                  | `List of labels, required` <br> List of .jar files to import, usually in `//external`. In practice, this usually corresponds to one jar.
+| deps                  | `List of labels, optional` <br>
+| runtime_deps          | `List of labels, optional` <br>
+| exports               | `List of labels, optional` <br> List of targets to add to the dependencies of those that depend on this target.
+| neverlink             | `boolean, optional (default False)` <br>
+| srcjar                | `Label, optional` <br>

--- a/docs/scala_import.md
+++ b/docs/scala_import.md
@@ -15,6 +15,9 @@ scala_import(
 `scala_import` enables the use of precompiled Scala .jar files as dependencies for other Scala rules
 like `scala_library`, similar to `java_import` from Java rules.
 
+This rule reimplements `java_import` without support for ijars, which break Scala macros.
+Generally, ijars don’t help much for external dependencies, which rarely change.
+
 ## Attributes
 
 | Attribute name        | Description                                           |

--- a/docs/scala_import.md
+++ b/docs/scala_import.md
@@ -21,8 +21,8 @@ like `scala_library`, similar to `java_import` from Java rules.
 | --------------------- | ----------------------------------------------------- |
 | name                  | `Name, required` <br> A unique name for this target.
 | jars                  | `List of labels, required` <br> List of .jar files to import, usually in `//external`. In practice, this usually corresponds to one jar.
-| deps                  | `List of labels, optional` <br>
-| runtime_deps          | `List of labels, optional` <br>
+| deps                  | `List of labels, optional` <br> Compile time dependencies that were used to create the jar.
+| runtime_deps          | `List of labels, optional` <br> Runtime dependencies that are needed for this library.
 | exports               | `List of labels, optional` <br> List of targets to add to the dependencies of those that depend on this target.
-| neverlink             | `boolean, optional (default False)` <br>
-| srcjar                | `Label, optional` <br>
+| neverlink             | `boolean, optional (default False)` <br> If true only use this library for compilation and not at runtime.
+| srcjar                | `Label, optional` <br> The source jar that was used to create the jar.


### PR DESCRIPTION
Related issue: #721

## Summary

This PR adds an initial doc for `scala_import`.

I chose to do it as a Markdown table written by hand. The rest of the docs are HTML tables that I think were generated long ago by Skydoc when it still worked. As soon as Stardoc works, generated files should replace these hand maintained files!

I do need a second look with these attributes though, since I don't really know all of them really mean and cribbed the descriptions from:

- https://docs.bazel.build/versions/master/skylark/lib/JavaInfo.html
- https://github.com/bazelbuild/rules_scala/blob/master/docs/scala_library.md