### PR TITLE
Remove the deprecated attribute proto_source_root.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,10 +20,9 @@ env:
   # See https://github.com/bazelbuild/rules_scala/pull/622
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
-  - V=0.23.1 TEST_SCRIPT=test_rules_scala
-  - V=0.28.0 TEST_SCRIPT=test_rules_scala
+  - V=0.28.1 TEST_SCRIPT=test_rules_scala
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.23.1 TEST_SCRIPT=test_reproducibility
+  - V=0.28.1 TEST_SCRIPT=test_reproducibility
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
   - V=0.28.0 TEST_SCRIPT=test_rules_scala
-    #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
+  #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.28.0 TEST_SCRIPT=test_reproducibility
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
   - V=0.28.0 TEST_SCRIPT=test_rules_scala
-  #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
+    #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.28.0 TEST_SCRIPT=test_reproducibility
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
   # See https://github.com/bazelbuild/rules_scala/pull/622
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
-  - V=0.28.1 TEST_SCRIPT=test_rules_scala
+  - V=0.26 TEST_SCRIPT=test_rules_scala
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.28.1 TEST_SCRIPT=test_reproducibility
+  - V=0.26 TEST_SCRIPT=test_reproducibility
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
   - V=0.26.0 TEST_SCRIPT=test_rules_scala
-    #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
+  #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.26.0 TEST_SCRIPT=test_reproducibility
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
   # See https://github.com/bazelbuild/rules_scala/pull/622
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
-  - V=0.26.0 TEST_SCRIPT=test_rules_scala
+  - V=0.28.0 TEST_SCRIPT=test_rules_scala
   #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.26.0 TEST_SCRIPT=test_reproducibility
+  - V=0.28.0 TEST_SCRIPT=test_reproducibility
 
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,9 +20,9 @@ env:
   # See https://github.com/bazelbuild/rules_scala/pull/622
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
-  - V=0.26 TEST_SCRIPT=test_rules_scala
+  - V=0.26.0 TEST_SCRIPT=test_rules_scala
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.26 TEST_SCRIPT=test_reproducibility
+  - V=0.26.0 TEST_SCRIPT=test_reproducibility
 
 
 before_install:

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -334,7 +334,7 @@ def _interim_java_provider_for_java_compilation(scala_output):
     return JavaInfo(
         output_jar = scala_output,
         compile_jar = scala_output,
-        neverlink = True,
+        neverlink = True
     )
 
 def _scalac_provider(ctx):
@@ -389,7 +389,7 @@ def try_to_compile_java_jar(
         ijar = provider.compile_jars.to_list().pop(),
         jar = full_java_jar,
         source_jars = provider.source_jars,
-        java_compilation_provider = provider,
+        java_compilation_provider = provider
     )
 
 def collect_java_providers_of(deps):
