### PR TITLE
Fix to error message

### DIFF
--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -49,7 +49,7 @@ object PrefixSuffixTestDiscoveringSuite {
     val classes = archives.flatMap(discoverClassesIn)
     if (classes.isEmpty)
       throw new IllegalStateException("Was not able to discover any classes " +
-                                      s"for archives=${archives.mkString(",")}" +
+                                      s"for archives=${archives.mkString(",")}, " +
                                       s"prefixes=$prefixes, " +
                                       s"suffixes=$suffixes")
     classes


### PR DESCRIPTION
Was not properly adding space, as such:

```
java.lang.IllegalStateException: Was not able to discover any classes for archives=testsuite/test/example/example.jarprefixes=Set(), suffixes=Set(Test)
```

Fixing for better readability of errors.