### PR TITLE
Move scala_binary to its own file

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,6 +17,12 @@ Before you start working on a larger contribution, you should get in touch
 with us first. Use the issue tracker to explain your idea so we can help and
 possibly guide you.
 
+### Code organization
+
+Core Scala rules (including their implementations) and macros go in [./scala/private/rules/](./scala/private/rules/)
+and [./scala/private/macros/](./scala/private/macros/), respectively, and are re-exported for public use
+in [./scala/scala.bzl](./scala/scala.bzl).
+
 ### Code reviews and other contributions.
 **All submissions, including submissions by project members, require review.**
 Please follow the instructions in [the contributors documentation](http://bazel.io/contributing.html).

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -1,0 +1,137 @@
+"""Shared attributes for rules"""
+
+load(
+    "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
+    _coverage_replacements_provider = "coverage_replacements_provider",
+)
+load(
+    "@io_bazel_rules_scala//scala:plusone.bzl",
+    _collect_plus_one_deps_aspect = "collect_plus_one_deps_aspect",
+)
+
+common_attrs_for_plugin_bootstrapping = {
+    "srcs": attr.label_list(allow_files = [
+        ".scala",
+        ".srcjar",
+        ".java",
+    ]),
+    "deps": attr.label_list(
+        aspects = [
+            _collect_plus_one_deps_aspect,
+            _coverage_replacements_provider.aspect,
+        ],
+        providers = [[JavaInfo]],
+    ),
+    "plugins": attr.label_list(allow_files = [".jar"]),
+    "runtime_deps": attr.label_list(providers = [[JavaInfo]]),
+    "data": attr.label_list(allow_files = True),
+    "resources": attr.label_list(allow_files = True),
+    "resource_strip_prefix": attr.string(),
+    "resource_jars": attr.label_list(allow_files = True),
+    "scalacopts": attr.string_list(),
+    "javacopts": attr.string_list(),
+    "jvm_flags": attr.string_list(),
+    "scalac_jvm_flags": attr.string_list(),
+    "javac_jvm_flags": attr.string_list(),
+    "expect_java_output": attr.bool(
+        default = True,
+        mandatory = False,
+    ),
+    "print_compile_time": attr.bool(
+        default = False,
+        mandatory = False,
+    ),
+}
+
+common_attrs = {}
+
+common_attrs.update(common_attrs_for_plugin_bootstrapping)
+
+common_attrs.update({
+    # using stricts scala deps is done by using command line flag called 'strict_java_deps'
+    # switching mode to "on" means that ANY API change in a target's transitive dependencies will trigger a recompilation of that target,
+    # on the other hand any internal change (i.e. on code that ijar omits) WON’T trigger recompilation by transitive dependencies
+    "_dependency_analyzer_plugin": attr.label(
+        default = Label(
+            "@io_bazel_rules_scala//third_party/dependency_analyzer/src/main:dependency_analyzer",
+        ),
+        allow_files = [".jar"],
+        mandatory = False,
+    ),
+    "unused_dependency_checker_mode": attr.string(
+        values = [
+            "warn",
+            "error",
+            "off",
+            "",
+        ],
+        mandatory = False,
+    ),
+    "_unused_dependency_checker_plugin": attr.label(
+        default = Label(
+            "@io_bazel_rules_scala//third_party/unused_dependency_checker/src/main:unused_dependency_checker",
+        ),
+        allow_files = [".jar"],
+        mandatory = False,
+    ),
+    "unused_dependency_checker_ignored_targets": attr.label_list(default = []),
+    "_code_coverage_instrumentation_worker": attr.label(
+        default = "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/coverage/instrumenter",
+        allow_files = True,
+        executable = True,
+        cfg = "host",
+    ),
+})
+
+implicit_deps = {
+    "_singlejar": attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label("@bazel_tools//tools/jdk:singlejar"),
+        allow_files = True,
+    ),
+    "_zipper": attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label("@bazel_tools//tools/zip:zipper"),
+        allow_files = True,
+    ),
+    "_java_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+    ),
+    "_host_javabase": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        cfg = "host",
+    ),
+    "_java_runtime": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+    ),
+    "_scalac": attr.label(
+        default = Label(
+            "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac",
+        ),
+    ),
+    "_exe": attr.label(
+        executable = True,
+        cfg = "host",
+        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/exe:exe"),
+    ),
+}
+
+launcher_template = {
+    "_java_stub_template": attr.label(
+        default = Label("@io_bazel_rules_scala//java_stub_template/file"),
+    ),
+}
+
+# Single dep to allow IDEs to pickup all the implicit dependencies.
+resolve_deps = {
+    "_scala_toolchain": attr.label_list(
+        default = [
+            Label(
+                "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+            ),
+        ],
+        allow_files = False,
+    ),
+}

--- a/scala/private/common_outputs.bzl
+++ b/scala/private/common_outputs.bzl
@@ -1,0 +1,8 @@
+"""Common outputs used in rule outputs"""
+
+common_outputs = {
+    "jar": "%{name}.jar",
+    "deploy_jar": "%{name}_deploy.jar",
+    "manifest": "%{name}_MANIFEST.MF",
+    "statsfile": "%{name}.statsfile",
+}

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -341,7 +341,7 @@ def _interim_java_provider_for_java_compilation(scala_output):
         neverlink = True
     )
 
