### PR TITLE
Copy the protos we need into a temp folder

### DIFF
--- a/src/scala/scripts/PBGenerateRequest.scala
+++ b/src/scala/scripts/PBGenerateRequest.scala
@@ -81,6 +81,6 @@ object PBGenerateRequest {
   }
 
   private def padWithProtoPathPrefix(tmpDir: Path)(transitiveProtoPathFlags: List[String]) =
-    transitiveProtoPathFlags.map(s"--proto_path=${tmpDir.toFile.toString}/"+_).map(_.stripSuffix("."))
+    transitiveProtoPathFlags.map(stripToVirtual).map(s"--proto_path=${tmpDir.toFile.toString}/"+_).map(_.stripSuffix("."))
 
 }

--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -35,15 +35,14 @@ object ScalaPBWorker extends GenericWorker(new ScalaPBGenerator) {
 
 class ScalaPBGenerator extends Processor {
   def setupIncludedProto(tmpRoot: Path, includedProto: List[(Path, Path)]): Unit = {
-    includedProto.foreach { case (root, fullPath) =>
-      require(fullPath.toFile.exists, s"Path $fullPath does not exist, which it should as a dependency of this rule")
-      val relativePath = if(root == fullPath) fullPath else root.relativize(fullPath)
-      val targetPath = tmpRoot.resolve(relativePath)
+    includedProto.foreach { case (srcPath, relativeTargetPath) =>
+      require(srcPath.toFile.exists, s"Path $srcPath does not exist, which it should as a dependency of this rule")
+      val targetPath = tmpRoot.resolve(relativeTargetPath)
 
       targetPath.toFile.getParentFile.mkdirs
-      Try(Files.copy(fullPath, targetPath)) match {
+      Try(Files.copy(srcPath, targetPath)) match {
         case Failure(err: FileAlreadyExistsException) =>
-          Console.println(s"File already exists, skipping copy from $fullPath to $targetPath: ${err.getMessage}")
+          Console.println(s"File already exists, skipping copy from $srcPath to $targetPath: ${err.getMessage}")
         case Failure(err) => throw err
         case _ => ()
       }

--- a/src/scala/scripts/ScalaPBGenerator.scala
+++ b/src/scala/scripts/ScalaPBGenerator.scala
@@ -92,6 +92,7 @@ class ScalaPBGenerator extends Processor {
         }
         JarCreator.buildJar(Array(extractRequestResult.jarOutput, extractRequestResult.scalaPBOutput.toString))
     } finally {
+      deleteDir(tmpRoot)
       deleteDir(extractRequestResult.scalaPBOutput)
     }
   }


### PR DESCRIPTION
### Description
We have errors around colliding files. The copying is putting things into trees that aren't part of the sandbox per build.

Eventually i believe the virtual_imports work will be a nicer solution to this, but from what i can tell part of it is still behind a flag. I wasn't quite sure exactly how to implement it all using that today. So for now instead of copying some stuff around and maybe colliding. Just copy everything into a temp location.

Also we weren't getting any error messages from protoc when run for scalapb so i made some changes here to redirect the output to a file and reply it back so we now get the error messages

### Motivation

Errors/problems in the copying approach