### PR TITLE
Add scala_doc rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ This project defines core build rules for [Scala](https://www.scala-lang.org/) t
 * [scalapb_proto_library](docs/scalapb_proto_library.md)
 * [scala_toolchain](docs/scala_toolchain.md)
 * [scala_import](docs/scala_import.md)
+* [scala_doc](docs/scala_doc.md)
 
 ## Getting started
 

--- a/docs/scala_doc.md
+++ b/docs/scala_doc.md
@@ -1,0 +1,20 @@
+# scala_doc
+
+```python
+scala_binary(
+    name,
+    deps,
+    plugins,
+)
+```
+
+`scala_doc` generates [Scaladoc](https://docs.scala-lang.org/style/scaladoc.html) for sources
+for targets, including sources from upstream deps. Readily hostable HTML is written to a `name.html` output folder.
+
+## Attributes
+
+| Attribute name        | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| name                  | `Name, required` <br> A unique name for this target.
+| deps                  | `List of labels, optional` <br> Labels for which you want to create scaladoc.
+| plugins               | `List of labels, optional` <br> Scala compiler plugins to pass through to the scaladoc tool.

--- a/docs/scala_doc.md
+++ b/docs/scala_doc.md
@@ -11,6 +11,28 @@ scala_binary(
 `scala_doc` generates [Scaladoc](https://docs.scala-lang.org/style/scaladoc.html) for sources
 for targets, including sources from upstream deps. Readily hostable HTML is written to a `name.html` output folder.
 
+## Example
+
+scala_doc(
+    name = "scala_docs",
+    plugins = ["//external:path/to/kind-projector.jar],
+    tags = ["manual"],
+    deps = [
+        ":target1",
+        ":target2",
+        ":anothertarget",
+    ],
+)
+
+# Use pkg_tar to tarball up
+# https://docs.bazel.build/versions/master/be/pkg.html#pkg_tar
+pkg_tar(
+    name = "scala_docs_archive",
+    srcs = [":scala_docs"],
+    extension = "tar.gz",
+)
+```
+
 ## Attributes
 
 | Attribute name        | Description                                           |

--- a/docs/scala_doc.md
+++ b/docs/scala_doc.md
@@ -10,6 +10,9 @@ scala_binary(
 `scala_doc` generates [Scaladoc](https://docs.scala-lang.org/style/scaladoc.html) for sources
 for targets, including sources from upstream deps. Readily hostable HTML is written to a `name.html` output folder.
 
+Scaladoc can be somewhat slow to build. In that case, you can tell Bazel to build this target manually,
+i.e. only when named explicitly and not through wildcards: `tags = ["manual"]`.
+
 ## Example
 
 scala_doc(

--- a/docs/scala_doc.md
+++ b/docs/scala_doc.md
@@ -15,6 +15,7 @@ i.e. only when named explicitly and not through wildcards: `tags = ["manual"]`.
 
 ## Example
 
+```python
 scala_doc(
     name = "scala_docs",
     tags = ["manual"],

--- a/docs/scala_doc.md
+++ b/docs/scala_doc.md
@@ -24,6 +24,10 @@ scala_doc(
         ":target2",
         ":anothertarget",
     ],
+    scalacopts = [
+        "-Ypartial-unification",
+        "-Ywarn-unused-import",
+    ],
 )
 
 # Use pkg_tar to tarball up
@@ -41,3 +45,4 @@ pkg_tar(
 | --------------------- | ----------------------------------------------------- |
 | name                  | `Name, required` <br> A unique name for this target.
 | deps                  | `List of labels, optional` <br> Labels for which you want to create scaladoc.
+| scalacopts            | `List of strings, optional` <br> Extra compiler options for this library to be passed to scalac.

--- a/docs/scala_doc.md
+++ b/docs/scala_doc.md
@@ -4,7 +4,6 @@
 scala_binary(
     name,
     deps,
-    plugins,
 )
 ```
 
@@ -15,7 +14,6 @@ for targets, including sources from upstream deps. Readily hostable HTML is writ
 
 scala_doc(
     name = "scala_docs",
-    plugins = ["//external:path/to/kind-projector.jar],
     tags = ["manual"],
     deps = [
         ":target1",
@@ -39,4 +37,3 @@ pkg_tar(
 | --------------------- | ----------------------------------------------------- |
 | name                  | `Name, required` <br> A unique name for this target.
 | deps                  | `List of labels, optional` <br> Labels for which you want to create scaladoc.
-| plugins               | `List of labels, optional` <br> Scala compiler plugins to pass through to the scaladoc tool.

--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -36,6 +36,23 @@ def collect_jars(
     else:
         return _collect_jars_when_dependency_analyzer_is_on(dep_targets)
 
+def collect_plugin_paths(plugins):
+    """Get the actual jar paths of plugins as a depset."""
+    paths = []
+    for p in plugins:
+        if hasattr(p, "path"):
+            paths.append(p)
+        elif hasattr(p, "scala"):
+            paths.extend([j.class_jar for j in p.scala.outputs.jars])
+        elif hasattr(p, "java"):
+            paths.extend([j.class_jar for j in p.java.outputs.jars])
+            # support http_file pointed at a jar. http_jar uses ijar,
+            # which breaks scala macros
+
+        elif hasattr(p, "files"):
+            paths.extend([f for f in p.files if not_sources_jar(f.basename)])
+    return depset(paths)
+
 def _collect_jars_when_dependency_analyzer_is_off(
         dep_targets,
         unused_dependency_checker_is_off,

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -32,6 +32,10 @@ load(
     "@io_bazel_rules_scala//scala:plusone.bzl",
     _collect_plus_one_deps_aspect = "collect_plus_one_deps_aspect",
 )
+load(
+    "@io_bazel_rules_scala//scala:scala_doc.bzl",
+    _scala_doc = "scala_doc",
+)
 
 _launcher_template = {
     "_java_stub_template": attr.label(
@@ -700,3 +704,5 @@ def scala_specs2_junit_test(name, **kwargs):
         suite_class = "io.bazel.rulesscala.specs2.Specs2DiscoveredTestSuite",
         **kwargs
     )
+
+scala_doc = _scala_doc

--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -40,7 +40,8 @@ scaladoc_aspect = aspect(
 )
 
 def _scala_doc_impl(ctx):
-    output_path = ctx.outputs.html
+    # scaladoc warns if you don't have the output directory already created, which is annoying.
+    output_path = ctx.actions.declare_directory("{}.html".format(ctx.attr.name))
 
     # Collect all source files and compile_jars to pass to scaladoc by way of an aspect.
     src_files = depset(transitive = [dep[ScaladocAspectInfo].src_files for dep in ctx.attr.deps])
@@ -56,7 +57,7 @@ def _scala_doc_impl(ctx):
     # See `scaladoc -help` for more information.
     args = ctx.actions.args()
     args.add("-usejavacp")
-    args.add("-d", output_path)
+    args.add("-d", output_path.path)
     args.add_all(plugins, format_each = "-Xplugin:%s")
     args.add_joined("-classpath", classpath, join_with = ":")
     args.add_all(src_files)
@@ -86,6 +87,5 @@ scala_doc = rule(
         ),
     },
     doc = "Generate Scaladoc HTML documentation for source files in from the given dependencies.",
-    outputs = {"html": "%{name}.html"},
     implementation = _scala_doc_impl,
 )

--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -66,6 +66,7 @@ def _scala_doc_impl(ctx):
     # See `scaladoc -help` for more information.
     args = ctx.actions.args()
     args.add("-usejavacp")
+    args.add("-nowarn")  # turn off warnings for now since they can obscure actual errors for large scala_doc targets
     args.add_all(ctx.attr.scalacopts)
     args.add("-d", output_path.path)
     args.add_all(plugins, format_each = "-Xplugin:%s")

--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -2,7 +2,7 @@
 
 load("@io_bazel_rules_scala//scala/private:common.bzl", "collect_plugin_paths")
 
-ScaladocAspectInfo = provider(fields = [
+_ScaladocAspectInfo = provider(fields = [
     "src_files",
     "compile_jars",
     "plugins",
@@ -23,7 +23,7 @@ def _scaladoc_aspect_impl(target, ctx):
         if hasattr(ctx.rule.attr, "plugins"):
             plugins = depset(direct = ctx.rule.attr.plugins)
 
-        return [ScaladocAspectInfo(
+        return [_ScaladocAspectInfo(
             src_files = src_files,
             compile_jars = compile_jars,
             plugins = plugins,
@@ -31,7 +31,7 @@ def _scaladoc_aspect_impl(target, ctx):
     else:
         return []
 
-scaladoc_aspect = aspect(
+_scaladoc_aspect = aspect(
     implementation = _scaladoc_aspect_impl,
     attr_aspects = ["deps"],
     required_aspect_providers = [
@@ -44,11 +44,11 @@ def _scala_doc_impl(ctx):
     output_path = ctx.actions.declare_directory("{}.html".format(ctx.attr.name))
 
     # Collect all source files and compile_jars to pass to scaladoc by way of an aspect.
-    src_files = depset(transitive = [dep[ScaladocAspectInfo].src_files for dep in ctx.attr.deps])
-    compile_jars = depset(transitive = [dep[ScaladocAspectInfo].compile_jars for dep in ctx.attr.deps])
+    src_files = depset(transitive = [dep[_ScaladocAspectInfo].src_files for dep in ctx.attr.deps])
+    compile_jars = depset(transitive = [dep[_ScaladocAspectInfo].compile_jars for dep in ctx.attr.deps])
 
     # Get the 'real' paths to the plugin jars.
-    plugins = collect_plugin_paths(depset(transitive = [dep[ScaladocAspectInfo].plugins for dep in ctx.attr.deps]))
+    plugins = collect_plugin_paths(depset(transitive = [dep[_ScaladocAspectInfo].plugins for dep in ctx.attr.deps]))
 
     # Construct the full classpath depset since we need to add compiler plugins too.
     classpath = depset(transitive = [plugins, compile_jars])
@@ -77,7 +77,7 @@ def _scala_doc_impl(ctx):
 scala_doc = rule(
     attrs = {
         "deps": attr.label_list(
-            aspects = [scaladoc_aspect],
+            aspects = [_scaladoc_aspect],
             providers = [JavaInfo],
         ),
         "_scaladoc": attr.label(

--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -1,0 +1,86 @@
+"""Scaladoc support"""
+
+load("@io_bazel_rules_scala//scala/private:common.bzl", "collect_plugin_paths")
+
+ScaladocAspectInfo = provider(fields = [
+    "src_files",
+    "compile_jars",
+])
+
+def _scaladoc_aspect_impl(target, ctx):
+    """Collect source files and compile_jars from JavaInfo-returning deps."""
+
+    # We really only care about visited targets with srcs, so only look at those.
+    if hasattr(ctx.rule.attr, "srcs"):
+        # Collect only Java and Scala sources enumerated in visited targets.
+        src_files = depset(direct = [file for file in ctx.rule.files.srcs if file.extension.lower() in ["java", "scala"]])
+
+        # Collect compile_jars from visited targets' deps.
+        compile_jars = depset(transitive = [dep[JavaInfo].compile_jars for dep in ctx.rule.attr.deps if JavaInfo in dep])
+
+        return [ScaladocAspectInfo(
+            src_files = src_files,
+            compile_jars = compile_jars,
+        )]
+    else:
+        return []
+
+scaladoc_aspect = aspect(
+    implementation = _scaladoc_aspect_impl,
+    attr_aspects = ["deps"],
+    required_aspect_providers = [
+        [JavaInfo],
+    ],
+)
+
+def _scala_doc_impl(ctx):
+    output_path = ctx.outputs.html
+
+    # Collect all source files and compile_jars to pass to scaladoc by way of an aspect.
+    src_files = depset(transitive = [dep[ScaladocAspectInfo].src_files for dep in ctx.attr.deps])
+    compile_jars = depset(transitive = [dep[ScaladocAspectInfo].compile_jars for dep in ctx.attr.deps])
+
+    # Get the 'real' paths to the plugin jars.
+    plugins = collect_plugin_paths(ctx.attr.plugins)
+
+    # Construct the full classpath depset since we need to add compiler plugins too.
+    classpath = depset(transitive = [plugins, compile_jars])
+
+    # Construct scaladoc args, which also include scalac args.
+    # See `scaladoc -help` for more information.
+    args = ctx.actions.args()
+    args.add("-usejavacp")
+    args.add("-d", output_path)
+    args.add_all(plugins, format_each = "-Xplugin:%s")
+    args.add_joined("-classpath", classpath, join_with = ":")
+    args.add_all(src_files)
+
+    # Run the scaladoc tool!
+    ctx.actions.run(
+        inputs = depset(transitive = [src_files, classpath]),
+        outputs = [output_path],
+        executable = ctx.attr._scaladoc.files_to_run.executable,
+        mnemonic = "ScalaDoc",
+        progress_message = "scaladoc {}".format(ctx.label),
+        arguments = [args],
+    )
+
+    return [DefaultInfo(files = depset(direct = [output_path]))]
+
+scala_doc = rule(
+    attrs = {
+        "deps": attr.label_list(
+            aspects = [scaladoc_aspect],
+            providers = [JavaInfo],
+        ),
+        "plugins": attr.label_list(allow_files = [".jar"]),
+        "_scaladoc": attr.label(
+            cfg = "host",
+            executable = True,
+            default = Label("//src/scala/io/bazel/rules_scala/scaladoc_support:scaladoc_generator"),
+        ),
+    },
+    doc = "Generate Scaladoc HTML documentation for source files in from the given dependencies.",
+    outputs = {"html": "%{name}.html"},
+    implementation = _scala_doc_impl,
+)

--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -66,6 +66,7 @@ def _scala_doc_impl(ctx):
     # See `scaladoc -help` for more information.
     args = ctx.actions.args()
     args.add("-usejavacp")
+    args.add_all(ctx.attr.scalacopts)
     args.add("-d", output_path.path)
     args.add_all(plugins, format_each = "-Xplugin:%s")
     args.add_joined("-classpath", classpath, join_with = ":")
@@ -89,6 +90,7 @@ scala_doc = rule(
             aspects = [_scaladoc_aspect],
             providers = [JavaInfo],
         ),
+        "scalacopts": attr.string_list(),
         "_scaladoc": attr.label(
             cfg = "host",
             executable = True,

--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -70,7 +70,7 @@ def _scala_doc_impl(ctx):
     args.add_all(ctx.attr.scalacopts)
     args.add("-d", output_path.path)
     args.add_all(plugins, format_each = "-Xplugin:%s")
-    args.add_joined("-classpath", classpath, join_with = ":")
+    args.add_joined("-classpath", classpath, join_with = ctx.configuration.host_path_separator)
     args.add_all(src_files)
 
     # Run the scaladoc tool!

--- a/src/scala/io/bazel/rules_scala/scaladoc_support/BUILD
+++ b/src/scala/io/bazel/rules_scala/scaladoc_support/BUILD
@@ -1,0 +1,17 @@
+load("//scala:scala.bzl", "scala_binary")
+
+# A simple scala_binary to run scaladoc.
+# `bazel run` this target with "-help" as a param for usage text:
+# bazel run -- "//src/scala/io/bazel/rules_scala/scaladoc_support:scaladoc_generator" -help
+scala_binary(
+    name = "scaladoc_generator",
+    main_class = "scala.tools.nsc.ScalaDoc",
+    visibility = ["//visibility:public"],
+    runtime_deps = [
+        "//external:io_bazel_rules_scala/dependency/scala/parser_combinators",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_compiler",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
+        "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
+    ],
+)

--- a/test/BUILD
+++ b/test/BUILD
@@ -3,6 +3,7 @@ package(default_testonly = 1)
 load(
     "//scala:scala.bzl",
     "scala_binary",
+    "scala_doc",
     "scala_library",
     "scala_test",
     "scala_macro_library",
@@ -135,6 +136,15 @@ scala_library(
     name = "OtherLib",
     srcs = ["OtherLib.scala"],
     deps = ["ExportOnly"],
+)
+
+scala_doc(
+    name = "ScalaDoc",
+    deps = [
+        ":HelloLib",
+        ":OtherLib",
+        "//test/src/main/scala/scalarules/test/compiler_plugin",  # brings kind-projector compiler plugin with it
+    ]
 )
 
 scala_library(

--- a/test/src/main/scala/scalarules/test/compiler_plugin/BUILD.bazel
+++ b/test/src/main/scala/scalarules/test/compiler_plugin/BUILD.bazel
@@ -2,6 +2,7 @@ load("//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "compiler_plugin",
-    srcs = [ "KindProjected.scala" ],
-    plugins = ["@org_spire_math_kind_projector//jar"]
+    srcs = ["KindProjected.scala"],
+    plugins = ["@org_spire_math_kind_projector//jar"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Closes https://github.com/bazelbuild/rules_scala/issues/230.

### Summary

This PR adds a basic implementation of `scala_doc`.

I hesitate to recommend using it widely yet since I haven't figured out if there are weird edge cases. Would it be better to somehow designate this as experimental or something?

I did _not_ automatically compress outputted scaladoc, instead I think you could use `pkg_tar`.

### Performance

For an internal target, scaladoc takes ~17sec to scaladoc for "324 documentable templates".

Comparatively, cats-core takes ~32sec to scaladoc for "771 documentable templates":
```
sbt:cats> coreJVM/doc
[info] Main Scala API documentation to /Users/long/oss/cats/core/.jvm/target/scala-2.12/api...
model contains 771 documentable templates
[info] Main Scala API documentation successful.
[success] Total time: 32 s, completed May 29, 2019 2:01:16 PM
```

... which seems to makes sense to me.

To wit, I've added a note in the markdown documentation that users may want to mark `scala_doc` targets as manually built but YMMV.

### Testing

- Added a simple test target that also pulls in kind-projector and passes that along via aspect as a compiler plugin to `scaladoc`.
- Ran this against an internal `scala_doc` target.