### PR TITLE
silence tut

### DIFF
--- a/tut_rule/tut.bzl
+++ b/tut_rule/tut.bzl
@@ -58,5 +58,5 @@ def scala_tut_doc(**kw):
         srcs = [src],
         outs = ["%s_tut.md" % name],
         tools = [tool],
-        cmd = "./$(location %s) $(location %s) \"$@\"" % (tool, src),
+        cmd = "./$(location %s) $(location %s) \"$@\" >/dev/null" % (tool, src),
     )


### PR DESCRIPTION
As per https://docs.bazel.build/versions/master/be/general.html

> Do not write informational messages to stdout or stderr. While useful for debugging, this can easily become noise; a successful genrule should be silent. On the other hand, a failing genrule should emit good error messages.

Before this change:
```
$ bazel test test/tut/...
INFO: Analyzed 3 targets (4 packages loaded, 631 targets configured).
INFO: Found 3 targets and 0 test targets...
INFO: From Executing genrule //test/tut:some_example:
[tut] compiling: test/tut/SomeExample.md
wrote: bazel-out/darwin-fastbuild/bin/test/tut/some_example_tut.md
INFO: Elapsed time: 5.178s, Critical Path: 4.49s
INFO: 1 process: 1 darwin-sandbox.
INFO: Build completed successfully, 2 total actions
INFO: Build completed successfully, 2 total actions
```

After:
```
$ bazel test test/tut/...
INFO: Analyzed 3 targets (5 packages loaded, 31 targets configured).
INFO: Found 3 targets and 0 test targets...
INFO: From Building external/com_google_protobuf/libprotobuf_java.jar (122 source files, 1 source jar) [for host]:
warning: -parameters is not supported for target value 1.7. Use 1.8 or later.
INFO: Elapsed time: 32.550s, Critical Path: 31.13s
INFO: 23 processes: 12 darwin-sandbox, 11 worker.
INFO: Build completed successfully, 47 total actions
INFO: Build completed successfully, 47 total actions
```