### PR TITLE
Handle FileAlreadyExistsException in ScalaPBGenerator

### DIFF
--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -1,7 +1,7 @@
 package scripts
 
 import java.io.PrintStream
-import java.nio.file.Path
+import java.nio.file.{Path, FileAlreadyExistsException}
 
 import io.bazel.rulesscala.io_utils.DeleteRecursively
 import io.bazel.rulesscala.jar.JarCreator
@@ -12,6 +12,7 @@ import scalapb.ScalaPbCodeGenerator
 import java.nio.file.{Files, Paths}
 import scalapb.{ScalaPBC, ScalaPbCodeGenerator, ScalaPbcException}
 import java.net.URLClassLoader
+import scala.util.{Try, Failure}
 
 object ScalaPBWorker extends GenericWorker(new ScalaPBGenerator) {
 
@@ -39,7 +40,13 @@ class ScalaPBGenerator extends Processor {
       val relativePath = root.relativize(fullPath)
 
       relativePath.toFile.getParentFile.mkdirs
-      Files.copy(fullPath, relativePath)
+      Try(Files.copy(fullPath, relativePath)) match {
+        case Failure(err) if err.isInstanceOf[FileAlreadyExistsException] =>
+          Console.println(s"File already exists, skipping: ${err.getMessage}")
+        case Failure(err) =>
+          sys.error(err.getMessage)
+        case _ => ()
+      }
     }
   }
   def deleteDir(path: Path): Unit =

--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -41,10 +41,9 @@ class ScalaPBGenerator extends Processor {
 
       relativePath.toFile.getParentFile.mkdirs
       Try(Files.copy(fullPath, relativePath)) match {
-        case Failure(err) if err.isInstanceOf[FileAlreadyExistsException] =>
+        case Failure(err: FileAlreadyExistsException) =>
           Console.println(s"File already exists, skipping: ${err.getMessage}")
-        case Failure(err) =>
-          sys.error(err.getMessage)
+        case Failure(err) => throw err
         case _ => ()
       }
     }


### PR DESCRIPTION
workaround for https://github.com/bazelbuild/rules_scala/issues/779