### PR TITLE
Fix an unformatted file that breaks ci

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -124,7 +124,6 @@ launcher_template = {
     ),
 }
 
-
 # Single dep to allow IDEs to pickup all the implicit dependencies.
 resolve_deps = {
     "_scala_toolchain": attr.label_list(


### PR DESCRIPTION
### Description
Formats a file that was missed due to sequencing of merges surrounding #826.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
CI is in red. This makes it green :).