### PR TITLE
Pin Bazel versions

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,4 +1,0 @@
-common:v0.28 --config=noop
-
-# pick something trivial as a noop
-common:noop --logging=3

--- a/.bazelrc
+++ b/.bazelrc
@@ -1,0 +1,4 @@
+common:v0.28 --config=noop
+
+# pick something trivial as a noop
+common:noop --logging=3

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
 dist: xenial
 sudo: required
-language: generic
-osx_image: xcode10.1
-
-# Not technically required but suppresses 'Ruby' in Job status message.
 language: sh
+osx_image: xcode10.1
 
 cache:
   directories:
@@ -33,7 +30,7 @@ _windows: &windows
 jobs:
   include:
     # test_rules_scala
-    - stage: test_rules_scala
+    - stage: test
       <<: *linux
       env: TEST_SCRIPT=test_rules_scala
     - <<: *osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,44 @@
-dist: xenial
+# trusty beta image has jdk8, gcc4.8.4
+dist: trusty
 sudo: required
+# xcode8 has jdk8
+osx_image: xcode8
+# Not technically required but suppresses 'Ruby' in Job status message.
 language: sh
-osx_image: xcode10.1
 
 cache:
-  directories:
-    - ~/.bazel_binaries
-    - .bazel_cache
+    directories:
+     - .bazel_cache
+     - ~/.bazel_binaries
 
 os:
   - linux
   - osx
   - windows
 
-_linux: &linux
-  os: linux
-_osx: &osx
-  os: osx
-  osx_image: xcode10.1
-_windows: &windows
-  os: windows
-  before_install:
-    - |
-      if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
-        choco install jdk8 -params 'installdir=c:\\java8'
-        choco install bazel --version ${V}
-      fi
+env:
+  # Linting is broken. Disable until fixed.
+  # See https://github.com/bazelbuild/rules_scala/pull/622
+  # we want to test the last release
+  #- V=0.16.1 TEST_SCRIPT=test_lint.sh
+  - TEST_SCRIPT=test_rules_scala
+  #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
+  - TEST_SCRIPT=test_reproducibility
 
-jobs:
-  include:
-    # test_rules_scala
-    - stage: test
-      <<: *linux
-      env: TEST_SCRIPT=test_rules_scala
-    - <<: *osx
-      env: TEST_SCRIPT=test_rules_scala
-    - <<: *windows
-      env: TEST_SCRIPT=test_rules_scala
-    # test_reproducibility
-    - stage: test_reproducibility
-      <<: *linux
-      env: TEST_SCRIPT=test_reproducibility
-    - <<: *osx
-      env: TEST_SCRIPT=test_reproducibility
-    - <<: *windows
-      env: TEST_SCRIPT=test_reproducibility
 
 before_install:
+  - |
+    if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
+      choco install jdk8 -params 'installdir=c:\\java8'
+      choco install bazel --version ${V}
+    fi
   - cat .bazelrc.travis >> .bazelrc
 
 script:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       powershell -Command 'Set-ExecutionPolicy RemoteSigned -scope CurrentUser'
-      powershell -File ./${TEST_SCRIPT}.ps1
+      BAZEL_VERSION=host powershell -File ./${TEST_SCRIPT}.ps1
     else
       bash ./${TEST_SCRIPT}.sh ci
     fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 dist: xenial
 sudo: required
-language: generic
+language: sh
 osx_image: xcode10.1
 
 cache:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,55 @@
-# trusty beta image has jdk8, gcc4.8.4
-dist: trusty
+dist: xenial
 sudo: required
-# xcode8 has jdk8
-osx_image: xcode8
+language: generic
+osx_image: xcode10.1
+
 # Not technically required but suppresses 'Ruby' in Job status message.
 language: sh
 
 cache:
-    directories:
-     - .bazel_cache
+  directories:
+    - ~/.bazel_binaries
+    - .bazel_cache
 
 os:
   - linux
   - osx
   - windows
 
-env:
-  # Linting is broken. Disable until fixed.
-  # See https://github.com/bazelbuild/rules_scala/pull/622
-  # we want to test the last release
-  #- V=0.16.1 TEST_SCRIPT=test_lint.sh
-  - V=0.28.0 TEST_SCRIPT=test_rules_scala
-  #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
-  - V=0.28.0 TEST_SCRIPT=test_reproducibility
+_linux: &linux
+  os: linux
+_osx: &osx
+  os: osx
+  osx_image: xcode10.1
+_windows: &windows
+  os: windows
+  before_install:
+    - |
+      if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
+        choco install jdk8 -params 'installdir=c:\\java8'
+        choco install bazel --version ${V}
+      fi
 