@@ -426,7 +426,7 @@ def _compile_or_empty(
             ijars = [ctx.outputs.jar],
             java_jar = False,
             source_jars = [],
-            merged_provider = scala_compilation_provider,
+            merged_provider = scala_compilation_provider
         )
     else:
         in_srcjars = [
@@ -525,7 +525,7 @@ def _compile_or_empty(
             ijars = ijars,
             java_jar = java_jar,
             source_jars = source_jars,
-            merged_provider = merged_provider,
+            merged_provider = merged_provider
         )
 
 def _create_scala_compilation_provider(ctx, ijar, source_jar, deps_providers):
@@ -769,13 +769,13 @@ def _collect_jars_from_common_ctx(
         transitive_rjars,
         jars2labels,
         transitive_compile_jars,
-        deps_providers,
+        deps_providers
     ) = (
         deps_jars.compile_jars,
         deps_jars.transitive_runtime_jars,
         deps_jars.jars2labels,
         deps_jars.transitive_compile_jars,
-        deps_jars.deps_providers,
+        deps_jars.deps_providers
     )
 
     transitive_rjars = depset(
@@ -1007,7 +1007,6 @@ def _pack_source_jar(ctx):
 
 def _pack_source_jars(ctx):
     source_jar = _pack_source_jar(ctx)
-
     #_pack_source_jar may return None if java_common.pack_sources returned None (and it can)
     return [source_jar] if source_jar else []
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -334,7 +334,7 @@ def _interim_java_provider_for_java_compilation(scala_output):
     return JavaInfo(
         output_jar = scala_output,
         compile_jar = scala_output,
-        neverlink = True
+        neverlink = True,
     )
 
 def _scalac_provider(ctx):
@@ -389,7 +389,7 @@ def try_to_compile_java_jar(
         ijar = provider.compile_jars.to_list().pop(),
         jar = full_java_jar,
         source_jars = provider.source_jars,
-        java_compilation_provider = provider
+        java_compilation_provider = provider,
     )
 
 def collect_java_providers_of(deps):
@@ -426,7 +426,7 @@ def _compile_or_empty(
             ijars = [ctx.outputs.jar],
             java_jar = False,
             source_jars = [],
-            merged_provider = scala_compilation_provider
+            merged_provider = scala_compilation_provider,
         )
     else:
         in_srcjars = [
@@ -525,7 +525,7 @@ def _compile_or_empty(
             ijars = ijars,
             java_jar = java_jar,
             source_jars = source_jars,
-            merged_provider = merged_provider
+            merged_provider = merged_provider,
         )
 
 def _create_scala_compilation_provider(ctx, ijar, source_jar, deps_providers):
@@ -769,13 +769,13 @@ def _collect_jars_from_common_ctx(
         transitive_rjars,
         jars2labels,
         transitive_compile_jars,
-        deps_providers
+        deps_providers,
     ) = (
         deps_jars.compile_jars,
         deps_jars.transitive_runtime_jars,
         deps_jars.jars2labels,
         deps_jars.transitive_compile_jars,
-        deps_jars.deps_providers
+        deps_jars.deps_providers,
     )
 
     transitive_rjars = depset(
@@ -1007,6 +1007,7 @@ def _pack_source_jar(ctx):
 
 def _pack_source_jars(ctx):
     source_jar = _pack_source_jar(ctx)
+
     #_pack_source_jar may return None if java_common.pack_sources returned None (and it can)
     return [source_jar] if source_jar else []
 

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -20,16 +20,16 @@ scala_proto_toolchain(
         "//test/proto:blacklisted_proto",
         "//test/proto:other_blacklisted_proto",
     ],
+    extra_generator_dependencies = [
+        "//test/src/main/scala/scalarules/test/extra_protobuf_generator",
+    ],
+    named_generators = {
+        "jvm_extra_protobuf_generator": "scalarules.test.extra_protobuf_generator.ExtraProtobufGenerator",
+    },
     visibility = ["//visibility:public"],
     with_flat_package = False,
     with_grpc = True,
     with_single_line_to_string = True,
-    named_generators = {
-        'jvm_extra_protobuf_generator': 'scalarules.test.extra_protobuf_generator.ExtraProtobufGenerator',
-    },
-    extra_generator_dependencies = [
-        "//test/src/main/scala/scalarules/test/extra_protobuf_generator",
-    ],
 )
 
 toolchain(
@@ -82,19 +82,19 @@ scalapb_proto_library(
 
 # Test that the `proto_source_root` attribute is handled properly
 proto_library(
-    name = "proto_source_root",
+    name = "strip_import_prefix",
     srcs = [
         "different_root.proto",
         "different_root2.proto",
     ],
-    proto_source_root = package_name(),
+    strip_import_prefix = "",
     visibility = ["//visibility:public"],
 )
 
 scalapb_proto_library(
-    name = "test_proto_source_root",
+    name = "test_strip_import_prefix",
     visibility = ["//visibility:public"],
-    deps = [":proto_source_root"],
+    deps = [":strip_import_prefix"],
 )
 
 proto_library(
@@ -157,7 +157,6 @@ scala_test(
         ":test_proto",
     ],
 )
-
 
 scala_test(
     name = "test_custom_object_exists",

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -20,16 +20,16 @@ scala_proto_toolchain(
         "//test/proto:blacklisted_proto",
         "//test/proto:other_blacklisted_proto",
     ],
-    extra_generator_dependencies = [
-        "//test/src/main/scala/scalarules/test/extra_protobuf_generator",
-    ],
-    named_generators = {
-        "jvm_extra_protobuf_generator": "scalarules.test.extra_protobuf_generator.ExtraProtobufGenerator",
-    },
     visibility = ["//visibility:public"],
     with_flat_package = False,
     with_grpc = True,
     with_single_line_to_string = True,
+    named_generators = {
+        'jvm_extra_protobuf_generator': 'scalarules.test.extra_protobuf_generator.ExtraProtobufGenerator',
+    },
+    extra_generator_dependencies = [
+        "//test/src/main/scala/scalarules/test/extra_protobuf_generator",
+    ],
 )
 
 toolchain(

--- a/test_expect_failure/proto_source_root/dependency/BUILD
+++ b/test_expect_failure/proto_source_root/dependency/BUILD
@@ -1,6 +1,6 @@
 proto_library(
     name = "dependency",
     srcs = glob(["*.proto"]),
-    proto_source_root = package_name(),
+    strip_import_prefix = "",
     visibility = ["//visibility:public"],
 )

--- a/test_expect_failure/proto_source_root/user/BUILD
+++ b/test_expect_failure/proto_source_root/user/BUILD
@@ -6,7 +6,7 @@ load(
 proto_library(
     name = "user",
     srcs = glob(["*.proto"]),
-    proto_source_root = package_name(),
+    strip_import_prefix = "",
     deps = ["//test_expect_failure/proto_source_root/dependency"],
 )
 


### PR DESCRIPTION
Replace it with strip_import_prefix, its spiritual successor.

And apparently some automatic buildifier cleanups.