### PR TITLE
remove long-deprecated 'suites' attr in scala_test

### DIFF
--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -146,7 +146,6 @@ _scala_test_attrs = {
     "main_class": attr.string(
         default = "io.bazel.rulesscala.scala_test.Runner",
     ),
-    "suites": attr.string_list(),
     "colors": attr.bool(default = True),
     "full_stacktraces": attr.bool(default = True),
     "_scalatest": attr.label(


### PR DESCRIPTION
### Description
Remove the `suites` attr from `scala_test`.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
Cleaning up per https://github.com/bazelbuild/rules_scala/pull/815#issuecomment-522344994, since it has been a deprecated attr for awhile.

![SQUg8OtEPRyFBWiq37cPmCsu1fc=](https://user-images.githubusercontent.com/48221800/63228812-c7209f00-c1c6-11e9-8788-9cb63f15457e.gif)