### PR TITLE
Add Canva to the adopters list

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for more info.
 Here's a (non-exhaustive) list of companies that use `rules_scala` in production. Don't see yours? [You can add it in a PR](https://github.com/bazelbuild/rules_scala/edit/master/README.md)!
 
 * [Ascend](https://ascend.io/)
+* [Canva](https://www.canva.com/)
 * [Etsy](https://www.etsy.com/)
 * [Kitty Hawk](https://kittyhawk.aero/)
 * [Meetup](https://meetup.com/)


### PR DESCRIPTION
### Description

We're using Bazel in our Data Engineering + Data Science monorepo to build Scala (and Python) 🙂 