-def _scalac_provider(ctx):
+def scalac_provider(ctx):
     return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_provider_attr[_ScalacProvider]
 
 def try_to_compile_java_jar(
@@ -358,7 +358,7 @@ def try_to_compile_java_jar(
         implicit_junit_deps_needed_for_java_compilation,
     )
     providers_of_dependencies += collect_java_providers_of(
-        _scalac_provider(ctx).default_classpath,
+        scalac_provider(ctx).default_classpath,
     )
     scala_sources_java_provider = _interim_java_provider_for_java_compilation(
         scala_output,
@@ -592,7 +592,7 @@ def _java_bin(ctx):
         javabin = "%s/%s" % (runfiles_root, java_path)
     return javabin
 
-def _write_java_wrapper(ctx, args = "", wrapper_preamble = ""):
+def write_java_wrapper(ctx, args = "", wrapper_preamble = ""):
     """This creates a wrapper that sets up the correct path
          to stand in for the java command."""
 
@@ -623,13 +623,13 @@ def _jar_path_based_on_java_bin(ctx):
     jar_path = java_bin.rpartition("/")[0] + "/jar"
     return jar_path
 
-def _write_executable(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
+def write_executable(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
     if (_is_windows(ctx)):
-        return _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco)
+        return write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco)
     else:
-        return _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco)
+        return write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco)
 
-def _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
+def write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
     # NOTE: `use_jacoco` is currently ignored on Windows.
     # TODO: tests coverage support for Windows
     classpath = ";".join(
@@ -651,7 +651,7 @@ def _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wra
     )
     return []
 
-def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
+def write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
     template = ctx.attr._java_stub_template.files.to_list()[0]
 
     jvm_flags = " ".join(
@@ -722,7 +722,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
         )
         return []
 
-def _declare_executable(ctx):
+def declare_executable(ctx):
     if (_is_windows(ctx)):
         return ctx.actions.declare_file("%s.exe" % ctx.label.name)
     else:
@@ -753,7 +753,7 @@ def _is_plus_one_deps_off(ctx):
 # Extract very common code out from dependency analysis into single place
 # automatically adds dependency on scala-library and scala-reflect
 # collects jars from deps, runtime jars from runtime_deps, and
