### PR TITLE
Fix action_should_fail_with_message does not exit 1

### DIFF
--- a/test/shell/test_helper.sh
+++ b/test/shell/test_helper.sh
@@ -55,6 +55,7 @@ action_should_fail_with_message() {
     exit 1
   elif [ $GREP_RES -ne 0 ]; then
     echo -e "${RED} \"bazel $TEST_ARG\" should have failed with message \"$MSG\" but did not. $NC"
+    exit 1
   else
     exit 0
   fi


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
`action_should_fail_with_message` should exit 1 if the action doesn't fail with the message. 

Track the issue here: https://github.com/bazelbuild/rules_scala/issues/855

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Intermediate step for test refactoring.