### PR TITLE
Due to limitations in the toolchains implementation this is required …

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ env:
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
   - V=0.23.1 TEST_SCRIPT=test_rules_scala
-  - V=0.28.1 TEST_SCRIPT=test_rules_scala
+  - V=0.28.0 TEST_SCRIPT=test_rules_scala
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.23.1 TEST_SCRIPT=test_reproducibility
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@ env:
   # we want to test the last release
   #- V=0.16.1 TEST_SCRIPT=test_lint.sh
   - V=0.23.1 TEST_SCRIPT=test_rules_scala
+  - V=0.28.1 TEST_SCRIPT=test_rules_scala
     #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
   - V=0.23.1 TEST_SCRIPT=test_reproducibility
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -177,7 +177,7 @@ def compile_scala(
 
         transitive_cjars_list = transitive_compile_jars.to_list()
         indirect_jars = _join_path(transitive_cjars_list)
-        indirect_targets = ",".join([labels[j.path] for j in transitive_cjars_list])
+        indirect_targets = ",".join([str(labels[j.path]) for j in transitive_cjars_list])
 
         current_target = str(target_label)
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -655,7 +655,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
         )
         ctx.actions.write(jacoco_metadata_file, "\n".join([
             jar.short_path.replace("../", "external/")
-            for jar in rjars
+            for jar in rjars.to_list()
         ]))
         ctx.actions.expand_template(
             template = template,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -1191,7 +1191,7 @@ def scala_test_impl(ctx):
 
         rjars = depset([
             coverage_replacements[jar] if jar in coverage_replacements else jar
-            for jar in rjars
+            for jar in rjars.to_list()
         ])
         coverage_runfiles = ctx.files._jacocorunner + ctx.files._lcov_merger + coverage_replacements.values()
 

--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -1,4 +1,6 @@
 load("//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
+load("//scala_proto:default_dep_sets.bzl", "DEFAULT_SCALAPB_COMPILE_DEPS", "DEFAULT_SCALAPB_GRPC_DEPS")
+
 
 toolchain_type(
     name = "toolchain_type",
@@ -34,5 +36,18 @@ toolchain(
     name = "enable_all_options_toolchain",
     toolchain = ":enable_all_options_toolchain_impl",
     toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+
+java_library(
+    name="default_scalapb_compile_dependencies",
+    exports = DEFAULT_SCALAPB_COMPILE_DEPS,
+    visibility = ["//visibility:public"],
+)
+
+java_library(
+    name="default_scalapb_grpc_dependencies",
+    exports = DEFAULT_SCALAPB_GRPC_DEPS,
     visibility = ["//visibility:public"],
 )

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -133,11 +133,11 @@ def _scalapb_aspect_impl(target, ctx):
 
         toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
         flags = []
-        imps = [j[JavaInfo] for j in toolchain.implicit_compile_deps]
+        imps = [j[JavaInfo] for j in ctx.attr._implicit_compile_deps]
 
         if toolchain.with_grpc:
             flags.append("grpc")
-            imps.extend([j[JavaInfo] for j in toolchain.grpc_deps])
+            imps.extend([j[JavaInfo] for j in ctx.attr._grpc_deps])
 
         if toolchain.with_flat_package:
             flags.append("flat_package")
@@ -224,6 +224,12 @@ scalapb_aspect = aspect(
     ],
     attrs = {
         "_protoc": attr.label(executable = True, cfg = "host", default = "@com_google_protobuf//:protoc"),
+        "_implicit_compile_deps": attr.label_list(cfg = "target", default = [
+                "//external:io_bazel_rules_scala/dependency/proto/implicit_compile_deps",
+            ]),
+        "_grpc_deps": attr.label_list(cfg = "target", default = [
+                "//external:io_bazel_rules_scala/dependency/proto/grpc_deps",
+            ])
     },
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -15,7 +15,6 @@ load(
 )
 
 def register_default_proto_dependencies():
-    print("here")
     if native.existing_rule("io_bazel_rules_scala/dependency/proto/grpc_deps") == None:
         native.bind(
             name = "io_bazel_rules_scala/dependency/proto/grpc_deps",

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -14,10 +14,30 @@ load(
     "scalapb_aspect",
 )
 
+def register_default_proto_dependencies():
+    print("here")
+    if native.existing_rule("io_bazel_rules_scala/dependency/proto/grpc_deps") == None:
+        native.bind(
+            name = "io_bazel_rules_scala/dependency/proto/grpc_deps",
+            actual = "@io_bazel_rules_scala//scala_proto:default_scalapb_compile_dependencies",
+        )
+
+    if native.existing_rule("io_bazel_rules_scala/dependency/proto/implicit_compile_deps") == None:
+        native.bind(
+            name = "io_bazel_rules_scala/dependency/proto/implicit_compile_deps",
+            actual = "@io_bazel_rules_scala//scala_proto:default_scalapb_grpc_dependencies",
+        )
+
+
+
 def scala_proto_repositories(
         scala_version = _default_scala_version(),
         maven_servers = ["http://central.maven.org/maven2"]):
-    return scala_proto_default_repositories(scala_version, maven_servers)
+    ret =  scala_proto_default_repositories(scala_version, maven_servers)
+    register_default_proto_dependencies()
+    return ret
+
+
 
 def _scalapb_proto_library_impl(ctx):
     aspect_info = merge_scalapb_aspect_info(

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -7,8 +7,6 @@ def _scala_proto_toolchain_impl(ctx):
         with_single_line_to_string = ctx.attr.with_single_line_to_string,
         blacklisted_protos = ctx.attr.blacklisted_protos,
         code_generator = ctx.attr.code_generator,
-        grpc_deps=ctx.attr.grpc_deps,
-        implicit_compile_deps=ctx.attr.implicit_compile_deps,
         extra_generator_dependencies = ctx.attr.extra_generator_dependencies,
         scalac=ctx.attr.scalac,
         named_generators = ctx.attr.named_generators,
@@ -38,14 +36,6 @@ scala_proto_toolchain = rule(
         "named_generators": attr.string_dict(),
         "extra_generator_dependencies": attr.label_list(
             providers = [JavaInfo]
-        ),
-        "grpc_deps": attr.label_list(
-            providers = [JavaInfo],
-            default = DEFAULT_SCALAPB_GRPC_DEPS
-        ),
-        "implicit_compile_deps": attr.label_list(
-            providers = [JavaInfo],
-            default = DEFAULT_SCALAPB_COMPILE_DEPS,
         ),
         "scalac": attr.label(
             default = Label(

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -114,6 +114,13 @@ scalapb_proto_library(
     deps = [":test2"],
 )
 
+scala_binary(
+    name = "test_binary_to_ensure_no_host_deps",
+    main_class = "a.b.c",
+    visibility = ["//visibility:public"],
+    deps = [":test_proto_nogrpc"],
+)
+
 java_proto_library(
     name = "test_proto_java_lib",
     deps = [

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -890,9 +890,12 @@ test_scala_classpath_resources_expect_warning_on_namespace_conflict() {
 scala_pb_library_targets_do_not_have_host_deps() {
   set -e
   bazel build test/proto:test_binary_to_ensure_no_host_deps
-  LINES=$(find bazel-bin/test/proto/test_binary_to_ensure_no_host_deps.runfiles  -name '*.jar' -exec readlink {} \; | grep 'bazel-out/host' | wc -l)
-  if [ "$LINES" != "0" ]; then
-    echo "Host deps exist in output of target"
+  set +e
+  find bazel-bin/test/proto/test_binary_to_ensure_no_host_deps.runfiles  -name '*.jar' -exec readlink {} \; | grep 'bazel-out/host'
+  RET=$?
+  set -e
+  if [ "$RET" == "0" ]; then
+    echo "Host deps exist in output of target:"
     echo "Possibly toolchains limitation?"
     find bazel-bin/test/proto/test_binary_to_ensure_no_host_deps.runfiles  -name '*.jar' -exec readlink {} \; | grep 'bazel-out/host'
     exit 1

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -887,6 +887,18 @@ test_scala_classpath_resources_expect_warning_on_namespace_conflict() {
   fi
 }
 
+scala_pb_library_targets_do_not_have_host_deps() {
+  set -e
+  bazel build test/proto:test_binary_to_ensure_no_host_deps
+  LINES=$(find bazel-bin/test/proto/test_binary_to_ensure_no_host_deps.runfiles  -name '*.jar' -exec readlink {} \; | grep 'bazel-out/host' | wc -l)
+  if [ "$LINES" != "0" ]; then
+    echo "Host deps exist in output of target"
+    echo "Possibly toolchains limitation?"
+    find bazel-bin/test/proto/test_binary_to_ensure_no_host_deps.runfiles  -name '*.jar' -exec readlink {} \; | grep 'bazel-out/host'
+    exit 1
+  fi
+}
+
 scala_binary_common_jar_is_exposed_in_build_event_protocol() {
   local target=$1
   set +e
@@ -1088,3 +1100,4 @@ $runner test_plus_one_deps_only_works_for_java_info_targets
 $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
 $runner test_unused_dependency_fails_even_if_also_exists_in_plus_one_deps
 $runner test_coverage_on
+$runner scala_pb_library_targets_do_not_have_host_deps


### PR DESCRIPTION
…to stop these being host deps rather than target deps

First commit here should add a test, second one (once travis starts) will add a refactor to fix the test.


The bad part here is that this is due to https://groups.google.com/d/msg/bazel-discuss/vXrG6uFL5V8/RjK8_chaEgAJ

so a limitation in toolchains. The only real way i could see around this is to remove the deps portion from the toolchain and move them to be binds.


r? @johnynek 
cc @ignasl

relates to https://github.com/bazelbuild/rules_scala/issues/797

