### PR TITLE
Include Bazel 1.0.0 in compatibility table

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,7 @@ for an example workspace using another scala version.
 
 | bazel  | rules_scala gitsha |
 |--------|--------------------|
+| 1.0.0  | HEAD               |
 | 0.28.0 | HEAD               |
 | 0.23.x | ca655e5a330cbf1d66ce1d9baa63522752ec6011 |                                     |
 | 0.22.x | f3113fb6e9e35cb8f441d2305542026d98afc0a2 |


### PR DESCRIPTION
### Description

[From this it's my understanding](https://github.com/bazelbuild/rules_scala/pull/861#issuecomment-540713730) that `0.28.0` can remain at `HEAD` as CI is still being run for that version.

### Motivation

https://github.com/bazelbuild/rules_scala/issues/862#issuecomment-541296893
