### PR TITLE
Prevent showing filtered-out specs2 tests in the test.xml

### DIFF
--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -512,6 +512,22 @@ scala_specs2_junit_test_test_filter_one_test(){
   fi
 }
 
+scala_specs2_only_filtered_test_shows_in_the_xml(){
+  bazel test \
+    --nocache_test_results \
+    --test_output=streamed \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#specs2 tests should::run smoothly in bazel$' \
+    test:Specs2Tests
+  matches=$(grep -c -e "testcase name='specs2 tests should::run smoothly in bazel'" -e "testcase name='specs2 tests should::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
+  if [ $matches -eq 1 ]; then
+    return 0
+  else
+    echo "Expecting only one result, found more than one. Please check 'bazel-testlogs/test/Specs2Tests/test.xml'"
+    return 1
+  fi
+  test -e
+}
+
 scala_specs2_junit_test_test_filter_exact_match(){
   local output=$(bazel test \
     --nocache_test_results \
@@ -983,6 +999,7 @@ $runner scala_specs2_junit_test_test_filter_exact_match_escaped_and_sanitized
 $runner scala_specs2_junit_test_test_filter_match_multiple_methods
 $runner scala_specs2_exception_in_initializer_without_filter
 $runner scala_specs2_exception_in_initializer_terminates_without_timeout
+$runner scala_specs2_only_filtered_test_shows_in_the_xml
 $runner scalac_jvm_flags_are_configured
 $runner javac_jvm_flags_are_configured
 $runner javac_jvm_flags_via_javacopts_are_configured


### PR DESCRIPTION
This change fixes a bug in test.xml generation produced by the bazel JUnit runner. Before this fix, the test.xml produced by the test runner will contain all test cases, regardless whether they ran or not, and incorrectly display them in IntelliJ as successful.

<img src="https://user-images.githubusercontent.com/601206/58420398-d693be80-8095-11e9-99b8-e608655d58a9.png" width=640></img>
(shows `foo` as having successfully ran even though it never actually ran, due to test filter) 

When providing a `test_filter`, the string is passed to the underlying specs2 runner, so it runs just the filtered tests, but the test model contains all the tests, regardless of the filter. In Java, the underlying model is modified, so the test children which don't match the filter are removed from the model. In Scala the model is immutable, so the solution is to generate a test model that is already filtered. This works by first flattening the tree structure of a model, filtering the tests according to the `test_filter` string, and reconstructing the tree model from filtered results.

An additional benefit of this fix is the resulting test.xml - it will no longer contain redundant "should" blocks!
<details>
<summary>
  <strong>XML differences</strong>
</summary>
<p>
Given a test like the screenshot above:

```scala
class MyTest extends SpecWithJunit {
  "my test" should {
    "foo" in ...
    "bar" in ...
  }
}
```
When running with `--test_filter=MyTest#my test should::foo$`,

**Before:**
```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuites>
  <testsuite name='Aggregate Specs2 Test Suite' timestamp='1970-01-01T17:14:20.074Z' hostname='localhost' tests='2' failures='0' errors='0' time='0.002' package='' id='0'>
    <properties />
    <system-out />
    <system-err /></testsuite>
  <testsuite name='MyTest' id='1'>
    <properties />
  </testsuite>
  <testsuite name='my test should' id='2'>  // <--- 1
    <properties />
    <testcase name='my test should::foo' classname='MyTest' time='0.002' />
    <testcase name='my test should::bar' classname='MyTest' time='0.0' />    // <-- 2
  </testsuite>
</testsuites>
```

Notice the **1** and **2** noise.

**After:**
```xml
<?xml version='1.0' encoding='UTF-8'?>
<testsuites>
  <testsuite name='Aggregate Specs2 Test Suite' ... package='' id='0'>
    <properties />
  <testsuite name='MyTest' id='1'>
    <properties />
    <testcase name='my test should::foo' classname='MyTest' time='0.002' />
  </testsuite>
</testsuites>
```
</p>