### PR TITLE
WIP: use scala sculpt to automatically break targets

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -249,4 +249,5 @@ scala_maven_import_external(
 
 # here is the source build for sculpt
 load("@io_bazel_rules_scala//src/scala/io/bazel/rules_scala/target_split:sculpt.bzl", "make_sculpt")
+
 make_sculpt()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -246,3 +246,7 @@ scala_maven_import_external(
         "https://repo.maven.apache.org/maven2/",
     ],
 )
+
+# here is the source build for sculpt
+load("@io_bazel_rules_scala//src/scala/io/bazel/rules_scala/target_split:sculpt.bzl", "make_sculpt")
+make_sculpt()

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -30,6 +30,10 @@ def _default_scala_extra_jars():
                 "version": "1.0.4",
                 "sha256": "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
             },
+            "io_spray_spray_json": {
+                "version": "1.3.5",
+                "sha256": "6f341db92de96d4c4a768f478aa44662ecfecdb6d8d94facaf8e23cd00f59a93",
+            },
         },
         "2.12": {
             "scalatest": {
@@ -47,6 +51,10 @@ def _default_scala_extra_jars():
             "scala_parser_combinators": {
                 "version": "1.0.4",
                 "sha256": "282c78d064d3e8f09b3663190d9494b85e0bb7d96b0da05994fe994384d96111",
+            },
+            "io_spray_spray_json": {
+                "version": "1.3.5",
+                "sha256": "0dfaafce29a9a245b0a9180ec2c1073d2bd8f0330f03a9f1f6a74d1bc83f62d6",
             },
         },
     }
@@ -109,6 +117,18 @@ def scala_repositories(
                 extra_jar_version = scala_version_extra_jars["scala_parser_combinators"]["version"],
             ),
         artifact_sha256 = scala_version_extra_jars["scala_parser_combinators"]["sha256"],
+        licenses = ["notice"],
+        server_urls = maven_servers,
+    )
+
+    _scala_maven_import_external(
+        name = "io_bazel_rules_scala_spray_json",
+        artifact =
+            "io.spray:spray-json_{major_version}:{extra_jar_version}".format(
+                major_version = major_version,
+                extra_jar_version = scala_version_extra_jars["io_spray_spray_json"]["version"],
+            ),
+        artifact_sha256 = scala_version_extra_jars["io_spray_spray_json"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
     )

--- a/src/scala/io/bazel/rules_scala/target_split/BUILD
+++ b/src/scala/io/bazel/rules_scala/target_split/BUILD
@@ -3,63 +3,69 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 
 sculpt_json(
     name = "example",
-    srcs = ["File1.scala", "File2.scala"],
-    deps = [
-      "@io_bazel_rules_scala_scala_library",
-      "@io_bazel_rules_scala_scala_compiler",
-      "@io_bazel_rules_scala_scala_reflect",
+    srcs = [
+        "File0.scala",
+        "File1.scala",
+        "File2.scala",
     ],
-    )
-
-
+    deps = [
+        "@io_bazel_rules_scala_scala_compiler",
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_reflect",
+    ],
+)
 
 scala_library(
     name = "example0_scala",
     srcs = ["File0.scala"],
-    )
+)
 
 scala_library(
     name = "example_scala",
-    srcs = ["File1.scala", "File2.scala"],
-    deps = [":example0_scala"],
+    srcs = [
+        "File1.scala",
+        "File2.scala",
+    ],
     exports = [":example0_scala"],
-    )
+    deps = [":example0_scala"],
+)
 
 java_binary(
     name = "scalac_runner",
-    runtime_deps = [
-      "@io_bazel_rules_scala_scala_library",
-      "@io_bazel_rules_scala_scala_compiler",
-      "@io_bazel_rules_scala_scala_reflect",
-      "@io_bazel_rules_scala_spray_json",
-    ],
     main_class = "scala.tools.nsc.Main",
     visibility = ["//visibility:public"],
-    )
+    runtime_deps = [
+        "@io_bazel_rules_scala_scala_compiler",
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_reflect",
+        "@io_bazel_rules_scala_spray_json",
+    ],
+)
 
 scala_library(
     name = "dagify",
     srcs = ["Dagify.scala"],
-    )
+)
 
 scala_library(
     name = "bazelgen",
     srcs = ["BazelGen.scala"],
-    )
+)
 
 scala_library(
     name = "sculpt_processor",
     srcs = ["SculptProcessor.scala"],
     deps = [
-      ":bazelgen",
-      ":dagify",
-      "@io_bazel_rules_scala_spray_json",
-      "@sculpt//:sculpt",
-    ])
+        ":bazelgen",
+        ":dagify",
+        "@io_bazel_rules_scala_spray_json",
+        "@sculpt",
+    ],
+)
 
 java_binary(
     name = "sculpt_processor_runner",
-    runtime_deps = [":sculpt_processor"],
     main_class = "io.bazel.rules_scala.target_split.SculptProcessor",
     visibility = ["//visibility:public"],
-    )
+    runtime_deps = [":sculpt_processor"],
+)

