### PR TITLE
Refactor build_deployable

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -548,7 +548,7 @@ def _create_scala_compilation_provider(ctx, ijar, source_jar, deps_providers):
         runtime_deps = runtime_deps,
     )
 
-def merge_jars(actions, deploy_jar, singlejar_executable, label, jars_list, main_class = ""):
+def merge_jars(actions, deploy_jar, singlejar_executable, jars_list, main_class = "", progress_message = ""):
     """Calls Bazel's singlejar utility.
 
     For a full list of available command line options see:
@@ -559,9 +559,9 @@ def merge_jars(actions, deploy_jar, singlejar_executable, label, jars_list, main
         actions: The actions module from ctx: https://docs.bazel.build/versions/master/skylark/lib/actions.html
         deploy_jar: The deploy jar, usually defined in ctx.outputs.
         singlejar_executable: The singlejar executable file.
-        label: The label of the target, usually from ctx.label.
         jars_list: The jars to pass to singlejar.
         main_class: The main class to run, if any. Defaults to an empty string.
+        progress_message: A progress message to display when Bazel executes this action. Defaults to an empty string.
     """
     args = ["--compression", "--normalize", "--sources"]
     args.extend([j.path for j in jars_list])
@@ -573,7 +573,7 @@ def merge_jars(actions, deploy_jar, singlejar_executable, label, jars_list, main
         outputs = [deploy_jar],
         executable = singlejar_executable,
         mnemonic = "ScalaDeployJar",
-        progress_message = "scala deployable %s" % label,
+        progress_message = progress_message,
         arguments = args,
     )
 
@@ -846,9 +846,9 @@ def scala_binary_common(
         actions = ctx.actions,
         deploy_jar = ctx.outputs.deploy_jar,
         singlejar_executable = ctx.executable._singlejar,
-        label = ctx.label,
         jars_list = rjars.to_list(),
         main_class = getattr(ctx.attr, "main_class", ""),
+        progress_message = "Merging Scala binary jar: %s" % ctx.label,
     )
 
     runfiles = ctx.runfiles(

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -86,9 +86,9 @@ def _lib(
         actions = ctx.actions,
         deploy_jar = ctx.outputs.deploy_jar,
         singlejar_executable = ctx.executable._singlejar,
-        label = ctx.label,
         jars_list = transitive_rjars.to_list(),
         main_class = getattr(ctx.attr, "main_class", ""),
+        progress_message = "Merging Scala library jar: %s" % ctx.label,
     )
 
     # Using transitive_files since transitive_rjars a depset and avoiding linearization

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -20,7 +20,7 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    "build_deployable",
+    "merge_jars",
     "collect_jars_from_common_ctx",
     "compile_or_empty",
     "get_scalac_provider",
@@ -82,7 +82,14 @@ def _lib(
 
     transitive_rjars = depset(outputs.full_jars, transitive = [transitive_rjars])
 
-    build_deployable(ctx, transitive_rjars.to_list())
+    merge_jars(
+        main_class = getattr(ctx.attr, "main_class", ""),
+        actions = ctx.actions,
+        deploy_jar = ctx.outputs.deploy_jar,
+        singlejar_executable = ctx.executable._singlejar,
+        label = ctx.label,
+        jars_list = transitive_rjars.to_list(),
+    )
 
     # Using transitive_files since transitive_rjars a depset and avoiding linearization
     runfiles = ctx.runfiles(

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -20,11 +20,11 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    "merge_jars",
     "collect_jars_from_common_ctx",
     "compile_or_empty",
     "get_scalac_provider",
     "get_unused_dependency_checker_mode",
+    "merge_jars",
     "pack_source_jars",
 )
 

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -83,12 +83,12 @@ def _lib(
     transitive_rjars = depset(outputs.full_jars, transitive = [transitive_rjars])
 
     merge_jars(
-        main_class = getattr(ctx.attr, "main_class", ""),
         actions = ctx.actions,
         deploy_jar = ctx.outputs.deploy_jar,
         singlejar_executable = ctx.executable._singlejar,
         label = ctx.label,
         jars_list = transitive_rjars.to_list(),
+        main_class = getattr(ctx.attr, "main_class", ""),
     )
 
     # Using transitive_files since transitive_rjars a depset and avoiding linearization


### PR DESCRIPTION
### Description
Refactors `build_deployable` and documents it a bit per suggestion in https://github.com/bazelbuild/rules_scala/pull/827#discussion_r315972566.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
Restrict the API of this function rather than taking a `ctx` object wholesale.
