### PR TITLE
Add scala toolchain to aspect

### DIFF
--- a/scala/private/coverage_replacements_provider.bzl
+++ b/scala/private/coverage_replacements_provider.bzl
@@ -67,6 +67,7 @@ def _aspect_impl(target, ctx):
 _aspect = aspect(
     attr_aspects = _dependency_attributes,
     implementation = _aspect_impl,
+    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
 )
 
 def _is_enabled(ctx):

--- a/test/coverage/expected-coverage.dat
+++ b/test/coverage/expected-coverage.dat
@@ -50,6 +50,22 @@ DA:7,5
 LH:1
 LF:2
 end_of_record
+SF:/C2.scala
+FN:-1,C2$::<clinit> ()V
+FN:5,C2$::<init> ()V
+FN:3,C2$::c2 (Ljava/lang/String;)Ljava/lang/String;
+FN:-1,C2::c2 (Ljava/lang/String;)Ljava/lang/String;
+FNDA:1,C2$::<clinit> ()V
+FNDA:1,C2$::<init> ()V
+FNDA:1,C2$::c2 (Ljava/lang/String;)Ljava/lang/String;
+FNDA:1,C2::c2 (Ljava/lang/String;)Ljava/lang/String;
+FNF:4
+FNH:4
+DA:3,9
+DA:5,5
+LH:2
+LF:2
+end_of_record
 SF:/TestAll.scala
 FN:10,TestAll$$anonfun$1::<init> (LTestAll;)V
 FN:10,TestAll$$anonfun$1::apply ()V


### PR DESCRIPTION
This fixes an issue where the aspect that gathers up coverage data needs access to the scala toolchain, but the scala toolchain is not enabled for the aspect. This results in coverage data only being created for the test targets and none of its transitive deps.

This is the part of the aspect that fails because the toolchain is not enabled for the aspect:
https://github.com/bazelbuild/rules_scala/blob/09790bb54249ab8ad517cd696171bc50a8e8a218/scala/private/coverage_replacements_provider.bzl#L72-L76

The updated `expected-coverage.dat` tracefile shows that more coverage data is being generated.