--- a/src/scala/io/bazel/rules_scala/target_split/BUILD
+++ b/src/scala/io/bazel/rules_scala/target_split/BUILD
@@ -11,6 +11,20 @@ sculpt_json(
     ],
     )
 
+
+
+scala_library(
+    name = "example0_scala",
+    srcs = ["File0.scala"],
+    )
+
+scala_library(
+    name = "example_scala",
+    srcs = ["File1.scala", "File2.scala"],
+    deps = [":example0_scala"],
+    exports = [":example0_scala"],
+    )
+
 java_binary(
     name = "scalac_runner",
     runtime_deps = [
@@ -47,4 +61,5 @@ java_binary(
     name = "sculpt_processor_runner",
     runtime_deps = [":sculpt_processor"],
     main_class = "io.bazel.rules_scala.target_split.SculptProcessor",
+    visibility = ["//visibility:public"],
     )

--- a/src/scala/io/bazel/rules_scala/target_split/BUILD
+++ b/src/scala/io/bazel/rules_scala/target_split/BUILD
@@ -1,0 +1,25 @@
+load(":sculpt.bzl", "sculpt_json")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary")
+
+sculpt_json(
+    name = "example",
+    srcs = ["File1.scala", "File2.scala"],
+    deps = [
+      "@io_bazel_rules_scala_scala_library",
+      "@io_bazel_rules_scala_scala_compiler",
+      "@io_bazel_rules_scala_scala_reflect",
+    ],
+    )
+
+java_binary(
+    name = "scalac_runner",
+    runtime_deps = [
+      "@io_bazel_rules_scala_scala_library",
+      "@io_bazel_rules_scala_scala_compiler",
+      "@io_bazel_rules_scala_scala_reflect",
+      "@io_bazel_rules_scala_spray_json",
+    ],
+    main_class = "scala.tools.nsc.Main",
+    visibility = ["//visibility:public"],
+    )
+

--- a/src/scala/io/bazel/rules_scala/target_split/BUILD
+++ b/src/scala/io/bazel/rules_scala/target_split/BUILD
@@ -1,5 +1,5 @@
 load(":sculpt.bzl", "sculpt_json")
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 
 sculpt_json(
     name = "example",
@@ -23,3 +23,22 @@ java_binary(
     visibility = ["//visibility:public"],
     )
 
+scala_library(
+    name = "dagify",
+    srcs = ["Dagify.scala"],
+    )
+
+scala_library(
+    name = "sculpt_processor",
+    srcs = ["SculptProcessor.scala"],
+    deps = [
+      ":dagify",
+      "@io_bazel_rules_scala_spray_json",
+      "@sculpt//:sculpt",
+    ])
+
+java_binary(
+    name = "sculpt_processor_runner",
+    runtime_deps = [":sculpt_processor"],
+    main_class = "io.bazel.rules_scala.target_split.SculptProcessor",
+    )

--- a/src/scala/io/bazel/rules_scala/target_split/BUILD
+++ b/src/scala/io/bazel/rules_scala/target_split/BUILD
@@ -29,9 +29,15 @@ scala_library(
     )
 
 scala_library(
+    name = "bazelgen",
+    srcs = ["BazelGen.scala"],
+    )
+
+scala_library(
     name = "sculpt_processor",
     srcs = ["SculptProcessor.scala"],
     deps = [
+      ":bazelgen",
       ":dagify",
       "@io_bazel_rules_scala_spray_json",
       "@sculpt//:sculpt",

--- a/src/scala/io/bazel/rules_scala/target_split/BazelGen.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/BazelGen.scala
@@ -1,0 +1,28 @@
+package io.bazel.rules_scala.target_split
+
+object BazelGen {
+  final case class ScalaLibrary(
+    name: String,
+    srcs: List[String],
+    deps: List[String],
+    visibility: List[String],
+    exports: List[String]) {
+
+    def render: String = {
+      def q(s: String): String = "\"" + s + "\""
+      def list(s: List[String], indent: String): String =
+        if (s.isEmpty) "[]"
+        else s.iterator.map(q).mkString(s"[\n$indent", s",\n$indent",s",\n$indent]")
+
+      val ident = " " * 8
+      s"""|scala_library(
+          |    name = ${q(name)},
+          |    srcs = ${list(srcs, ident)},
+          |    deps = ${list(deps, ident)},
+          |    visibility = ${list(visibility, ident)},
+          |    exports = ${list(exports, ident)},
+          |    )""".stripMargin
+    }
+  }
+}
+

--- a/src/scala/io/bazel/rules_scala/target_split/Dagify.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/Dagify.scala
@@ -96,6 +96,23 @@ object Graph {
         (c, deps)
       }.toMap
 
+    lazy val topological: List[List[Cluster]] = {
+      def loop(prev: List[Cluster], rest: List[Cluster], acc: List[List[Cluster]]): List[List[Cluster]] =
+        if (rest.isEmpty) acc.reverse.map(_.sorted)
+        else {
+          // everyone that can reach the prev is in the next group
+          val (next, notyet) = rest.partition { c =>
+            val cdeps = clusterDeps(c)
+            // are all of the deps already seen?
+            prev.forall(cdeps)
+          }
+
+          loop(next reverse_::: prev, notyet, next :: acc)
+        }
+
+        loop(Nil, clusterMembers.toList, Nil)
+    }
+
     /**
      * if the original A graph was a DAG, then all the clusters are singletons
      */

--- a/src/scala/io/bazel/rules_scala/target_split/Dagify.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/Dagify.scala
@@ -1,0 +1,106 @@
+package io.bazel.rules_scala.target_split
+
+import scala.collection.immutable.SortedSet
+
+object Graph {
+
+  def dagify[A: Ordering](seed: Set[A])(neighbors: A => Set[A]): Dagify[A] =
+    new Dagify[A](seed, neighbors)
+
+  def dagifyGraph[A: Ordering](graph: Map[A, Iterable[A]]): Dagify[A] =
+    dagify(graph.keySet) { a => graph.getOrElse(a, Nil).toSet }
+
+  /**
+   * Build a DAG by merging individual nodes of type A into merged nodes of type SortedSet[A]
+   */
+  final class Dagify[A: Ordering](seed: Set[A], val neighbors: A => Set[A]) {
+
+    @annotation.tailrec
+    private def allNodes(toCheck: List[A], reached: Set[A], acc: SortedSet[A]): SortedSet[A] =
+      toCheck match {
+        case Nil => acc
+        case h :: tail =>
+          if (reached(h)) allNodes(tail, reached, acc)
+          else allNodes(neighbors(h).toList.sorted ::: tail, reached + h, acc + h)
+      }
+
+    // all the reachable nodes in a sorted order
+    val nodes: SortedSet[A] =
+      allNodes(seed.toList, Set.empty, SortedSet.empty)
+
+    /*
+     * For each node, build the full set of nodes it can reach by the neighbors function
+     */
+    @annotation.tailrec
+    private def reachable(m: List[(A, SortedSet[A])],
+                          acc: List[(A, SortedSet[A])]): Map[A, SortedSet[A]] =
+      if (m.isEmpty) acc.toMap
+      else {
+        // if A -> B, then include all the nodes B can reach
+        val stepped = m.iterator.map {
+          case (src, dest0) =>
+            // expand src + dest0 by looking at all the neighbors of this set
+            val dest1 = dest0.flatMap(neighbors) ++ neighbors(src)
+            (src, (dest0, dest1))
+        }.toList
+
+        // if the expanded set is the same as the initial set, that node has computed its full reach
+        // and is done, else we need to continue to expand
+        val (done, notDone) = stepped.partition { case (_, (d0, d1)) => d0 == d1 }
+        reachable(notDone.map { case (k, (_, d1))                    => (k, d1) }, done.map {
+          case (k, (d0, _))                                          => (k, d0)
+        } ::: acc)
+      }
+
+    private def toSortedSet[T: Ordering](it: Iterator[T]): SortedSet[T] = {
+      val bldr = SortedSet.newBuilder[T]
+      bldr ++= it
+      bldr.result()
+    }
+
+    // all the reachable nodes from a given node
+    val reachableMap: Map[A, SortedSet[A]] =
+      reachable(nodes.iterator.map { a =>
+        (a, SortedSet.empty[A])
+      }.toList, Nil)
+
+    type Cluster = SortedSet[A]
+    implicit val ordCluster: Ordering[Cluster] = Ordering.Iterable[A].on { s: SortedSet[A] =>
+      s
+    }
+
+    // To make a dag, we group nodes together that are mutually reachable, these larger sets
+    // become the new nodes in the bigger graph
+    val clusterMembers: SortedSet[Cluster] =
+      toSortedSet(reachableMap.iterator.map {
+        case (n, reach) =>
+          if (reach(n)) {
+            // we can reach ourselves, so we include everyone in this cluster that can reach us
+            toSortedSet(reach.iterator.collect { case n1 if reachableMap(n1)(n) => n1 })
+          } else SortedSet(n)
+      })
+
+    // which cluster is each node in
+    val clusterMap: Map[A, Cluster] =
+      nodes.iterator.map { n =>
+        n -> clusterMembers.iterator.filter(_(n)).next
+      }.toMap
+
+    // this must form a DAG now by construction
+    val clusterDeps: Map[Cluster, SortedSet[Cluster]] =
+      clusterMembers.iterator.map { c =>
+        val reach = c.flatMap(neighbors)
+        val deps = clusterMembers.filter { c1 =>
+          reach.exists(c1)
+        } - c
+        (c, deps)
+      }.toMap
+
+    /**
+     * if the original A graph was a DAG, then all the clusters are singletons
+     */
+    lazy val originalIsDag: Boolean =
+      clusterMembers.forall(_.size == 1)
+  }
+}
+

--- a/src/scala/io/bazel/rules_scala/target_split/File0.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/File0.scala
@@ -1,0 +1,5 @@
+package example
+
+object File0 {
+  def ident[A](a: A): A = a
+}

--- a/src/scala/io/bazel/rules_scala/target_split/File1.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/File1.scala
@@ -1,0 +1,5 @@
+package example
+
+object File1 {
+  val message: String = "this is file 1"
+}

--- a/src/scala/io/bazel/rules_scala/target_split/File1.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/File1.scala
@@ -1,5 +1,5 @@
 package example
 
 object File1 {
-  val message: String = "this is file 1"
+  val message: String = File0.ident("this is file 1")
 }

--- a/src/scala/io/bazel/rules_scala/target_split/File2.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/File2.scala
@@ -1,0 +1,5 @@
+package example
+
+object File2 {
+  val message: String = File1.message + " called from File2"
+}

--- a/src/scala/io/bazel/rules_scala/target_split/SculptProcessor.scala
+++ b/src/scala/io/bazel/rules_scala/target_split/SculptProcessor.scala
@@ -1,0 +1,76 @@
+package io.bazel.rules_scala.target_split
+
+import com.lightbend.tools.sculpt.model.{EntityKind, FullDependency, ModelJsonProtocol, Path => SPath, DependencyKind}
+import java.nio.file.{Files, Path, Paths}
+
+object SculptProcessor {
+  def loadFullDeps(p: Path): Seq[FullDependency] = {
+    // narrow implicit scope
+    import ModelJsonProtocol._
+    import spray.json._
+
+    val str = new String(Files.readAllBytes(p), "utf-8")
+    str.parseJson.convertTo[Seq[FullDependency]]
+  }
+
+
+  def addEdges[A](graph: Map[A, Set[A]], from: A, to: Set[A]): Map[A, Set[A]] =
+    graph.get(from) match {
+      case None => graph.updated(from, to)
+      case Some(n) => graph.updated(from, n.union(to))
+    }
+
+  def fileGraph(deps: Seq[FullDependency]): Map[Path, Set[Path]] = {
+    val pathToFile: Map[SPath, Path] =
+      deps.flatMap {
+        case fd if fd.kind == DependencyKind.Declares =>
+          fd
+            .from
+            .elems
+            .collect { case e if e.kind == EntityKind.File && e.name != "" => (fd.to, Paths.get(e.name)) }
+        case _ => Nil
+      }
+      .toMap
+
+    // here if an SPath extends or uses an SPath, we list it here
+   val useExtendGraph: Map[SPath, Set[SPath]] =
+      deps.foldLeft(Map.empty[SPath, Set[SPath]]) { (graph, fd) =>
+        if (fd.kind == DependencyKind.Uses || fd.kind == DependencyKind.Extends) {
+          addEdges(graph, fd.from, Set(fd.to))
+        }
+        else graph
+      }
+
+    val allSPaths: Set[SPath] =
+      deps.flatMap { fd => fd.from :: fd.to :: Nil }.toSet
+
+    def getFile(spath: SPath): Option[Path] =
+      pathToFile.get(spath) match {
+        case None =>
+          println(s"warning: $spath file is unknown")
+          None
+        case some => some
+      }
+
+    allSPaths.foldLeft(Map.empty[Path, Set[Path]]) { (graph, spath) =>
+      getFile(spath) match {
+        case Some(path) =>
+          val deps = useExtendGraph.getOrElse(spath, Set.empty)
+            .iterator
+            .flatMap(getFile(_).iterator)
+            .toSet
+
+          addEdges(graph, path, deps)
+        case None => graph
+      }
+    }
+  }
+
+  def main(args: Array[String]): Unit = {
+    val fds = loadFullDeps(Paths.get(args(0)))
+
+    val graph = fileGraph(fds)
+    val dag = Graph.dagifyGraph(graph)
+    println(dag.clusterDeps)
+  }
+}

--- a/src/scala/io/bazel/rules_scala/target_split/sculpt.bzl
+++ b/src/scala/io/bazel/rules_scala/target_split/sculpt.bzl
@@ -1,0 +1,65 @@
+load("@bazel_tools//tools/build_defs/repo:git.bzl", "new_git_repository")
+
+def make_sculpt():
+  new_git_repository(
+      name = "sculpt",
+      remote = "https://github.com/johnynek/scala-sculpt.git",
+      commit = "722c598fa38113f0641dc7806709682ca2534f6f",
+      build_file_content = """
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "sculpt",
+    srcs = glob(["src/main/scala/**/*.scala"]),
+    resources = ["src/main/resources/scalac-plugin.xml"],
+    deps = [
+      "@io_bazel_rules_scala_scala_reflect",
+      "@io_bazel_rules_scala_scala_compiler",
+      "@io_bazel_rules_scala_spray_json",
+    ],
+    visibility = ["//visibility:public"],
+)
+""",
+  )
+
+def sculpt_json_impl(ctx):
+    outjson = ctx.actions.declare_file(ctx.label.name + "_sculpt.json")
+    args = ctx.actions.args()
+
+    args.add("-Xplugin:" + ctx.files._sculpt_plugin[0].path)
+    args.add("-Xplugin-require:sculpt")
+    args.add("-P:sculpt:out=" + outjson.path)
+    args.add("-usejavacp")
+    args.add_joined("-toolcp", ctx.files.deps, join_with = ":")
+    args.add_all([f.path for f in ctx.files.srcs])
+
+    ctx.actions.run(
+        outputs = [outjson],
+        inputs = ctx.files.srcs + ctx.files._sculpt_plugin,
+        arguments = [args],
+        executable = ctx.executable._scalac_runner)
+
+    return [DefaultInfo(files = depset([outjson]))]
+
+sculpt_json = rule(
+    implementation = sculpt_json_impl,
+    attrs = {
+      "srcs": attr.label_list(allow_files = [
+          ".scala",
+      ]),
+      "deps": attr.label_list(
+          providers = [[JavaInfo]],
+      ),
+      "_scalac_runner": attr.label(
+          default = Label("@io_bazel_rules_scala//src/scala/io/bazel/rules_scala/target_split:scalac_runner"),
+          allow_files = True,
+          executable = True,
+          cfg = "host",
+        ),
+      "_sculpt_plugin": attr.label(
+          default = Label("@sculpt//:sculpt.jar"),
+          allow_files = True,
+        ),
+    }
+)
+

--- a/src/scala/io/bazel/rules_scala/target_split/sculpt.bzl
+++ b/src/scala/io/bazel/rules_scala/target_split/sculpt.bzl
@@ -4,7 +4,7 @@ def make_sculpt():
   new_git_repository(
       name = "sculpt",
       remote = "https://github.com/johnynek/scala-sculpt.git",
-      commit = "722c598fa38113f0641dc7806709682ca2534f6f",
+      commit = "d7fa6084f47034caea115bce9a38ff5e68fbfb08",
       build_file_content = """
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-default_bazel_version='0.28.1'
+default_bazel_version='1.2.1'
 
 if [ "$BUILDKITE" = true ]; then
     bazel_version='host'


### PR DESCRIPTION
### Description
A demonstration of a solution to #265 : automatically splitting targets into smaller targets.

### Motivation
The goal of this is to add a new optional output to all scala_library targets such as `target_split.BUILD` which will emit a fine grained segment of a build that has broken a large target into the smallest DAG we can. It will have one section of external_dependencies, all the `deps` of the current rule, which in this first version will just be forwarded to each node in the dag, then the dag nodes, finally a single export target that exports the entire dag with the same name as the original target to that downstream consumers aren't broken.

The code is not yet complete (and of course should not be merged yet) but I plan to have a basic version of this workable by this friday so people can start experimenting with it.

It is my opinion that onboarding becomes much easier: you build one big globs target, then use this to output a dag for your repo and rewrite it.

My hope is that it can get more people onto using strict reproducible compilations and help people move away from zinc (which still has a number of reproducibility issues and fixing them does not seem to be a priority of that team, but I would love to be corrected and learn it is a priority for them).