### PR TITLE
Disable windows CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,8 @@ cache:
 os:
   - linux
   - osx
-  - windows
+# re-enable when someone can get windows green
+#  - windows
 
 ###
 #


### PR DESCRIPTION
### Description
Disable the windows CI.

### Motivation
Address #749. The windows CI has a few tests that fail (protobuf, maybe some others). We don't have any current contributors that have windows machines to test this.

cc @majcherm-da if you have time to try to get this green, either by fixing the issues, or disabling certain tests, PRs would be welcome. 