### PR TITLE
Migrate jar dependencies of tests from maven_jar to jvm_maven_import_external

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,19 @@ Rules scala supports all minor versions of Scala 2.11/2.12. By default `Scala 2.
 version you need to
 specify it when calling `scala_repositories`. `scala_repositories` takes a tuple `(scala_version, scala_version_jar_shas)`
 as a parameter where `scala_version` is the scala version and `scala_version_jar_shas` is a `dict` with
-`sha256` hashes for the maven artifacts `scala_library`, `scala_reflect` and `scala_compiler`:
+`sha256` hashes for the maven artifacts `scala_compiler`, `scala_library`, and `scala_reflect`:
+
 ```python
 scala_repositories((
-    "2.12.8",
+    "2.12.10",
     {
-       "scala_compiler": "f34e9119f45abd41e85b9e121ba19dd9288b3b4af7f7047e86dc70236708d170",
-       "scala_library": "321fb55685635c931eba4bc0d7668349da3f2c09aee2de93a70566066ff25c28",
-       "scala_reflect": "4d6405395c4599ce04cea08ba082339e3e42135de9aae2923c9f5367e957315a"
+       "scala_compiler": "cedc3b9c39d215a9a3ffc0cc75a1d784b51e9edc7f13051a1b4ad5ae22cfbc0c",
+       "scala_library": "0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d",
+       "scala_reflect": "56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730"
     }
 ))
 ```
+
 If you're using any of the rules `twitter_scrooge`, `tut_repositories`, `scala_proto_repositories`
 or `specs2_junit_repositories` you also need to specify `scala_version` for them. See `./test_version/WORKSPACE.template`
 for an example workspace using another scala version.

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -42,7 +42,7 @@ jvm_maven_import_external(
         "com.twitter:scalding-date:0.17.0",
         default_scala_major_version(),
     ),
-    artifact_sha256 = "",
+    artifact_sha256 = "bf743cd6d224a4568d6486a2b794143e23145d2afd7a1d2de412d49e45bdb308",
     server_urls = MAVEN_SERVER_URLS,
 )
 
@@ -53,7 +53,7 @@ jvm_maven_import_external(
         "org.typelevel:cats-core:0.9.0",
         default_scala_major_version(),
     ),
-    artifact_sha256 = "",
+    artifact_sha256 = "3fda7a27114b0d178107ace5c2cf04e91e9951810690421768e65038999ffca5",
     server_urls = MAVEN_SERVER_URLS,
 )
 
@@ -64,7 +64,7 @@ jvm_maven_import_external(
         "org.psywerx.hairyfotr:linter:0.1.13",
         default_scala_major_version(),
     ),
-    artifact_sha256 = "",
+    artifact_sha256 = "9444dd78684c0cc89d070af0f5ca3f3ae7d56b2a4d7ac1c038f8218ad4d66fad",
     server_urls = MAVEN_SERVER_URLS,
 )
 
@@ -72,7 +72,7 @@ jvm_maven_import_external(
 jvm_maven_import_external(
     name = "com_google_guava_guava_21_0_with_file",
     artifact = "com.google.guava:guava:21.0",
-    artifact_sha256= "",
+    artifact_sha256= "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     server_urls = MAVEN_SERVER_URLS,
 )
 
@@ -97,7 +97,7 @@ scala_maven_import_external(
 jvm_maven_import_external(
     name = "org_apache_commons_commons_lang_3_5",
     artifact = "org.apache.commons:commons-lang3:3.5",
-    artifact_sha256 = "",
+    artifact_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
     server_urls = MAVEN_SERVER_URLS,
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -72,7 +72,7 @@ jvm_maven_import_external(
 jvm_maven_import_external(
     name = "com_google_guava_guava_21_0_with_file",
     artifact = "com.google.guava:guava:21.0",
-    artifact_sha256= "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    artifact_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     server_urls = MAVEN_SERVER_URLS,
 )
 
@@ -239,10 +239,10 @@ scala_maven_import_external(
         "org.spire-math:kind-projector:0.9.10",
         default_scala_major_version(),
     ),
+    artifact_sha256 = "897460d4488b7dd6ac9198937d6417b36cc6ec8ab3693fdf2c532652f26c4373",
     fetch_sources = False,
     licenses = ["notice"],
     server_urls = [
         "https://repo.maven.apache.org/maven2/",
     ],
-    artifact_sha256 = "897460d4488b7dd6ac9198937d6417b36cc6ec8ab3693fdf2c532652f26c4373"
 )

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -2,6 +2,7 @@ workspace(name = "io_bazel_rules_scala")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
+load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 load("//scala:scala.bzl", "scala_repositories")
 
 scala_repositories()
@@ -29,41 +30,50 @@ specs2_junit_repositories()
 
 load("//scala:scala_cross_version.bzl", "default_scala_major_version", "scala_mvn_artifact")
 
+MAVEN_SERVER_URLS = [
+    "https://jcenter.bintray.com",
+    "https://repo1.maven.org/maven2",
+]
+
 # test adding a scala jar:
-maven_jar(
+jvm_maven_import_external(
     name = "com_twitter__scalding_date",
     artifact = scala_mvn_artifact(
         "com.twitter:scalding-date:0.17.0",
         default_scala_major_version(),
     ),
-    sha1 = "420fb0c4f737a24b851c4316ee0362095710caa5",
+    artifact_sha256 = "",
+    server_urls = MAVEN_SERVER_URLS,
 )
 
 # For testing that we don't include sources jars to the classpath
-maven_jar(
+jvm_maven_import_external(
     name = "org_typelevel__cats_core",
     artifact = scala_mvn_artifact(
         "org.typelevel:cats-core:0.9.0",
         default_scala_major_version(),
     ),
-    sha1 = "b2f8629c6ec834d8b6321288c9fe77823f1e1314",
+    artifact_sha256 = "",
+    server_urls = MAVEN_SERVER_URLS,
 )
 
 # test of a plugin
-maven_jar(
+jvm_maven_import_external(
     name = "org_psywerx_hairyfotr__linter",
     artifact = scala_mvn_artifact(
         "org.psywerx.hairyfotr:linter:0.1.13",
         default_scala_major_version(),
     ),
-    sha1 = "e5b3e2753d0817b622c32aedcb888bcf39e275b4",
+    artifact_sha256 = "",
+    server_urls = MAVEN_SERVER_URLS,
 )
 
 # test of strict deps (scalac plugin UT + E2E)
-maven_jar(
+jvm_maven_import_external(
     name = "com_google_guava_guava_21_0_with_file",
     artifact = "com.google.guava:guava:21.0",
-    sha1 = "3a3d111be1be1b745edfa7d91678a12d7ed38709",
+    artifact_sha256= "",
+    server_urls = MAVEN_SERVER_URLS,
 )
 
 # test of import external
@@ -84,10 +94,11 @@ scala_maven_import_external(
     srcjar_sha256 = "5e586357a289f5fe896f7b48759e1c16d9fa419333156b496696887e613d7a19",
 )
 
-maven_jar(
+jvm_maven_import_external(
     name = "org_apache_commons_commons_lang_3_5",
     artifact = "org.apache.commons:commons-lang3:3.5",
-    sha1 = "6c6c702c89bfff3cd9e80b04d668c5e190d588c6",
+    artifact_sha256 = "",
+    server_urls = MAVEN_SERVER_URLS,
 )
 
 new_local_repository(
@@ -233,4 +244,5 @@ scala_maven_import_external(
     server_urls = [
         "https://repo.maven.apache.org/maven2/",
     ],
+    artifact_sha256 = "897460d4488b7dd6ac9198937d6417b36cc6ec8ab3693fdf2c532652f26c4373"
 )

--- a/docs/scala_proto_library.md
+++ b/docs/scala_proto_library.md
@@ -5,7 +5,7 @@ which adds a few dependencies needed for ScalaPB:
 
 ```python
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
-scala_proto_repositories(scala_version = "2.12.8") # or whatever scala_version you're on
+scala_proto_repositories(scala_version = "2.12.10") # or whatever scala_version you're on
 ```
 
 Then you can import `scala_proto_library` in any `BUILD` file like this:

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -5,8 +5,8 @@ load("//scala:scala_import.bzl", "scala_import")
 scala_import(
     name = "guava_and_commons_lang",
     jars = [
-        "@com_google_guava_guava_21_0_with_file//jar:file",
-        "@org_apache_commons_commons_lang_3_5//jar:file",
+        "@com_google_guava_guava_21_0_with_file//:guava-21.0.jar",
+        "@org_apache_commons_commons_lang_3_5//:commons-lang3-3.5.jar",
     ],
 )
 
@@ -41,23 +41,19 @@ scala_specs2_junit_test(
     deps = [":relate"],
 )
 
-#filter source jars
-scala_import(
-    name = "cats",
-    jars = ["@org_typelevel__cats_core//jar:file"],
-)
-
 scala_library(
     name = "source_jar_not_oncp",
     srcs = ["ReferCatsImplicits.scala"],
-    deps = [":cats"],
+    # jvm_maven_import_external doesn't fetch source jars automatically
+    deps = ["@org_typelevel__cats_core//jar"],
 )
 
 ##Runtime deps
 scala_import(
     name = "indirection_for_transitive_runtime_deps",
     jars = [],
-    runtime_deps = [":cats"],
+    # jvm_maven_import_external doesn't fetch source jars automatically
+    deps = ["@org_typelevel__cats_core//jar"],
 )
 
 scala_import(
@@ -80,8 +76,8 @@ scala_specs2_junit_test(
 java_import(
     name = "guava_and_commons_lang_java_import",
     jars = [
-        "@com_google_guava_guava_21_0_with_file//jar:file",
-        "@org_apache_commons_commons_lang_3_5//jar:file",
+        "@com_google_guava_guava_21_0_with_file//:guava-21.0.jar",
+        "@org_apache_commons_commons_lang_3_5//:commons-lang3-3.5.jar",
     ],
 )
 

--- a/test_expect_failure/scala_import/BUILD
+++ b/test_expect_failure/scala_import/BUILD
@@ -6,18 +6,18 @@ load("//scala:scala_import.bzl", "scala_import")
 
 scala_import(
     name = "dummy_dependency_to_trigger_create_provider_transitive_compile_jar_usage",
-    jars = ["@org_psywerx_hairyfotr__linter//jar:file"],
+    jars = ["@org_psywerx_hairyfotr__linter//jar"],
 )
 
 scala_import(
     name = "guava",
-    jars = ["@com_google_guava_guava_21_0_with_file//jar:file"],
+    jars = ["@com_google_guava_guava_21_0_with_file//jar"],
     deps = [":dummy_dependency_to_trigger_create_provider_transitive_compile_jar_usage"],
 )
 
 scala_import(
     name = "cats",
-    jars = ["@org_typelevel__cats_core//jar:file"],
+    jars = ["@org_typelevel__cats_core//jar"],
 )
 
 scala_import(
@@ -28,7 +28,7 @@ scala_import(
 
 scala_import(
     name = "commons_lang_as_imported_jar_cats_and_guava_as_compile_deps",
-    jars = ["@org_apache_commons_commons_lang_3_5//jar:file"],
+    jars = ["@org_apache_commons_commons_lang_3_5//jar"],
     deps = [
         ":guava",
         ":indirection_for_transitive_compile_deps",

--- a/test_version.sh
+++ b/test_version.sh
@@ -4,30 +4,30 @@ set -e
 
 test_scala_version() {
   SCALA_VERSION=$1
-  
+
   SCALA_VERSION_SHAS=''
   SCALA_VERSION_SHAS+='"scala_compiler": "'$2'",'
   SCALA_VERSION_SHAS+='"scala_library": "'$3'",'
   SCALA_VERSION_SHAS+='"scala_reflect": "'$4'"'
 
   cd "${dir}"/test_version
-  
+
   timestamp=$(date +%s)
-  
+
   NEW_TEST_DIR="test_${SCALA_VERSION}_${timestamp}"
-  
+
   cp -r version_specific_tests_dir/ $NEW_TEST_DIR
-  
+
   sed \
       -e "s/\${scala_version}/$SCALA_VERSION/" \
       -e "s/\${scala_version_shas}/$SCALA_VERSION_SHAS/" \
       WORKSPACE.template >> $NEW_TEST_DIR/WORKSPACE
-  
+
   cd $NEW_TEST_DIR
 
   bazel test //...
   RESPONSE_CODE=$?
-  
+
   cd ..
   rm -rf $NEW_TEST_DIR
 
@@ -44,7 +44,8 @@ $runner test_scala_version "2.11.12" \
     "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0" \
     "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce" \
     "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04"
-$runner test_scala_version "2.12.6" \
-    "3023b07cc02f2b0217b2c04f8e636b396130b3a8544a8dfad498a19c3e57a863" \
-    "f81d7144f0ce1b8123335b72ba39003c4be2870767aca15dd0888ba3dab65e98" \
-    "ffa70d522fc9f9deec14358aa674e6dd75c9dfa39d4668ef15bb52f002ce99fa"
+
+$runner test_scala_version "2.12.10" \
+    "cedc3b9c39d215a9a3ffc0cc75a1d784b51e9edc7f13051a1b4ad5ae22cfbc0c" \
+    "0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d" \
+    "56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730"


### PR DESCRIPTION
### Description

This pull request converts all maven_jar usages to jvm_maven_import_external.

See https://github.com/bazelbuild/bazel/issues/6799 for more information about `maven_jar`'s removal.

### Motivation

`maven_jar` is planned for removal in Bazel 2.0. 
