### PR TITLE
remove usage of attr scala with JavaInfo outputs

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -1236,13 +1236,8 @@ def _serialize_archives_short_path(archives):
 def _get_test_archive_jars(ctx, test_archives):
     flattened_list = []
     for archive in test_archives:
-        # because we (rules_scala) use the legacy JavaInfo (java_common.create_provider)
-        # runtime_output_jars contains more jars than needed
-        if hasattr(archive, "scala"):
-            jars = [jar.class_jar for jar in archive.scala.outputs.jars]
-        else:
-            jars = archive[JavaInfo].runtime_output_jars
-        flattened_list.extend(jars)
+        class_jars = [java_output.class_jar for java_output in archive[JavaInfo].outputs.jars]
+        flattened_list.extend(class_jars)
     return flattened_list
 
 def scala_junit_test_impl(ctx):


### PR DESCRIPTION
@iirina I used to think that because we use `java_common.create_provider` then our `JavaInfo` instances are faulty and return empty sequence for `archive[JavaInfo].runtime_output_jars`.
I've now tried to remove this hack thanks to your work but it still returns an empty sequence.
1. Are we constructing the JavaInfo incorrectly?
2. Is the below usage of `outputs.jars` correct?
3. When is `runtime_output_jars` non empty?