### PR TITLE
[WIP] see what happens if we drop scala attribute

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -879,7 +879,6 @@ def scala_binary_common(
         instrumented_files = outputs.coverage.instrumented_files,
         providers = [outputs.merged_provider, jars2labels] + outputs.coverage.providers,
         runfiles = runfiles,
-        scala = scalaattr,
         transitive_rjars =
             rjars,  #calling rules need this for the classpath in the launcher
     )

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -105,7 +105,7 @@ def _scala_junit_test_impl(ctx):
     if ctx.attr.tests_from:
         archives = _get_test_archive_jars(ctx, ctx.attr.tests_from)
     else:
-        archives = [archive.class_jar for archive in out.scala.outputs.jars]
+        archives = out.providers[0].runtime_output_jars
 
     serialized_archives = _serialize_archives_short_path(archives)
     test_suite = _gen_test_suite_flags_based_on_prefixes_and_suffixes(

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -127,7 +127,6 @@ def _lib(
         jars_to_labels = jars.jars2labels,
         providers = [outputs.merged_provider, jars.jars2labels] + outputs.coverage.providers,
         runfiles = runfiles,
-        scala = scalaattr,
     )
 
 ##

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -139,7 +139,6 @@ def _scala_test_impl(ctx):
         instrumented_files = out.instrumented_files,
         providers = out.providers,
         runfiles = ctx.runfiles(coverage_runfiles, transitive_files = out.runfiles.files),
-        scala = out.scala,
     )
 
 _scala_test_attrs = {

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -33,9 +33,6 @@ def _scala_import_impl(ctx):
         current_target_providers = [_new_java_info(ctx, ctx.file._placeholder_jar)]
 
     return struct(
-        scala = struct(
-            outputs = struct(jars = intellij_metadata),
-        ),
         providers = [
             java_common.merge(current_target_providers),
             DefaultInfo(


### PR DESCRIPTION
### Description
Checking impact of dropping scala attribute

### Motivation
Bazel is going to drop the sturct/attribute syntax (https://github.com/bazelbuild/bazel/issues/9014)
We need to understand the impact of dropping the scala attribute.
One thing is that this requires Bazel 1.1.0 due to both junit and IJ import needing this fix https://github.com/bazelbuild/bazel/issues/8916
