### PR TITLE
Explicitly convert depset to list

### DIFF
--- a/scala/scala_doc.bzl
+++ b/scala/scala_doc.bzl
@@ -57,7 +57,7 @@ def _scala_doc_impl(ctx):
     compile_jars = depset(transitive = [dep[_ScaladocAspectInfo].compile_jars for dep in ctx.attr.deps])
 
     # Get the 'real' paths to the plugin jars.
-    plugins = collect_plugin_paths(depset(transitive = [dep[_ScaladocAspectInfo].plugins for dep in ctx.attr.deps]))
+    plugins = collect_plugin_paths(depset(transitive = [dep[_ScaladocAspectInfo].plugins for dep in ctx.attr.deps]).to_list())
 
     # Construct the full classpath depset since we need to add compiler plugins too.
     classpath = depset(transitive = [plugins, compile_jars])


### PR DESCRIPTION
This will be required by Bazel 0.27, where the flag
`--incompatible_no_support_tools_in_action_inputs` will be on by
default.

The function `collect_plugin_paths` iterates over its argument, so we
need to flatten the depset.