+jobs:
+  include:
+    # test_rules_scala
+    - stage: test_rules_scala
+      <<: *linux
+      env: TEST_SCRIPT=test_rules_scala
+    - <<: *osx
+      env: TEST_SCRIPT=test_rules_scala
+    - <<: *windows
+      env: TEST_SCRIPT=test_rules_scala
+    # test_reproducibility
+    - stage: test_reproducibility
+      <<: *linux
+      env: TEST_SCRIPT=test_reproducibility
+    - <<: *osx
+      env: TEST_SCRIPT=test_reproducibility
+    - <<: *windows
+      env: TEST_SCRIPT=test_reproducibility
 
 before_install:
-  - |
-    if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
-      choco install jdk8 -params 'installdir=c:\\java8'
-      choco install bazel --version ${V}
-    else
-      if [[ "${TRAVIS_OS_NAME}" == "osx" ]]; then
-        OS=darwin
-      else
-        sudo sysctl kernel.unprivileged_userns_clone=1
-        sudo add-apt-repository -y ppa:openjdk-r/ppa
-        sudo apt-get update -q
-        sudo apt-get install openjdk-8-jdk -y
-        sudo apt-get install libxml2-utils -y
-        OS=linux
-      fi
-
-      if [[ $V =~ .*rc[0-9]+.* ]]; then
-        PRE_RC=$(expr "$V" : '\([0-9.]*\)rc.*')
-        RC_PRC=$(expr "$V" : '[0-9.]*\(rc.*\)')
-        URL="https://storage.googleapis.com/bazel/${PRE_RC}/${RC_PRC}/bazel-${V}-installer-${OS}-x86_64.sh"
-      else
-        URL="https://github.com/bazelbuild/bazel/releases/download/${V}/bazel-${V}-installer-${OS}-x86_64.sh"
-      fi
-      wget -O install.sh "${URL}"
-      chmod +x install.sh
-      ./install.sh --user
-      rm -f install.sh
-    fi
   - cat .bazelrc.travis >> .bazelrc
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,11 @@ sudo: required
 language: sh
 osx_image: xcode10.1
 
+addons:
+  apt:
+    packages:
+    - libxml2-utils
+
 cache:
     directories:
      - .bazel_cache
@@ -28,8 +33,6 @@ before_install:
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       choco install jdk8 -params 'installdir=c:\\java8'
       choco install bazel --version 0.28.0
-    else
-      sudo apt-get install -y libxml2-utils
     fi
   - cat .bazelrc.travis >> .bazelrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       choco install jdk8 -params 'installdir=c:\\java8'
-      choco install bazel --version 0.28.1
+      choco install bazel --version 0.28.0
     fi
   - cat .bazelrc.travis >> .bazelrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,7 @@
-# trusty beta image has jdk8, gcc4.8.4
-dist: trusty
+dist: xenial
 sudo: required
-# xcode8 has jdk8
-osx_image: xcode8
-# Not technically required but suppresses 'Ruby' in Job status message.
-language: sh
+language: generic
+osx_image: xcode10.1
 
 cache:
     directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,8 @@ before_install:
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       choco install jdk8 -params 'installdir=c:\\java8'
       choco install bazel --version 0.28.0
+    else
+      sudo apt-get install -y libxml2-utils
     fi
   - cat .bazelrc.travis >> .bazelrc
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,13 +18,34 @@ os:
   - osx
   - windows
 
+###
+#
+# Want to update/change bazel versions?
+#
+# 1. Update the bazel_version case statement in
+#    ./tools/bazel to include hashes for the bazel version
+#    you're targeting.
+#
+# 2. either
+#    - If you're updating the default bazel version, change
+#      default_bazel_version in ./tools/bazel.
+#    or
+#    - If you want to add an additional bazel version to the build
+#      matrix, set BAZEL_VERSION=<desired-version> along side
+#      TEST_SCRIPT below.
+#
+# 3. If you need to update the Windows version, adjust
+#    the windows specific install code below.
+#
+###
+
 env:
   # Linting is broken. Disable until fixed.
   # See https://github.com/bazelbuild/rules_scala/pull/622
   # we want to test the last release
-  #- V=0.16.1 TEST_SCRIPT=test_lint.sh
+  #- TEST_SCRIPT=test_lint.sh
   - TEST_SCRIPT=test_rules_scala
