### PR TITLE
Remove jvm_flags debug print for scala_library

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -30,7 +30,6 @@ common_attrs_for_plugin_bootstrapping = {
     "resource_jars": attr.label_list(allow_files = True),
     "scalacopts": attr.string_list(),
     "javacopts": attr.string_list(),
-    "jvm_flags": attr.string_list(),
     "scalac_jvm_flags": attr.string_list(),
     "javac_jvm_flags": attr.string_list(),
     "expect_java_output": attr.bool(

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -65,6 +65,7 @@ def _scala_binary_impl(ctx):
 _scala_binary_attrs = {
     "main_class": attr.string(mandatory = True),
     "classpath_resources": attr.label_list(allow_files = True),
+    "jvm_flags": attr.string_list(),
 }
 
 _scala_binary_attrs.update(launcher_template)

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -147,6 +147,7 @@ _scala_junit_test_attrs = {
         default = False,
         mandatory = False,
     ),
+    "jvm_flags": attr.string_list(),
     "_junit": attr.label(
         default = Label(
             "//external:io_bazel_rules_scala/dependency/junit/junit",

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -135,6 +135,11 @@ def _lib(
 ##
 
 def _scala_library_impl(ctx):
+    if hasattr(ctx.attr, "jvm_flags"):
+        fail(
+            msg = "'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.",
+            attr = "jvm_flags",
+        )
     scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -135,11 +135,6 @@ def _lib(
 ##
 
 def _scala_library_impl(ctx):
-    if hasattr(ctx.attr, "jvm_flags"):
-        fail(
-            msg = "'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.",
-            attr = "jvm_flags",
-        )
     scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -135,8 +135,6 @@ def _lib(
 ##
 
 def _scala_library_impl(ctx):
-    if ctx.attr.jvm_flags:
-        print("'jvm_flags' for scala_library is deprecated. It does nothing today and will be removed from scala_library to avoid confusion.")
     scalac_provider = get_scalac_provider(ctx)
     unused_dependency_checker_mode = get_unused_dependency_checker_mode(ctx)
     return _lib(

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -84,7 +84,9 @@ trap finish EXIT
 
     return out
 
-_scala_repl_attrs = {}
+_scala_repl_attrs = {
+    "jvm_flags": attr.string_list(),
+}
 
 _scala_repl_attrs.update(launcher_template)
 

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -148,6 +148,7 @@ _scala_test_attrs = {
     ),
     "colors": attr.bool(default = True),
     "full_stacktraces": attr.bool(default = True),
+    "jvm_flags": attr.string_list(),
     "_scalatest": attr.label(
         default = Label(
             "//external:io_bazel_rules_scala/dependency/scalatest/scalatest",

--- a/test/BUILD
+++ b/test/BUILD
@@ -287,10 +287,6 @@ scala_library(
     srcs = glob(["src/main/scala/scalarules/test/mix_java_scala/*.scala"]) + glob([
         "src/main/scala/scalarules/test/mix_java_scala/*.java",
     ]),
-    jvm_flags = [
-        "-Xms1G",
-        "-Xmx4G",
-    ],
 )
 
 genrule(
@@ -323,10 +319,6 @@ scala_library(
         # srcjar created with `jar -cfM Baz.srcjar Baz.java`
         "src/main/scala/scalarules/test/mix_java_scala/*.srcjar",
     ]),
-    jvm_flags = [
-        "-Xms1G",
-        "-Xmx4G",
-    ],
 )
 
 #needed to test java sources are compiled


### PR DESCRIPTION
### Description
Closes https://github.com/bazelbuild/rules_scala/issues/669.

Removes the warning for `jvm_flags` usage in `scala_library` and instances where they were passed in tests.

### Motivation

Follow up from https://github.com/bazelbuild/rules_scala/pull/795 which advocates for removing the debug completely after some period of time (~a month). Feel free to table this if it's too soon and I'll close for now.
