### PR TITLE
Move scala_test/scala_test_suite to their own file

### DIFF
--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -162,3 +162,13 @@ def _provider_of_dependency_label_of(dependency, path):
         return dependency[JarsToLabelsInfo].jars_to_labels.get(path)
     else:
         return None
+
+def sanitize_string_for_usage(s):
+    res_array = []
+    for idx in range(len(s)):
+        c = s[idx]
+        if c.isalnum() or c == ".":
+            res_array.append(c)
+        else:
+            res_array.append("_")
+    return "".join(res_array)

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -135,17 +135,3 @@ resolve_deps = {
         allow_files = False,
     ),
 }
-
-test_resolve_deps = {
-    "_scala_toolchain": attr.label_list(
-        default = [
-            Label(
-                "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-            ),
-            Label(
-                "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
-            ),
-        ],
-        allow_files = False,
-    ),
-}

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -135,3 +135,17 @@ resolve_deps = {
         allow_files = False,
     ),
 }
+
+test_resolve_deps = {
+    "_scala_toolchain": attr.label_list(
+        default = [
+            Label(
+                "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+            ),
+            Label(
+                "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
+            ),
+        ],
+        allow_files = False,
+    ),
+}

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -37,9 +37,6 @@ def _scala_test_flags(ctx):
     return flags
 
 def _scala_test_impl(ctx):
-    if len(ctx.attr.suites) != 0:
-        print("suites attribute is deprecated. All scalatest test suites are run")
-
     scalac_provider = get_scalac_provider(ctx)
 
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -1,3 +1,5 @@
+"""Rules for writing tests with ScalaTest"""
+
 load(
     "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
     "common_attrs",

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -5,7 +5,6 @@ load(
     "common_attrs",
     "implicit_deps",
     "launcher_template",
-    "test_resolve_deps",
 )
 load("@io_bazel_rules_scala//scala/private:common.bzl", "sanitize_string_for_usage")
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
@@ -173,13 +172,27 @@ _scala_test_attrs = {
     ),
 }
 
+_test_resolve_deps = {
+    "_scala_toolchain": attr.label_list(
+        default = [
+            Label(
+                "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+            ),
+            Label(
+                "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
+            ),
+        ],
+        allow_files = False,
+    ),
+}
+
 _scala_test_attrs.update(launcher_template)
 
 _scala_test_attrs.update(implicit_deps)
 
 _scala_test_attrs.update(common_attrs)
 
-_scala_test_attrs.update(test_resolve_deps)
+_scala_test_attrs.update(_test_resolve_deps)
 
 scala_test = rule(
     attrs = _scala_test_attrs,

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -1,0 +1,189 @@
+load(
+    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "common_attrs",
+    "implicit_deps",
+    "launcher_template",
+    "test_resolve_deps",
+)
+load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load(
+    "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
+    _coverage_replacements_provider = "coverage_replacements_provider",
+)
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "collect_jars_from_common_ctx",
+    "declare_executable",
+    "expand_location",
+    "first_non_empty",
+    "get_scalac_provider",
+    "get_unused_dependency_checker_mode",
+    "scala_binary_common",
+    "write_executable",
+    "write_java_wrapper",
+)
+
+def _scala_test_flags(ctx):
+    # output report test duration
+    flags = "-oD"
+    if ctx.attr.full_stacktraces:
+        flags += "F"
+    else:
+        flags += "S"
+    if not ctx.attr.colors:
+        flags += "W"
+    return flags
+
+def _scala_test_impl(ctx):
+    if len(ctx.attr.suites) != 0:
+        print("suites attribute is deprecated. All scalatest test suites are run")
+
+    scalac_provider = get_scalac_provider(ctx)
+
+    unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
+    unused_dependency_checker_ignored_targets = [
+        target.label
+        for target in scalac_provider.default_classpath +
+                      ctx.attr.unused_dependency_checker_ignored_targets
+    ]
+    unused_dependency_checker_is_off = unused_dependency_checker_mode == "off"
+
+    scalatest_base_classpath = scalac_provider.default_classpath + [ctx.attr._scalatest]
+    jars = collect_jars_from_common_ctx(
+        ctx,
+        scalatest_base_classpath,
+        extra_runtime_deps = [
+            ctx.attr._scalatest_reporter,
+            ctx.attr._scalatest_runner,
+        ],
+        unused_dependency_checker_is_off = unused_dependency_checker_is_off,
+    )
+    (
+        cjars,
+        transitive_rjars,
+        transitive_compile_jars,
+        jars_to_labels,
+    ) = (
+        jars.compile_jars,
+        jars.transitive_runtime_jars,
+        jars.transitive_compile_jars,
+        jars.jars2labels,
+    )
+
+    args = "\n".join([
+        "-R",
+        ctx.outputs.jar.short_path,
+        _scala_test_flags(ctx),
+        "-C",
+        "io.bazel.rules.scala.JUnitXmlReporter",
+    ])
+
+    argsFile = ctx.actions.declare_file("%s.args" % ctx.label.name)
+    ctx.actions.write(argsFile, args)
+
+    executable = declare_executable(ctx)
+
+    wrapper = write_java_wrapper(ctx, "", "")
+    out = scala_binary_common(
+        ctx,
+        executable,
+        cjars,
+        transitive_rjars,
+        transitive_compile_jars,
+        jars_to_labels,
+        wrapper,
+        unused_dependency_checker_ignored_targets =
+            unused_dependency_checker_ignored_targets,
+        unused_dependency_checker_mode = unused_dependency_checker_mode,
+        runfiles_ext = [argsFile],
+        deps_providers = jars.deps_providers,
+    )
+
+    rjars = out.transitive_rjars
+
+    coverage_runfiles = []
+    if ctx.configuration.coverage_enabled and _coverage_replacements_provider.is_enabled(ctx):
+        coverage_replacements = _coverage_replacements_provider.from_ctx(
+            ctx,
+            base = out.coverage.replacements,
+        ).replacements
+
+        rjars = depset([
+            coverage_replacements[jar] if jar in coverage_replacements else jar
+            for jar in rjars.to_list()
+        ])
+        coverage_runfiles = ctx.files._jacocorunner + ctx.files._lcov_merger + coverage_replacements.values()
+
+    # jvm_flags passed in on the target override scala_test_jvm_flags passed in on the
+    # toolchain
+    final_jvm_flags = first_non_empty(
+        ctx.attr.jvm_flags,
+        ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scala_test_jvm_flags,
+    )
+
+    coverage_runfiles.extend(write_executable(
+        ctx = ctx,
+        executable = executable,
+        jvm_flags = [
+            "-DRULES_SCALA_MAIN_WS_NAME=%s" % ctx.workspace_name,
+            "-DRULES_SCALA_ARGS_FILE=%s" % argsFile.short_path,
+        ] + expand_location(ctx, final_jvm_flags),
+        main_class = ctx.attr.main_class,
+        rjars = rjars,
+        use_jacoco = ctx.configuration.coverage_enabled,
+        wrapper = wrapper,
+    ))
+
+    return struct(
+        executable = executable,
+        files = out.files,
+        instrumented_files = out.instrumented_files,
+        providers = out.providers,
+        runfiles = ctx.runfiles(coverage_runfiles, transitive_files = out.runfiles.files),
+        scala = out.scala,
+    )
+
+_scala_test_attrs = {
+    "main_class": attr.string(
+        default = "io.bazel.rulesscala.scala_test.Runner",
+    ),
+    "suites": attr.string_list(),
+    "colors": attr.bool(default = True),
+    "full_stacktraces": attr.bool(default = True),
+    "_scalatest": attr.label(
+        default = Label(
+            "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
+        ),
+    ),
+    "_scalatest_runner": attr.label(
+        cfg = "host",
+        default = Label("//src/java/io/bazel/rulesscala/scala_test:runner"),
+    ),
+    "_scalatest_reporter": attr.label(
+        default = Label("//scala/support:test_reporter"),
+    ),
+    "_jacocorunner": attr.label(
+        default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
+    ),
+    "_lcov_merger": attr.label(
+        default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
+    ),
+}
+
+_scala_test_attrs.update(launcher_template)
+
+_scala_test_attrs.update(implicit_deps)
+
+_scala_test_attrs.update(common_attrs)
+
+_scala_test_attrs.update(test_resolve_deps)
+
+scala_test = rule(
+    attrs = _scala_test_attrs,
+    executable = True,
+    fragments = ["java"],
+    outputs = common_outputs,
+    test = True,
+    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+    implementation = _scala_test_impl,
+)

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -5,7 +5,6 @@ load(
     _scala_library_impl = "scala_library_impl",
     _scala_macro_library_impl = "scala_macro_library_impl",
     _scala_repl_impl = "scala_repl_impl",
-    _scala_test_impl = "scala_test_impl",
 )
 load(
     "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
@@ -40,20 +39,10 @@ load(
     "@io_bazel_rules_scala//scala/private:rules/scala_doc.bzl",
     _scala_doc = "scala_doc",
 )
-
-_test_resolve_deps = {
-    "_scala_toolchain": attr.label_list(
-        default = [
-            Label(
-                "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-            ),
-            Label(
-                "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
-            ),
-        ],
-        allow_files = False,
-    ),
-}
+load(
+    "@io_bazel_rules_scala//scala/private:rules/scala_test.bzl",
+    _scala_test = "scala_test",
+)
 
 _junit_resolve_deps = {
     "_scala_toolchain": attr.label_list(
@@ -150,51 +139,6 @@ scala_macro_library = rule(
     outputs = common_outputs,
     toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
     implementation = _scala_macro_library_impl,
-)
-
-_scala_test_attrs = {
-    "main_class": attr.string(
-        default = "io.bazel.rulesscala.scala_test.Runner",
-    ),
-    "suites": attr.string_list(),
-    "colors": attr.bool(default = True),
-    "full_stacktraces": attr.bool(default = True),
-    "_scalatest": attr.label(
-        default = Label(
-            "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",
-        ),
-    ),
-    "_scalatest_runner": attr.label(
-        cfg = "host",
-        default = Label("//src/java/io/bazel/rulesscala/scala_test:runner"),
-    ),
-    "_scalatest_reporter": attr.label(
-        default = Label("//scala/support:test_reporter"),
-    ),
-    "_jacocorunner": attr.label(
-        default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
-    ),
-    "_lcov_merger": attr.label(
-        default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
-    ),
-}
-
-_scala_test_attrs.update(launcher_template)
-
-_scala_test_attrs.update(implicit_deps)
-
-_scala_test_attrs.update(common_attrs)
-
-_scala_test_attrs.update(_test_resolve_deps)
-
-scala_test = rule(
-    attrs = _scala_test_attrs,
-    executable = True,
-    fragments = ["java"],
-    outputs = common_outputs,
-    test = True,
-    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-    implementation = _scala_test_impl,
 )
 
 _scala_repl_attrs = {}
@@ -348,3 +292,5 @@ scala_binary = _scala_binary
 scala_doc = _scala_doc
 
 scala_repositories = _scala_repositories
+
+scala_test = _scala_test


### PR DESCRIPTION
This PR moves `scala_test`/`scala_test_suite` to its own file, per #808 

I relocated `sanitize_string_for_usage` from `scala/scala.bzl` to `scala/private/common.bzl` for now and loaded it in `scala/scala.bzl`, but as things move into `private`, these functions will only be used in `private`.

As I get more familiar with the little private library of functions rules_scala has, perhaps organizing them a bit better like how [rules_haskell](https://github.com/tweag/rules_haskell/blob/b3bea97d7cf133bc5896dfa9d02f0258547b43b8/haskell/private/set.bzl) does for its own private lib would make sense, dunno yet.