### PR TITLE
Fix paths in --proto_path and avoid copying proto files

### DIFF
--- a/test/src/main/scala/scalarules/test/scripts/BUILD
+++ b/test/src/main/scala/scalarules/test/scripts/BUILD
@@ -5,6 +5,6 @@ scala_specs2_junit_test(
     name = "pb_generate_request_test",
     size = "small",
     srcs = ["PBGenerateRequestTest.scala"],
+    suffixes = ["Test"],
     deps = ["//src/scala/scripts:scala_proto_request_extractor"],
-    suffixes = ["Test"]
 )

--- a/test/src/main/scala/scalarules/test/scripts/BUILD
+++ b/test/src/main/scala/scalarules/test/scripts/BUILD
@@ -1,0 +1,10 @@
+load("//scala:scala.bzl", "scala_library", "scala_specs2_junit_test")
+load("//scala:scala_import.bzl", "scala_import")
+
+scala_specs2_junit_test(
+    name = "pb_generate_request_test",
+    size = "small",
+    srcs = ["PBGenerateRequestTest.scala"],
+    deps = ["//src/scala/scripts:scala_proto_request_extractor"],
+    suffixes = ["Test"]
+)

--- a/test/src/main/scala/scalarules/test/scripts/PBGenerateRequestTest.scala
+++ b/test/src/main/scala/scalarules/test/scripts/PBGenerateRequestTest.scala
@@ -1,0 +1,21 @@
+package scalarules.test.scripts
+
+import java.nio.file.Paths
+import scripts.PBGenerateRequest
+import org.specs2.mutable.SpecWithJUnit
+
+class PBGenerateRequestTest extends SpecWithJUnit {
+  "fixTransitiveProtoPath should fix path when included proto is available, ignore otherwise" >> {
+    val includedProtos = List(Paths.get("a/b/c") -> Paths.get("a/b/c/d/e/f.proto"))
+    Seq("d/e", "x/y/z").map(PBGenerateRequest.fixTransitiveProtoPath(includedProtos)) must
+      beEqualTo(Seq("a/b/c/d/e", "x/y/z"))
+  }
+
+  "actual case observed in builds" >> {
+    val includedProtos = List(
+      Paths.get("bazel-out/k8-fastbuild/bin") ->
+        Paths.get("bazel-out/k8-fastbuild/bin/external/com_google_protobuf/google/protobuf/source_context.proto"))
+    Seq("external/com_google_protobuf").map(PBGenerateRequest.fixTransitiveProtoPath(includedProtos)) must
+      beEqualTo(Seq("bazel-out/k8-fastbuild/bin/external/com_google_protobuf"))
+  }
+}


### PR DESCRIPTION
### Description
Through numerous trial-and-errors it was found that copying `proto` files is only necessary when they are withing well-known `com_google_protobuf` package. For unknown reasons (could be related to the fact that `protoc` also comes from `com_google_protobuf`) Bazel passes incorrect path that is used in `--proto_path`. This proposal shows a way to fix the `transitiveProtoPaths` by analyzing the `includedProtos` list of `proto` files.
 
1. We have a list of all required `.proto` files in `includedProtos` -- this is a tuple list (root -> full path), for example:
```
bazel-out/k8-fastbuild/bin -> bazel-out/k8-fastbuild/bin/external/com_google_protobuf/google/protobuf/source_context.proto
```
2. Convert the full path to relative from the root (as it was done in `ScalaPBGenerator.setupIncludedProto`):
```
bazel-out/k8-fastbuild/bin -> external/com_google_protobuf/google/protobuf/source_context.proto
```
3. In all the `includedProtos` we find the first one that is located within the `transitiveProtoPaths` we are processing -- relative path in `includedProtos` starts with the path we are processing
4. If found -- the include folder is our "orphan" and is not anchored in either host or target. To fix we prepend root of found proto. If not found, return original. This works as long as `external/com_google_protobuf` is available in target root:
```
bazel-out/k8-fastbuild/bin/external/com_google_protobuf
```

Normally, external `proto` paths are passed with the root (target or host):
```
bazel-out/k8-fastbuild/bin/external/com_my_shiny_dependency
```
However, some (namely `com_google_protobuf`) are passed without root:
```
external/com_google_protobuf
```
This PR "anchors" those "orphan" include paths and makes them available.

### Motivation
The `protoc` plugin fails to find some `proto` files because they end-up missing from the paths within given `transitiveProtoPaths`. However, the `includedProtos` list contains all required `proto` files and they are all available to plugin. As a solution plugin implementation copies all of the required files to the relative folder. This is not sustainable as relative folder depends on working folder thus changes in working folder potentially breaks the behavior, as happened with Bazel 0.27. After working directory was changed from `sanbox` to `execroot`, plugin started copying proto files to the repo it is building. Also, this caused issues when working with `proto` files in remote directories -- due to multiple copies same `proto` files a being build over and over again.

This PR attempts to avoid coping.

This fixes https://github.com/bazelbuild/rules_scala/issues/843
Quite possibly, the `fixTransitiveProtoPath` (and copying) function would become obsolete when https://github.com/bazelbuild/bazel/issues/7964 gets fixed in Bazel.
Alternative to https://github.com/bazelbuild/rules_scala/pull/848