### PR TITLE
WIP: Replace maven_jar with maven_install

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,12 +95,6 @@ scala_maven_import_external(
     srcjar_sha256 = "5e586357a289f5fe896f7b48759e1c16d9fa419333156b496696887e613d7a19",
 )
 
-# maven_jar(
-#     name = "org_apache_commons_commons_lang_3_5",
-#     artifact = "org.apache.commons:commons-lang3:3.5",
-#     sha1 = "6c6c702c89bfff3cd9e80b04d668c5e190d588c6",
-# )
-
 new_local_repository(
     name = "test_new_local_repo",
     build_file_content =

--- a/test/BUILD
+++ b/test/BUILD
@@ -63,7 +63,7 @@ scala_binary(
 scala_library(
     name = "HelloLib",
     srcs = ["HelloLib.scala"],
-    plugins = ["@org_psywerx_hairyfotr__linter//jar"],
+    plugins = ["@maven//:org_psywerx_hairyfotr_linter_2_11"],
     deps = [
         "Exported",
         "MacroTest",
@@ -278,7 +278,7 @@ scala_repl(
 
 scala_library(
     name = "jar_export",
-    exports = ["@com_twitter__scalding_date//jar"],
+    exports = ["@maven//:com_twitter_scalding_date_2_11"],
 )
 
 #Mix java scala

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -5,8 +5,8 @@ load("//scala:scala_import.bzl", "scala_import")
 scala_import(
     name = "guava_and_commons_lang",
     jars = [
-        "@com_google_guava_guava_21_0_with_file//jar:file",
-        "@org_apache_commons_commons_lang_3_5//jar:file",
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_apache_commons_commons_lang3",
     ],
 )
 
@@ -44,7 +44,7 @@ scala_specs2_junit_test(
 #filter source jars
 scala_import(
     name = "cats",
-    jars = ["@org_typelevel__cats_core//jar:file"],
+    jars = ["@maven//:org_typelevel_cats_core_2_11"],
 )
 
 scala_library(
@@ -77,11 +77,11 @@ scala_specs2_junit_test(
     runtime_deps = [":cats_and_guava_and_commons_lang_as_runtime_deps"],
 )
 
-java_import(
+java_library(
     name = "guava_and_commons_lang_java_import",
-    jars = [
-        "@com_google_guava_guava_21_0_with_file//jar:file",
-        "@org_apache_commons_commons_lang_3_5//jar:file",
+    exports = [
+        "@maven//:com_google_guava_guava",
+        "@maven//:org_apache_commons_commons_lang3",
     ],
 )
 

--- a/test/src/main/scala/scalarules/test/sources_jars_in_deps/BUILD
+++ b/test/src/main/scala/scalarules/test/sources_jars_in_deps/BUILD
@@ -4,6 +4,6 @@ scala_library(
     name = "source_jar_not_oncp",
     srcs = ["ReferCatsImplicits.scala"],
     deps = [
-        "@org_typelevel__cats_core//jar",
+        "@maven//:org_typelevel_cats_core_2_11",
     ],
 )

--- a/test_expect_failure/missing_direct_deps/external_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/external_deps/BUILD
@@ -31,5 +31,5 @@ scala_library(
     srcs = [
         "B.scala",
     ],
-    deps = ["@com_google_guava_guava_21_0_with_file//jar"],
+    deps = ["@maven//:com_google_guava_guava"],
 )

--- a/test_expect_failure/scala_import/BUILD
+++ b/test_expect_failure/scala_import/BUILD
@@ -6,18 +6,18 @@ load("//scala:scala_import.bzl", "scala_import")
 
 scala_import(
     name = "dummy_dependency_to_trigger_create_provider_transitive_compile_jar_usage",
-    jars = ["@org_psywerx_hairyfotr__linter//jar:file"],
+    jars = ["@maven//:org_psywerx_hairyfotr_linter_2_11:file"],
 )
 
 scala_import(
     name = "guava",
-    jars = ["@com_google_guava_guava_21_0_with_file//jar:file"],
+    jars = ["@maven//:com_google_guava_guava:file"],
     deps = [":dummy_dependency_to_trigger_create_provider_transitive_compile_jar_usage"],
 )
 
 scala_import(
     name = "cats",
-    jars = ["@org_typelevel__cats_core//jar:file"],
+    jars = ["@maven//:org_typelevel_cats_core_2_11:file"],
 )
 
 scala_import(
@@ -28,7 +28,7 @@ scala_import(
 
 scala_import(
     name = "commons_lang_as_imported_jar_cats_and_guava_as_compile_deps",
-    jars = ["@org_apache_commons_commons_lang_3_5//jar:file"],
+    jars = ["@maven//:org_apache_commons_commons_lang3:file"],
     deps = [
         ":guava",
         ":indirection_for_transitive_compile_deps",

--- a/third_party/dependency_analyzer/src/test/BUILD
+++ b/third_party/dependency_analyzer/src/test/BUILD
@@ -11,7 +11,7 @@ scala_junit_test(
     jvm_flags = [
         "-Dplugin.jar.location=$(location //third_party/dependency_analyzer/src/main:dependency_analyzer)",
         "-Dscala.library.location=$(location //external:io_bazel_rules_scala/dependency/scala/scala_library)",
-        "-Dguava.jar.location=$(location @com_google_guava_guava_21_0_with_file//jar)",
+        "-Dguava.jar.location=$(location @maven//:com_google_guava_guava)",
         "-Dapache.commons.jar.location=$(location @org_apache_commons_commons_lang_3_5_without_file//:linkable_org_apache_commons_commons_lang_3_5_without_file)",
     ],
     suffixes = ["Test"],
@@ -22,7 +22,7 @@ scala_junit_test(
         "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
         "//third_party/dependency_analyzer/src/main:dependency_analyzer",
         "//third_party/utils/src/test:test_util",
-        "@com_google_guava_guava_21_0_with_file//jar",
+        "@maven//:com_google_guava_guava",
         "@org_apache_commons_commons_lang_3_5_without_file//:linkable_org_apache_commons_commons_lang_3_5_without_file",
     ],
 )


### PR DESCRIPTION
This should fix building this repo with Bazel@HEAD (and the upcoming Bazel 2.0 version).

Context: https://github.com/bazelbuild/bazel/issues/6799

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Replace native `maven_jar` rules with `maven_install` from https://github.com/bazelbuild/rules_jvm_external.

See https://github.com/bazelbuild/rules_jvm_external/blob/master/README.md

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

Bazel 2.0 will remove support for the native `maven_jar` rule. Bazel@HEAD can no longer run `bazel info` in this repo because of the `maven_jar` rules in the `WORKSPACE`.