### PR TITLE
Remove warning if dep has no JavaInfo since it's required now

### DIFF
--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -67,21 +67,18 @@ def _collect_jars_when_dependency_analyzer_is_off(
     for dep_target in dep_targets:
         # we require a JavaInfo for dependencies
         # must use java_import or scala_import if you have raw files
-        if JavaInfo in dep_target:
-            java_provider = dep_target[JavaInfo]
-            deps_providers.append(java_provider)
-            compile_jars.append(java_provider.compile_jars)
-            runtime_jars.append(java_provider.transitive_runtime_jars)
+        java_provider = dep_target[JavaInfo]
+        deps_providers.append(java_provider)
+        compile_jars.append(java_provider.compile_jars)
+        runtime_jars.append(java_provider.transitive_runtime_jars)
 
-            if not unused_dependency_checker_is_off:
-                add_labels_of_jars_to(
-                    jars2labels,
-                    dep_target,
-                    [],
-                    java_provider.compile_jars.to_list(),
-                )
-        else:
-            print("ignored dependency, has no JavaInfo: " + str(dep_target))
+        if not unused_dependency_checker_is_off:
+            add_labels_of_jars_to(
+                jars2labels,
+                dep_target,
+                [],
+                java_provider.compile_jars.to_list(),
+            )
 
         if (not plus_one_deps_is_off) and (PlusOneDeps in dep_target):
             plus_one_deps_compile_jars.append(
@@ -106,24 +103,21 @@ def _collect_jars_when_dependency_analyzer_is_on(dep_targets):
     for dep_target in dep_targets:
         # we require a JavaInfo for dependencies
         # must use java_import or scala_import if you have raw files
-        if JavaInfo in dep_target:
-            java_provider = dep_target[JavaInfo]
-            deps_providers.append(java_provider)
-            current_dep_compile_jars = java_provider.compile_jars
-            current_dep_transitive_compile_jars = java_provider.transitive_compile_time_jars
-            runtime_jars.append(java_provider.transitive_runtime_jars)
+        java_provider = dep_target[JavaInfo]
+        deps_providers.append(java_provider)
+        current_dep_compile_jars = java_provider.compile_jars
+        current_dep_transitive_compile_jars = java_provider.transitive_compile_time_jars
+        runtime_jars.append(java_provider.transitive_runtime_jars)
 
-            compile_jars.append(current_dep_compile_jars)
-            transitive_compile_jars.append(current_dep_transitive_compile_jars)
+        compile_jars.append(current_dep_compile_jars)
+        transitive_compile_jars.append(current_dep_transitive_compile_jars)
 
-            add_labels_of_jars_to(
-                jars2labels,
-                dep_target,
-                current_dep_transitive_compile_jars.to_list(),
-                current_dep_compile_jars.to_list(),
-            )
-        else:
-            print("ignored dependency, has no JavaInfo: " + str(dep_target))
+        add_labels_of_jars_to(
+            jars2labels,
+            dep_target,
+            current_dep_transitive_compile_jars.to_list(),
+            current_dep_compile_jars.to_list(),
+        )
 
     return struct(
         compile_jars = depset(transitive = compile_jars),


### PR DESCRIPTION
Follow-on from https://github.com/bazelbuild/rules_scala/pull/774.

Since deps now require `JavaInfo` providers this check is no longer needed.