-def _collect_jars_from_common_ctx(
+def collect_jars_from_common_ctx(
         ctx,
         base_classpath,
         extra_deps = [],
@@ -808,7 +808,7 @@ def _lib(
     srcjars = collect_srcjars(ctx.attr.deps)
 
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
-    jars = _collect_jars_from_common_ctx(
+    jars = collect_jars_from_common_ctx(
         ctx,
         base_classpath,
         unused_dependency_checker_is_off = unused_dependency_checker_is_off,
@@ -887,7 +887,7 @@ def get_unused_dependency_checker_mode(ctx):
 def scala_library_impl(ctx):
     if ctx.attr.jvm_flags:
         print("'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.")
-    scalac_provider = _scalac_provider(ctx)
+    scalac_provider = scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
@@ -898,7 +898,7 @@ def scala_library_impl(ctx):
     )
 
 def scala_library_for_plugin_bootstrapping_impl(ctx):
-    scalac_provider = _scalac_provider(ctx)
+    scalac_provider = scalac_provider(ctx)
     return _lib(
         ctx,
         scalac_provider.default_classpath,
@@ -908,7 +908,7 @@ def scala_library_for_plugin_bootstrapping_impl(ctx):
     )
 
 def scala_macro_library_impl(ctx):
-    scalac_provider = _scalac_provider(ctx)
+    scalac_provider = scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
@@ -919,7 +919,7 @@ def scala_macro_library_impl(ctx):
     )
 
 # Common code shared by all scala binary implementations.
-def _scala_binary_common(
+def scala_binary_common(
         ctx,
         executable,
         cjars,
@@ -1014,57 +1014,14 @@ def _pack_source_jars(ctx):
     #_pack_source_jar may return None if java_common.pack_sources returned None (and it can)
     return [source_jar] if source_jar else []
 
-def scala_binary_impl(ctx):
-    scalac_provider = _scalac_provider(ctx)
-    unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
-    unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
-
-    jars = _collect_jars_from_common_ctx(
-        ctx,
-        scalac_provider.default_classpath,
-        unused_dependency_checker_is_off = unused_dependency_checker_is_off,
-    )
-    (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
-
-    wrapper = _write_java_wrapper(ctx, "", "")
-
-    executable = _declare_executable(ctx)
-
-    out = _scala_binary_common(
-        ctx,
-        executable,
-        cjars,
-        transitive_rjars,
-        jars.transitive_compile_jars,
-        jars.jars2labels,
-        wrapper,
-        unused_dependency_checker_ignored_targets = [
-            target.label
-            for target in scalac_provider.default_classpath +
-                          ctx.attr.unused_dependency_checker_ignored_targets
-        ],
-        unused_dependency_checker_mode = unused_dependency_checker_mode,
-        deps_providers = jars.deps_providers,
-    )
-    _write_executable(
-        ctx = ctx,
-        executable = executable,
-        jvm_flags = ctx.attr.jvm_flags,
-        main_class = ctx.attr.main_class,
-        rjars = out.transitive_rjars,
-        use_jacoco = False,
-        wrapper = wrapper,
-    )
-    return out
-
 def scala_repl_impl(ctx):
-    scalac_provider = _scalac_provider(ctx)
+    scalac_provider = scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
     # need scala-compiler for MainGenericRunner below
-    jars = _collect_jars_from_common_ctx(
+    jars = collect_jars_from_common_ctx(
         ctx,
         scalac_provider.default_repl_classpath,
         unused_dependency_checker_is_off = unused_dependency_checker_is_off,
@@ -1073,9 +1030,9 @@ def scala_repl_impl(ctx):
 
     args = " ".join(ctx.attr.scalacopts)
 
-    executable = _declare_executable(ctx)
+    executable = declare_executable(ctx)
 
-    wrapper = _write_java_wrapper(
+    wrapper = write_java_wrapper(
         ctx,
         args,
         wrapper_preamble = """
@@ -1094,7 +1051,7 @@ trap finish EXIT
 """,
     )
 
-    out = _scala_binary_common(
+    out = scala_binary_common(
         ctx,
         executable,
         cjars,
@@ -1110,7 +1067,7 @@ trap finish EXIT
         unused_dependency_checker_mode = unused_dependency_checker_mode,
         deps_providers = jars.deps_providers,
     )
-    _write_executable(
+    write_executable(
         ctx = ctx,
         executable = executable,
         jvm_flags = ["-Dscala.usejavacp=true"] + ctx.attr.jvm_flags,
@@ -1137,7 +1094,7 @@ def scala_test_impl(ctx):
     if len(ctx.attr.suites) != 0:
         print("suites attribute is deprecated. All scalatest test suites are run")
 
-    scalac_provider = _scalac_provider(ctx)
+    scalac_provider = scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
@@ -1148,7 +1105,7 @@ def scala_test_impl(ctx):
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
     scalatest_base_classpath = scalac_provider.default_classpath + [ctx.attr._scalatest]
-    jars = _collect_jars_from_common_ctx(
+    jars = collect_jars_from_common_ctx(
         ctx,
         scalatest_base_classpath,
         extra_runtime_deps = [
@@ -1180,10 +1137,10 @@ def scala_test_impl(ctx):
     argsFile = ctx.actions.declare_file("%s.args" % ctx.label.name)
     ctx.actions.write(argsFile, args)
 
-    executable = _declare_executable(ctx)
+    executable = declare_executable(ctx)
 
-    wrapper = _write_java_wrapper(ctx, "", "")
-    out = _scala_binary_common(
+    wrapper = write_java_wrapper(ctx, "", "")
+    out = scala_binary_common(
         ctx,
         executable,
         cjars,
@@ -1219,8 +1176,8 @@ def scala_test_impl(ctx):
         ctx.attr.jvm_flags,
         ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scala_test_jvm_flags
     )
-    
-    coverage_runfiles.extend(_write_executable(
+
+    coverage_runfiles.extend(write_executable(
         ctx = ctx,
         executable = executable,
         jvm_flags = [
@@ -1275,7 +1232,7 @@ def scala_junit_test_impl(ctx):
         fail(
             "Setting at least one of the attributes ('prefixes','suffixes') is required",
         )
-    scalac_provider = _scalac_provider(ctx)
+    scalac_provider = scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
@@ -1290,7 +1247,7 @@ def scala_junit_test_impl(ctx):
     ]
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
-    jars = _collect_jars_from_common_ctx(
+    jars = collect_jars_from_common_ctx(
         ctx,
         scalac_provider.default_classpath,
         extra_deps = [
@@ -1307,10 +1264,10 @@ def scala_junit_test_impl(ctx):
         ctx.attr._hamcrest,
     ]
 
-    executable = _declare_executable(ctx)
+    executable = declare_executable(ctx)
 
-    wrapper = _write_java_wrapper(ctx, "", "")
-    out = _scala_binary_common(
+    wrapper = write_java_wrapper(ctx, "", "")
+    out = scala_binary_common(
         ctx,
         executable,
         cjars,
@@ -1344,7 +1301,7 @@ def scala_junit_test_impl(ctx):
         test_suite.printFlag,
         test_suite.testSuiteFlag,
     ]
-    _write_executable(
+    write_executable(
         ctx = ctx,
         executable = executable,
         jvm_flags = launcherJvmFlags + ctx.attr.jvm_flags,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -887,21 +887,21 @@ def get_unused_dependency_checker_mode(ctx):
 def scala_library_impl(ctx):
     if ctx.attr.jvm_flags:
         print("'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.")
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
-        scalac_provider.default_classpath,
+        _scalac_provider.default_classpath,
         True,
         unused_dependency_checker_mode,
         ctx.attr.unused_dependency_checker_ignored_targets,
     )
 
 def scala_library_for_plugin_bootstrapping_impl(ctx):
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
     return _lib(
         ctx,
-        scalac_provider.default_classpath,
+        _scalac_provider.default_classpath,
         True,
         unused_dependency_checker_ignored_targets = [],
         unused_dependency_checker_mode = "off",

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -887,32 +887,32 @@ def get_unused_dependency_checker_mode(ctx):
 def scala_library_impl(ctx):
     if ctx.attr.jvm_flags:
         print("'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.")
-    _scalac_provider = get_scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
-        _scalac_provider.default_classpath,
+        scalac_provider.default_classpath,
         True,
         unused_dependency_checker_mode,
         ctx.attr.unused_dependency_checker_ignored_targets,
     )
 
 def scala_library_for_plugin_bootstrapping_impl(ctx):
-    _scalac_provider = get_scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
     return _lib(
         ctx,
-        _scalac_provider.default_classpath,
+        scalac_provider.default_classpath,
         True,
         unused_dependency_checker_ignored_targets = [],
         unused_dependency_checker_mode = "off",
     )
 
 def scala_macro_library_impl(ctx):
-    _scalac_provider = get_scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
-        _scalac_provider.default_macro_classpath,
+        scalac_provider.default_macro_classpath,
         False,  # don't build the ijar for macros
         unused_dependency_checker_mode,
         ctx.attr.unused_dependency_checker_ignored_targets,
@@ -1015,7 +1015,7 @@ def _pack_source_jars(ctx):
     return [source_jar] if source_jar else []
 
 def scala_repl_impl(ctx):
-    _scalac_provider = get_scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
@@ -1023,7 +1023,7 @@ def scala_repl_impl(ctx):
     # need scala-compiler for MainGenericRunner below
     jars = collect_jars_from_common_ctx(
         ctx,
-        _scalac_provider.default_repl_classpath,
+        scalac_provider.default_repl_classpath,
         unused_dependency_checker_is_off = unused_dependency_checker_is_off,
     )
     (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
@@ -1061,7 +1061,7 @@ trap finish EXIT
         wrapper,
         unused_dependency_checker_ignored_targets = [
             target.label
-            for target in _scalac_provider.default_repl_classpath +
+            for target in scalac_provider.default_repl_classpath +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
         unused_dependency_checker_mode = unused_dependency_checker_mode,
@@ -1094,17 +1094,17 @@ def scala_test_impl(ctx):
     if len(ctx.attr.suites) != 0:
         print("suites attribute is deprecated. All scalatest test suites are run")
 
-    _scalac_provider = get_scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
         target.label
-        for target in _scalac_provider.default_classpath +
+        for target in scalac_provider.default_classpath +
                       ctx.attr.unused_dependency_checker_ignored_targets
     ]
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
-    scalatest_base_classpath = _scalac_provider.default_classpath + [ctx.attr._scalatest]
+    scalatest_base_classpath = scalac_provider.default_classpath + [ctx.attr._scalatest]
     jars = collect_jars_from_common_ctx(
         ctx,
         scalatest_base_classpath,
@@ -1232,12 +1232,12 @@ def scala_junit_test_impl(ctx):
         fail(
             "Setting at least one of the attributes ('prefixes','suffixes') is required",
         )
-    _scalac_provider = get_scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
         target.label
-        for target in _scalac_provider.default_classpath +
+        for target in scalac_provider.default_classpath +
                       ctx.attr.unused_dependency_checker_ignored_targets
     ] + [
         ctx.attr._junit.label,
@@ -1249,7 +1249,7 @@ def scala_junit_test_impl(ctx):
 
     jars = collect_jars_from_common_ctx(
         ctx,
-        _scalac_provider.default_classpath,
+        scalac_provider.default_classpath,
         extra_deps = [
             ctx.attr._junit,
             ctx.attr._hamcrest,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -908,11 +908,11 @@ def scala_library_for_plugin_bootstrapping_impl(ctx):
     )
 
 def scala_macro_library_impl(ctx):
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
-        scalac_provider.default_macro_classpath,
+        _scalac_provider.default_macro_classpath,
         False,  # don't build the ijar for macros
         unused_dependency_checker_mode,
         ctx.attr.unused_dependency_checker_ignored_targets,
@@ -1015,7 +1015,7 @@ def _pack_source_jars(ctx):
     return [source_jar] if source_jar else []
 
 def scala_repl_impl(ctx):
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
@@ -1023,7 +1023,7 @@ def scala_repl_impl(ctx):
     # need scala-compiler for MainGenericRunner below
     jars = collect_jars_from_common_ctx(
         ctx,
-        scalac_provider.default_repl_classpath,
+        _scalac_provider.default_repl_classpath,
         unused_dependency_checker_is_off = unused_dependency_checker_is_off,
     )
     (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
@@ -1061,7 +1061,7 @@ trap finish EXIT
         wrapper,
         unused_dependency_checker_ignored_targets = [
             target.label
-            for target in scalac_provider.default_repl_classpath +
+            for target in _scalac_provider.default_repl_classpath +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
         unused_dependency_checker_mode = unused_dependency_checker_mode,
@@ -1094,17 +1094,17 @@ def scala_test_impl(ctx):
     if len(ctx.attr.suites) != 0:
         print("suites attribute is deprecated. All scalatest test suites are run")
 
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
         target.label
-        for target in scalac_provider.default_classpath +
+        for target in _scalac_provider.default_classpath +
                       ctx.attr.unused_dependency_checker_ignored_targets
     ]
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
-    scalatest_base_classpath = scalac_provider.default_classpath + [ctx.attr._scalatest]
+    scalatest_base_classpath = _scalac_provider.default_classpath + [ctx.attr._scalatest]
     jars = collect_jars_from_common_ctx(
         ctx,
         scalatest_base_classpath,
@@ -1232,12 +1232,12 @@ def scala_junit_test_impl(ctx):
         fail(
             "Setting at least one of the attributes ('prefixes','suffixes') is required",
         )
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
         target.label
-        for target in scalac_provider.default_classpath +
+        for target in _scalac_provider.default_classpath +
                       ctx.attr.unused_dependency_checker_ignored_targets
     ] + [
         ctx.attr._junit.label,
@@ -1249,7 +1249,7 @@ def scala_junit_test_impl(ctx):
 
     jars = collect_jars_from_common_ctx(
         ctx,
-        scalac_provider.default_classpath,
+        _scalac_provider.default_classpath,
         extra_deps = [
             ctx.attr._junit,
             ctx.attr._hamcrest,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -341,7 +341,7 @@ def _interim_java_provider_for_java_compilation(scala_output):
         neverlink = True
     )
 
-def scalac_provider(ctx):
+def get_scalac_provider(ctx):
     return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_provider_attr[_ScalacProvider]
 
 def try_to_compile_java_jar(
@@ -358,7 +358,7 @@ def try_to_compile_java_jar(
         implicit_junit_deps_needed_for_java_compilation,
     )
     providers_of_dependencies += collect_java_providers_of(
-        scalac_provider(ctx).default_classpath,
+        get_scalac_provider(ctx).default_classpath,
     )
     scala_sources_java_provider = _interim_java_provider_for_java_compilation(
         scala_output,
@@ -887,7 +887,7 @@ def get_unused_dependency_checker_mode(ctx):
 def scala_library_impl(ctx):
     if ctx.attr.jvm_flags:
         print("'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.")
-    _scalac_provider = scalac_provider(ctx)
+    _scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
@@ -898,7 +898,7 @@ def scala_library_impl(ctx):
     )
 
 def scala_library_for_plugin_bootstrapping_impl(ctx):
-    _scalac_provider = scalac_provider(ctx)
+    _scalac_provider = get_scalac_provider(ctx)
     return _lib(
         ctx,
         _scalac_provider.default_classpath,
@@ -908,7 +908,7 @@ def scala_library_for_plugin_bootstrapping_impl(ctx):
     )
 
 def scala_macro_library_impl(ctx):
-    _scalac_provider = scalac_provider(ctx)
+    _scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(
         ctx,
@@ -1015,7 +1015,7 @@ def _pack_source_jars(ctx):
     return [source_jar] if source_jar else []
 
 def scala_repl_impl(ctx):
-    _scalac_provider = scalac_provider(ctx)
+    _scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
@@ -1094,7 +1094,7 @@ def scala_test_impl(ctx):
     if len(ctx.attr.suites) != 0:
         print("suites attribute is deprecated. All scalatest test suites are run")
 
-    _scalac_provider = scalac_provider(ctx)
+    _scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [
@@ -1232,7 +1232,7 @@ def scala_junit_test_impl(ctx):
         fail(
             "Setting at least one of the attributes ('prefixes','suffixes') is required",
         )
-    _scalac_provider = scalac_provider(ctx)
+    _scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_ignored_targets = [

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -12,21 +12,21 @@ load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
     "collect_jars_from_common_ctx",
     "declare_executable",
+    "get_scalac_provider",
     "get_unused_dependency_checker_mode",
     "scala_binary_common",
-    "scalac_provider",
     "write_executable",
     "write_java_wrapper",
 )
 
 def _scala_binary_impl(ctx):
-    _scalac_provider = scalac_provider(ctx)
+    scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
     jars = collect_jars_from_common_ctx(
         ctx,
-        _scalac_provider.default_classpath,
+        scalac_provider.default_classpath,
         unused_dependency_checker_is_off = unused_dependency_checker_is_off,
     )
     (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
@@ -45,7 +45,7 @@ def _scala_binary_impl(ctx):
         wrapper,
         unused_dependency_checker_ignored_targets = [
             target.label
-            for target in _scalac_provider.default_classpath +
+            for target in scalac_provider.default_classpath +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
         unused_dependency_checker_mode = unused_dependency_checker_mode,

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -1,6 +1,14 @@
 """Builds Scala binaries"""
 
 load(
+    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "common_attrs",
+    "implicit_deps",
+    "launcher_template",
+    "resolve_deps",
+)
+load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
     "collect_jars_from_common_ctx",
     "declare_executable",
@@ -59,19 +67,19 @@ _scala_binary_attrs = {
     "classpath_resources": attr.label_list(allow_files = True),
 }
 
-_scala_binary_attrs.update(_launcher_template)
+_scala_binary_attrs.update(launcher_template)
 
-_scala_binary_attrs.update(_implicit_deps)
+_scala_binary_attrs.update(implicit_deps)
 
-_scala_binary_attrs.update(_common_attrs)
+_scala_binary_attrs.update(common_attrs)
 
-_scala_binary_attrs.update(_resolve_deps)
+_scala_binary_attrs.update(resolve_deps)
 
 scala_binary = rule(
     attrs = _scala_binary_attrs,
     executable = True,
     fragments = ["java"],
-    outputs = _common_outputs,
+    outputs = common_outputs,
     toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
     implementation = _scala_binary_impl,
 )

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -1,0 +1,77 @@
+"""Builds Scala binaries"""
+
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "collect_jars_from_common_ctx",
+    "declare_executable",
+    "get_unused_dependency_checker_mode",
+    "scala_binary_common",
+    "scalac_provider",
+    "write_executable",
+    "write_java_wrapper",
+)
+
+def _scala_binary_impl(ctx):
+    scalac_provider = scalac_provider(ctx)
+    unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
+    unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
+
+    jars = collect_jars_from_common_ctx(
+        ctx,
+        scalac_provider.default_classpath,
+        unused_dependency_checker_is_off = unused_dependency_checker_is_off,
+    )
+    (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
+
+    wrapper = write_java_wrapper(ctx, "", "")
+
+    executable = declare_executable(ctx)
+
+    out = scala_binary_common(
+        ctx,
+        executable,
+        cjars,
+        transitive_rjars,
+        jars.transitive_compile_jars,
+        jars.jars2labels,
+        wrapper,
+        unused_dependency_checker_ignored_targets = [
+            target.label
+            for target in scalac_provider.default_classpath +
+                          ctx.attr.unused_dependency_checker_ignored_targets
+        ],
+        unused_dependency_checker_mode = unused_dependency_checker_mode,
+        deps_providers = jars.deps_providers,
+    )
+    write_executable(
+        ctx = ctx,
+        executable = executable,
+        jvm_flags = ctx.attr.jvm_flags,
+        main_class = ctx.attr.main_class,
+        rjars = out.transitive_rjars,
+        use_jacoco = False,
+        wrapper = wrapper,
+    )
+    return out
+
+_scala_binary_attrs = {
+    "main_class": attr.string(mandatory = True),
+    "classpath_resources": attr.label_list(allow_files = True),
+}
+
+_scala_binary_attrs.update(_launcher_template)
+
+_scala_binary_attrs.update(_implicit_deps)
+
+_scala_binary_attrs.update(_common_attrs)
+
+_scala_binary_attrs.update(_resolve_deps)
+
+scala_binary = rule(
+    attrs = _scala_binary_attrs,
+    executable = True,
+    fragments = ["java"],
+    outputs = _common_outputs,
+    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+    implementation = _scala_binary_impl,
+)

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -20,13 +20,13 @@ load(
 )
 
 def _scala_binary_impl(ctx):
-    scalac_provider = scalac_provider(ctx)
+    _scalac_provider = scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
 
     jars = collect_jars_from_common_ctx(
         ctx,
-        scalac_provider.default_classpath,
+        _scalac_provider.default_classpath,
         unused_dependency_checker_is_off = unused_dependency_checker_is_off,
     )
     (cjars, transitive_rjars) = (jars.compile_jars, jars.transitive_runtime_jars)
@@ -45,7 +45,7 @@ def _scala_binary_impl(ctx):
         wrapper,
         unused_dependency_checker_ignored_targets = [
             target.label
-            for target in scalac_provider.default_classpath +
+            for target in _scalac_provider.default_classpath +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
         unused_dependency_checker_mode = unused_dependency_checker_mode,

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -78,10 +78,6 @@ _library_attrs = {
     ),
 }
 
-_library_outputs = {}
-
-_library_outputs.update(common_outputs)
-
 _scala_library_attrs = {}
 
 _scala_library_attrs.update(implicit_deps)
@@ -95,7 +91,7 @@ _scala_library_attrs.update(resolve_deps)
 scala_library = rule(
     attrs = _scala_library_attrs,
     fragments = ["java"],
-    outputs = _library_outputs,
+    outputs = common_outputs,
     toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
     implementation = _scala_library_impl,
 )
@@ -118,7 +114,7 @@ _scala_library_for_plugin_bootstrapping_attrs.update(
 scala_library_for_plugin_bootstrapping = rule(
     attrs = _scala_library_for_plugin_bootstrapping_attrs,
     fragments = ["java"],
-    outputs = _library_outputs,
+    outputs = common_outputs,
     toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
     implementation = _scala_library_for_plugin_bootstrapping_impl,
 )

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -1,6 +1,5 @@
 load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    _scala_binary_impl = "scala_binary_impl",
     _scala_junit_test_impl = "scala_junit_test_impl",
     _scala_library_for_plugin_bootstrapping_impl = "scala_library_for_plugin_bootstrapping_impl",
     _scala_library_impl = "scala_library_impl",
@@ -23,6 +22,10 @@ load(
 load(
     "@io_bazel_rules_scala//scala/private:macros/scala_repositories.bzl",
     _scala_repositories = "scala_repositories",
+)
+load(
+    "@io_bazel_rules_scala//scala/private:rules/scala_binary.bzl",
+    _scala_binary = "scala_binary",
 )
 load(
     "@io_bazel_rules_scala//scala/private:rules/scala_doc.bzl",
@@ -279,28 +282,6 @@ scala_macro_library = rule(
     implementation = _scala_macro_library_impl,
 )
 
-_scala_binary_attrs = {
-    "main_class": attr.string(mandatory = True),
-    "classpath_resources": attr.label_list(allow_files = True),
-}
-
-_scala_binary_attrs.update(_launcher_template)
-
-_scala_binary_attrs.update(_implicit_deps)
-
-_scala_binary_attrs.update(_common_attrs)
-
-_scala_binary_attrs.update(_resolve_deps)
-
-scala_binary = rule(
-    attrs = _scala_binary_attrs,
-    executable = True,
-    fragments = ["java"],
-    outputs = _common_outputs,
-    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-    implementation = _scala_binary_impl,
-)
-
 _scala_test_attrs = {
     "main_class": attr.string(
         default = "io.bazel.rulesscala.scala_test.Runner",
@@ -491,6 +472,8 @@ def scala_specs2_junit_test(name, **kwargs):
         suite_class = "io.bazel.rulesscala.specs2.Specs2DiscoveredTestSuite",
         **kwargs
     )
+
+scala_binary = _scala_binary
 
 scala_doc = _scala_doc
 


### PR DESCRIPTION
This PR moves `scala_binary` to its own file, per convention established in https://github.com/bazelbuild/rules_scala/pull/808.

In the process, I made quite a few formerly private functions in `rule_impls.bzl` public in order for it to be imported by `scala_binary.bzl`. These functions will eventually be moved somewhere else but I'm leaving them in place until rules are split out to avoid even larger PRs. Even with the newly exposed public functions, I figure that by convention a user isn't supposed to be directly loading something from a `private` package anyhow, so I think we can abdicate responsibility and give no guarantees of compatibility if a user is doing that.

Too bad Starlark doesn't have better access modifiers than a leading underscore, but I think if I ever want to untangle the big files then something has to give here.

Also:

* Moves any common attributes that `scala_binary` depends on to `common_attributes.bzl`
* Moves common outputs that `scala_binary` depends on to `common_outputs.bzl`
* Added a short note about code organization in CONTRIBUTING.md, feel free to add suggestions for wording or more detail.