### PR TITLE
JavaInfo provider should be given for deps

### DIFF
--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -131,10 +131,10 @@ _common_attrs_for_plugin_bootstrapping = {
             _collect_plus_one_deps_aspect,
             _coverage_replacements_provider.aspect,
         ],
-        providers = [JavaInfo],
+        providers = [[JavaInfo]],
     ),
     "plugins": attr.label_list(allow_files = [".jar"]),
-    "runtime_deps": attr.label_list(providers = [JavaInfo]),
+    "runtime_deps": attr.label_list(providers = [[JavaInfo]]),
     "data": attr.label_list(allow_files = True),
     "resources": attr.label_list(allow_files = True),
     "resource_strip_prefix": attr.string(),
@@ -673,7 +673,7 @@ _scala_junit_test_attrs.update(_common_attrs)
 _scala_junit_test_attrs.update(_junit_resolve_deps)
 
 _scala_junit_test_attrs.update({
-    "tests_from": attr.label_list(providers = [JavaInfo]),
+    "tests_from": attr.label_list(providers = [[JavaInfo]]),
 })
 
 scala_junit_test = rule(

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -126,10 +126,13 @@ _common_attrs_for_plugin_bootstrapping = {
         ".srcjar",
         ".java",
     ]),
-    "deps": attr.label_list(aspects = [
-        _collect_plus_one_deps_aspect,
-        _coverage_replacements_provider.aspect,
-    ]),
+    "deps": attr.label_list(
+        aspects = [
+            _collect_plus_one_deps_aspect,
+            _coverage_replacements_provider.aspect,
+        ],
+        providers = [[JavaInfo]],
+    ),
     "plugins": attr.label_list(allow_files = [".jar"]),
     "runtime_deps": attr.label_list(providers = [[JavaInfo]]),
     "data": attr.label_list(allow_files = True),

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -131,10 +131,10 @@ _common_attrs_for_plugin_bootstrapping = {
             _collect_plus_one_deps_aspect,
             _coverage_replacements_provider.aspect,
         ],
-        providers = [[JavaInfo]],
+        providers = [JavaInfo],
     ),
     "plugins": attr.label_list(allow_files = [".jar"]),
-    "runtime_deps": attr.label_list(providers = [[JavaInfo]]),
+    "runtime_deps": attr.label_list(providers = [JavaInfo]),
     "data": attr.label_list(allow_files = True),
     "resources": attr.label_list(allow_files = True),
     "resource_strip_prefix": attr.string(),
@@ -673,7 +673,7 @@ _scala_junit_test_attrs.update(_common_attrs)
 _scala_junit_test_attrs.update(_junit_resolve_deps)
 
 _scala_junit_test_attrs.update({
-    "tests_from": attr.label_list(providers = [[JavaInfo]]),
+    "tests_from": attr.label_list(providers = [JavaInfo]),
 })
 
 scala_junit_test = rule(


### PR DESCRIPTION
It seems like `deps` should behave like `runtime_deps` in that a `JavaInfo` provider must be given.

Opening a drive-by PR now to see if CI will build this and confirm my hunch...