-  #- V=0.14.1 TEST_SCRIPT=test_intellij_aspect.sh
+  #- TEST_SCRIPT=test_intellij_aspect.sh
   - TEST_SCRIPT=test_reproducibility
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,7 +30,7 @@ before_install:
   - |
     if [[ "${TRAVIS_OS_NAME}" == "windows" ]]; then
       choco install jdk8 -params 'installdir=c:\\java8'
-      choco install bazel --version ${V}
+      choco install bazel --version 0.28.1
     fi
   - cat .bazelrc.travis >> .bazelrc
 

--- a/test_reproducibility.sh
+++ b/test_reproducibility.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# ci stopgap: ensure tools/bazel is run for `bazel` invocations
+PATH="$(cd "$(dirname "$0")"/..; pwd)"/tools:$PATH
+
 md5_util() {
     if [[ "$OSTYPE" == "darwin"* ]]; then
         _md5_util="md5"

--- a/test_reproducibility.sh
+++ b/test_reproducibility.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-# ci stopgap: ensure tools/bazel is run for `bazel` invocations
-PATH="$(cd "$(dirname "$0")"/..; pwd)"/tools:$PATH
+if ! bazel_loc="$(type -p 'bazel')" || [[ -z "$bazel_loc" ]]; then
+  export PATH="$(cd "$(dirname "$0")"; pwd)"/tools:$PATH
+  echo 'Using ./tools/bazel directly for bazel calls'
+fi
 
 md5_util() {
     if [[ "$OSTYPE" == "darwin"* ]]; then

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -2,8 +2,10 @@
 
 set -e
 
-# ci stopgap: ensure tools/bazel is run for `bazel` invocations
-PATH="$(cd "$(dirname "$0")"/..; pwd)"/tools:$PATH
+if ! bazel_loc="$(type -p 'bazel')" || [[ -z "$bazel_loc" ]]; then
+  export PATH="$(cd "$(dirname "$0")"; pwd)"/tools:$PATH
+  echo 'Using ./tools/bazel directly for bazel calls'
+fi
 
 test_disappearing_class() {
   git checkout test_expect_failure/disappearing_class/ClassProvider.scala

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+# ci stopgap: ensure tools/bazel is run for `bazel` invocations
+PATH="$(cd "$(dirname "$0")"/..; pwd)"/tools:$PATH
+
 test_disappearing_class() {
   git checkout test_expect_failure/disappearing_class/ClassProvider.scala
   bazel build test_expect_failure/disappearing_class:uses_class

--- a/test_runner.sh
+++ b/test_runner.sh
@@ -12,7 +12,7 @@ run_test_ci() {
   local TEST_ARG=$@
   local log_file=output_$$.log
   echo "running test $TEST_ARG"
-  $TEST_ARG &>$log_file &
+  eval $TEST_ARG &>$log_file &
   local test_pid=$!
   SECONDS=0
   test_pulse_printer $! $TIMOUT $TEST_ARG &

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
 set -e
 
-workspace="$(cd "$(dirname "$0")"/..; pwd)"
-
 default_bazel_version='0.28.1'
 
 if [ "$BUILDKITE" = true ]; then

--- a/tools/bazel
+++ b/tools/bazel
@@ -5,7 +5,10 @@ workspace="$(cd "$(dirname "$0")"/..; pwd)"
 
 default_bazel_version='0.28.1'
 
-case $(uname -s) in
+if [ "$BUILDKITE" = true ]; then
+    bazel_version='host'
+else
+    case $(uname -s) in
     Darwin|Linux)
 	# shellcheck disable=SC2153
 	if [ -z "$BAZEL_VERSION" ]; then
@@ -18,7 +21,8 @@ case $(uname -s) in
 	# windows, presumably
 	bazel_version='host'
 	;;
-esac
+    esac
+fi
 
 case "$bazel_version" in
     'host')
@@ -80,27 +84,4 @@ if [ -z "$bazel" ]; then
     fi
 fi
 
-extra_command_args=()
-
-# shellcheck disable=SC2034
-IFS=. read -r major minor patch < <(echo "$bazel_version")
-extra_command_args+=("--config=v$major.$minor")
-
-for (( i=1; i<=$#; i++ ))
-do
-    case "${!i}" in
-        -*)
-            ;;
-        *)
-            n=$((i + 1))
-            set -- "${@:1:$i}" "${extra_command_args[@]}" "${@:$n}"
-            break
-            ;;
-    esac
-done
-
-disk_cache="$workspace"/.bazel_cache
-mkdir -p "$disk_cache"
-
-# (>&2 echo :: exec "$bazel" "$@")
 exec "$bazel" "$@"

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+set -e
+
+workspace="$(cd "$(dirname "$0")"/..; pwd)"
+
+default_bazel_version='0.28.1'
+
+case $(uname -s) in
+    Darwin|Linux)
+	# shellcheck disable=SC2153
+	if [ -z "$BAZEL_VERSION" ]; then
+	    bazel_version="$default_bazel_version"
+	else
+	    bazel_version="$BAZEL_VERSION"
+	fi
+        ;;
+    *)
+	# windows, presumably
+	bazel_version='host'
+	;;
+esac
+
+case "$bazel_version" in
+    'host')
+        bazel_version=$("$BAZEL_REAL" version | awk '/Build label/ {print $3}' | cut -d '-' -f 1)
+        bazel="$BAZEL_REAL"
+        ;;
+    '0.28.1')
+        darwin_sha='5d50ae13ba01a224ddf54cfd818289bee5b38e551cca22bffc79b89f377d2095'
+        linux_sha='a2a7e4cb38d7bc774a5bbfab4d45293f5f2158eb6caf0128792cc1148732a4e6'
+        ;;
+    *)
+        echo "The requested Bazel version '$bazel_version' is not supported"
+        exit 1
+        ;;
+esac
+
+if [ -z "$bazel" ]; then
+    bazel_bin_loc=~/.bazel_binaries
+    bazel=$bazel_bin_loc/$bazel_version/bin/bazel-real
+
+    if ! [ -f "$bazel" ]; then
+	case $(uname -s) in
+            Darwin)
+		platform='darwin'
+		sha=$darwin_sha
+		;;
+            Linux)
+		platform='linux'
+		sha=$linux_sha
+		;;
+            *)
+		echo 'Your OS is not supported for automatic bazel installs.'
+		exit 1
+		;;
+	esac
+	remote_source=https://github.com/bazelbuild/bazel/releases/download
+	installer_name="bazel-$bazel_version-installer-$platform-x86_64.sh"
+	url="$remote_source/$bazel_version/$installer_name"
+	(
+            tmp_dir=$(mktemp -d)
+	    # shellcheck disable=SC2064
+            trap "rm -rf $tmp_dir" EXIT
+            cd "$tmp_dir"
+            (>&2 echo "downloading installer from")
+            (>&2 echo "$url")
+            curl -o installer.sh -L "$url"
+            generated_sha=$(shasum -a 256 installer.sh | awk '{print $1}')
+            if [ "$generated_sha" != "$sha" ]; then
+		echo "Sha 256 does not match, expected: $sha"
+		echo "But found $generated_sha"
+		echo "Recommend you: update the sha to the expected"
+		echo "and then re-run this script"
+		exit 1
+            fi
+	    mkdir -p $bazel_bin_loc
+            chmod +x installer.sh
+            ./installer.sh --base="$bazel_bin_loc"/"$bazel_version" --bin="$bazel_bin_loc"/"$bazel_version"/bin_t
+	) >&2
+    fi
+fi
+
+extra_command_args=()
+
+# shellcheck disable=SC2034
+IFS=. read -r major minor patch < <(echo "$bazel_version")
+extra_command_args+=("--config=v$major.$minor")
+
+for (( i=1; i<=$#; i++ ))
+do
+    case "${!i}" in
+        -*)
+            ;;
+        *)
+            n=$((i + 1))
+            set -- "${@:1:$i}" "${extra_command_args[@]}" "${@:$n}"
+            break
+            ;;
+    esac
+done
+
+disk_cache="$workspace"/.bazel_cache
+mkdir -p "$disk_cache"
+
+# (>&2 echo :: exec "$bazel" "$@")
+exec "$bazel" "$@"


### PR DESCRIPTION
**Description:**

Ports over bazel pinning functionality from https://github.com/higherkindness/rules_scala.

With this, rules_scala developers on Linux/OSX will have Bazel pinned to the version rules_scala expects, automatically, regardless of the global bazel install version. Windows developers will still need to match global bazel with the rules_scala bazel version.

The `tools/bazel` script has been tested extensively (via other projects) for OSX/Linux developers.

**Motivation:**

One hurdle for development on bazelbuild/rules_scala is a lack of Bazel version pinning that's consistent for local development and CI.