### PR TITLE
Update README.md to include Grand Rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Here's a (non-exhaustive) list of companies that use `rules_scala` in production
 * [Ascend](https://ascend.io/)
 * [Canva](https://www.canva.com/)
 * [Etsy](https://www.etsy.com/)
+* [Grand Rounds](http://grandrounds.com/)
 * [Kitty Hawk](https://kittyhawk.aero/)
 * [Meetup](https://meetup.com/)
 * [Spotify](https://www.spotify.com/)


### PR DESCRIPTION
Grand Rounds uses bazelbuild/rules_scala in production.

### Description
Adding Grand Rounds to the list of companies that use bazelbuild/rules_scala in production.

### Motivation
We maintain a fork of rules_scala for use in production, and would love to contribute back!

