### PR TITLE
Add scalac_jvm_flags option to toolchain

### DIFF
--- a/docs/scala_toolchain.md
+++ b/docs/scala_toolchain.md
@@ -63,6 +63,9 @@ scala_register_toolchains()
         <p>
           Extra compiler options for this binary to be passed to scalac. 
         </p>
+        <p>
+          This is overridden by the `scalac_jvm_flags` attribute on individual targets.
+        </p>
       </td>
     </tr>
     <tr>

--- a/docs/scala_toolchain.md
+++ b/docs/scala_toolchain.md
@@ -2,8 +2,6 @@
 
 `scala_toolchain` allows you to define global configuration to all Scala targets.
 
-Currently, the only option that can be set is `scalacopts` but the plan is to expand it to other options as well.
-
 **Some scala_toolchain must be registered!**
 
 ### Several options to configure `scala_toolchain`:
@@ -46,3 +44,45 @@ scala_register_toolchains()
     # WORKSPACE
     register_toolchains("//toolchains:my_scala_toolchain")
     ```
+
+<table class="table table-condensed table-bordered table-params">
+  <colgroup>
+    <col class="col-param" />
+    <col class="param-description" />
+  </colgroup>
+  <thead>
+    <tr>
+      <th colspan="2">Attributes</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <td><code>scalacopts</code></td>
+      <td>
+        <p><code>List of strings; optional</code></p>
+        <p>
+          Extra compiler options for this binary to be passed to scalac. 
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>scalac_jvm_flags</code></td>
+      <td>
+        <p><code>List of strings; optional</code></p>
+        <p>
+          List of JVM flags to be passed to scalac. For example <code>["-Xmx5G"]</code> could be passed to control memory usage of Scalac.
+        </p>
+      </td>
+    </tr>
+    <tr>
+      <td><code>unused_dependency_checker_mode</code></td>
+      <td>
+        <p><code>String; optional</code></p>
+        <p>
+          Enable unused dependency checking (see <a href="https://github.com/bazelbuild/rules_scala#experimental-unused-dependency-checking">Unused dependency checking</a>).
+          Possible values are: <code>off</code>, <code>warn</code> and <code>error</code>.
+        </p>
+      </td>
+    </tr>
+  </tbody>
+</table>

--- a/docs/scala_toolchain.md
+++ b/docs/scala_toolchain.md
@@ -84,5 +84,14 @@ scala_register_toolchains()
         </p>
       </td>
     </tr>
+    <tr>
+      <td><code>enable_code_coverage_aspect</code></td>
+      <td>
+        <p><code>"on" or "off"; optional; defaults to "off"</code></p>
+        <p>
+            This enables instrumenting tests with jacoco code coverage.
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -294,6 +294,13 @@ StatsfileOutput: {statsfile_output}
         resource_jars + [manifest, argfile] + scalac_inputs
     )
 
+    # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the
+    # toolchain
+    if scalac_jvm_flags:
+        final_scalac_jvm_flags = _expand_location(ctx, scalac_jvm_flags)
+    else:
+        final_scalac_jvm_flags = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags
+
     ctx.actions.run(
         inputs = ins,
         outputs = outs,
@@ -312,7 +319,7 @@ StatsfileOutput: {statsfile_output}
         # consume the flags on startup.
         arguments = [
             "--jvm_flag=%s" % f
-            for f in _expand_location(ctx, scalac_jvm_flags) + ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags
+            for f in final_scalac_jvm_flags
         ] + ["@" + argfile.path],
     )
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -312,7 +312,7 @@ StatsfileOutput: {statsfile_output}
         # consume the flags on startup.
         arguments = [
             "--jvm_flag=%s" % f
-            for f in _expand_location(ctx, scalac_jvm_flags)
+            for f in _expand_location(ctx, scalac_jvm_flags) + ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags
         ] + ["@" + argfile.path],
     )
 

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -10,6 +10,7 @@ def _scala_toolchain_impl(ctx):
         unused_dependency_checker_mode = ctx.attr.unused_dependency_checker_mode,
         plus_one_deps_mode = ctx.attr.plus_one_deps_mode,
         enable_code_coverage_aspect = ctx.attr.enable_code_coverage_aspect,
+        scalac_jvm_flags = ctx.attr.scalac_jvm_flags,
     )
     return [toolchain]
 
@@ -32,6 +33,7 @@ scala_toolchain = rule(
         "enable_code_coverage_aspect": attr.string(
             default = "off",
             values = ["off", "on"],
-        )
+        ),
+        "scalac_jvm_flags": attr.string_list(),
     },
 )

--- a/test_expect_failure/scalac_jvm_opts/BUILD
+++ b/test_expect_failure/scalac_jvm_opts/BUILD
@@ -1,0 +1,35 @@
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("//scala:scala.bzl", "scala_library")
+
+scala_toolchain(
+    name = "failing_toolchain_impl",
+    # This will fail because 1 meg isn't enough
+    scalac_jvm_flags = ["-Xmx1M"],
+    visibility = ["//visibility:public"],
+)
+
+scala_toolchain(
+    name = "passing_toolchain_impl",
+    # This will fail because 1 meg isn't enough
+    scalac_jvm_flags = ["-Xmx1G"],
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "failing_scala_toolchain",
+    toolchain = "failing_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "passing_scala_toolchain",
+    toolchain = "passing_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+scala_library(
+    name = "empty_build",
+    srcs = ["Empty.scala"],
+)

--- a/test_expect_failure/scalac_jvm_opts/BUILD
+++ b/test_expect_failure/scalac_jvm_opts/BUILD
@@ -3,14 +3,14 @@ load("//scala:scala.bzl", "scala_library")
 
 scala_toolchain(
     name = "failing_toolchain_impl",
-    # This will fail because 1 meg isn't enough
+    # This will fail because 1M isn't enough
     scalac_jvm_flags = ["-Xmx1M"],
     visibility = ["//visibility:public"],
 )
 
 scala_toolchain(
     name = "passing_toolchain_impl",
-    # This will fail because 1 meg isn't enough
+    # This will pass because 5G is enough
     scalac_jvm_flags = ["-Xmx1G"],
     visibility = ["//visibility:public"],
 )

--- a/test_expect_failure/scalac_jvm_opts/BUILD
+++ b/test_expect_failure/scalac_jvm_opts/BUILD
@@ -10,7 +10,7 @@ scala_toolchain(
 
 scala_toolchain(
     name = "passing_toolchain_impl",
-    # This will pass because 5G is enough
+    # This will pass because 1G is enough
     scalac_jvm_flags = ["-Xmx1G"],
     visibility = ["//visibility:public"],
 )
@@ -32,4 +32,12 @@ toolchain(
 scala_library(
     name = "empty_build",
     srcs = ["Empty.scala"],
+)
+
+scala_library(
+    name = "empty_overriding_build",
+    srcs = ["Empty.scala"],
+    # This overrides the option passed in on the toolchain, and should BUILD, even if
+    # the `failing_scala_toolchain` is used.
+    scalac_jvm_flags = ["-Xmx1G"],
 )

--- a/test_expect_failure/scalac_jvm_opts/Empty.scala
+++ b/test_expect_failure/scalac_jvm_opts/Empty.scala
@@ -1,0 +1,3 @@
+package test_expect_failure.scalac_jvm_opts
+
+class Empty

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -833,6 +833,10 @@ test_scalac_jvm_flags_from_scala_toolchain_passes() {
   bazel build --extra_toolchains="//test_expect_failure/scalac_jvm_opts:passing_scala_toolchain" //test_expect_failure/scalac_jvm_opts:empty_build
 }
 
+test_scalac_jvm_flags_on_target_overrides_toolchain_passes() {
+  bazel build --extra_toolchains="//test_expect_failure/scalac_jvm_opts:failing_scala_toolchain" //test_expect_failure/scalac_jvm_opts:empty_overriding_build
+}
+
 test_unused_dependency_checker_mode_set_in_rule() {
   action_should_fail build //test_expect_failure/unused_dependency_checker:failing_build
 }
@@ -1112,5 +1116,6 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 $runner test_unused_dependency_fails_even_if_also_exists_in_plus_one_deps
 $runner test_coverage_on
 $runner scala_pb_library_targets_do_not_have_host_deps
+$runner test_scalac_jvm_flags_on_target_overrides_toolchain_passes
 $runner test_scalac_jvm_flags_from_scala_toolchain_passes
 $runner test_scalac_jvm_flags_from_scala_toolchain_fails

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -825,6 +825,14 @@ test_scalaopts_from_scala_toolchain() {
   action_should_fail build --extra_toolchains="//test_expect_failure/scalacopts_from_toolchain:failing_scala_toolchain" //test_expect_failure/scalacopts_from_toolchain:failing_build
 }
 
+test_scalac_jvm_flags_from_scala_toolchain_fails() {
+  action_should_fail build --extra_toolchains="//test_expect_failure/scalac_jvm_opts:failing_scala_toolchain" //test_expect_failure/scalac_jvm_opts:empty_build
+}
+
+test_scalac_jvm_flags_from_scala_toolchain_passes() {
+  bazel build --extra_toolchains="//test_expect_failure/scalac_jvm_opts:passing_scala_toolchain" //test_expect_failure/scalac_jvm_opts:empty_build
+}
+
 test_unused_dependency_checker_mode_set_in_rule() {
   action_should_fail build //test_expect_failure/unused_dependency_checker:failing_build
 }
@@ -1104,3 +1112,5 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 $runner test_unused_dependency_fails_even_if_also_exists_in_plus_one_deps
 $runner test_coverage_on
 $runner scala_pb_library_targets_do_not_have_host_deps
+$runner test_scalac_jvm_flags_from_scala_toolchain_passes
+$runner test_scalac_jvm_flags_from_scala_toolchain_fails


### PR DESCRIPTION
This is useful for globally setting the max heap usage of Scalac workers. At Stripe, we've seen Scalac workers get killed by the kernel OOM killer because the default JVM heap size is too large.