### PR TITLE
warn if jvm_flags is used in scala_library

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -867,6 +867,8 @@ def get_unused_dependency_checker_mode(ctx):
         return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].unused_dependency_checker_mode
 
 def scala_library_impl(ctx):
+    if ctx.attr.jvm_flags:
+        print("'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.")
     scalac_provider = _scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(


### PR DESCRIPTION
While reviewing `scala_library` attributes I saw that `jvm_flags` is in the common attributes when actually it should be part of the common attributes for binary rules.
Added a print to clarify to users they shouldn't use this attribute and I guess we should remove it completely in ~ a month 