### PR TITLE
Fix test_scala_library_jar.sh

### DIFF
--- a/test/shell/test_scala_library_jar.sh
+++ b/test/shell/test_scala_library_jar.sh
@@ -22,7 +22,7 @@ scala_library_jar_without_srcs_must_include_filegroup_resources(){
 }
 
 scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix() {
-  action_should_fail build test_expect_failure/wrong_resource_strip_prefix:noSrcsJarWithWrongStripPrefix
+  action_should_fail build test_expect_failure/mismatching_resource_strip_prefix:noSrcsJarWithWrongStripPrefix
 }
 
 $runner scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
It fixes the issue that `scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix` is not testing correctly.

Fixes #857

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Intermediate step for test refactoring.