### PR TITLE
Migrate from old-style .java provider to JavaInfo.

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -77,7 +77,7 @@ def jmh_repositories(maven_servers = ["http://central.maven.org/maven2"]):
 
 def _scala_construct_runtime_classpath(deps):
     scala_targets = [d.scala for d in deps if hasattr(d, "scala")]
-    java_targets = [d.java for d in deps if hasattr(d, "java")]
+    java_targets = [d[JavaInfo] for d in deps if hasattr(d, "JavaInfo")]
     files = []
     for scala in scala_targets:
         files.append(scala.transitive_runtime_jars)

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -76,13 +76,9 @@ def jmh_repositories(maven_servers = ["http://central.maven.org/maven2"]):
     )
 
 def _scala_construct_runtime_classpath(deps):
-    scala_targets = [d.scala for d in deps if hasattr(d, "scala")]
-    java_targets = [d[JavaInfo] for d in deps if hasattr(d, "JavaInfo")]
     files = []
-    for scala in scala_targets:
-        files.append(scala.transitive_runtime_jars)
-    for java in java_targets:
-        files.append(java.transitive_runtime_deps)
+    [files.append(target[JavaInfo].transitive_runtime_deps) for target in deps if JavaInfo in target]
+
     return depset(transitive = files)
 
 def _scala_generate_benchmark(ctx):

--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -42,9 +42,7 @@ def collect_plugin_paths(plugins):
     for p in plugins:
         if hasattr(p, "path"):
             paths.append(p)
-        elif hasattr(p, "scala"):
-            paths.extend([j.class_jar for j in p.scala.outputs.jars])
-        elif hasattr(p, "JavaInfo"):
+        elif JavaInfo in p:
             paths.extend([j.class_jar for j in p[JavaInfo].outputs.jars])
             # support http_file pointed at a jar. http_jar uses ijar,
             # which breaks scala macros

--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -44,8 +44,8 @@ def collect_plugin_paths(plugins):
             paths.append(p)
         elif hasattr(p, "scala"):
             paths.extend([j.class_jar for j in p.scala.outputs.jars])
-        elif hasattr(p, "java"):
-            paths.extend([j.class_jar for j in p.java.outputs.jars])
+        elif hasattr(p, "JavaInfo"):
+            paths.extend([j.class_jar for j in p[JavaInfo].outputs.jars])
             # support http_file pointed at a jar. http_jar uses ijar,
             # which breaks scala macros
 


### PR DESCRIPTION
Migrating in preparation of flipping the flag [--incompatible_disallow_legacy_java_provider](https://github.com/bazelbuild/bazel/issues/7598) in bazel.