### PR TITLE
expand locations in scalacptops, take 2

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -238,7 +238,8 @@ CurrentTarget: {current_target}
     compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
-    scalacopts = [ctx.expand_location(v, ctx.attr.plugins) for v in toolchain.scalacopts + in_scalacopts]
+    scalacopts_expansion_targets = getattr(ctx.attr, 'plugins', [])
+    scalacopts = [ctx.expand_location(v, scalacopts_expansion_targets) for v in toolchain.scalacopts + in_scalacopts]
 
     scalac_args = """
 Classpath: {cp}

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -238,7 +238,7 @@ CurrentTarget: {current_target}
     compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
-    scalacopts = toolchain.scalacopts + in_scalacopts
+    scalacopts = [ctx.expand_location(v, ctx.attr.plugins) for v in toolchain.scalacopts + in_scalacopts]
 
     scalac_args = """
 Classpath: {cp}

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -238,7 +238,7 @@ CurrentTarget: {current_target}
     compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
-    scalacopts_expansion_targets = getattr(ctx.attr, 'plugins', [])
+    scalacopts_expansion_targets = getattr(ctx.attr, "plugins", [])
     scalacopts = [ctx.expand_location(v, scalacopts_expansion_targets) for v in toolchain.scalacopts + in_scalacopts]
 
     scalac_args = """

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -1,0 +1,40 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "check_expand_location",
+    srcs = ["trivial.scala"],
+    plugins = [
+        ":check_expand_location_plugin_deploy.jar",
+    ],
+    scalacopts = [
+        "-P:diablerie:location=$(location :check_expand_location_plugin_deploy.jar)",
+    ],
+)
+
+scala_library(
+    name = "check_expand_location_plugin",
+    srcs = [
+        "check_expand_location_plugin.scala",
+    ],
+    resource_strip_prefix = package_name(),
+    resources = [
+        ":gen-scalac-plugin.xml",
+    ],
+    deps = [
+        "@io_bazel_rules_scala_scala_compiler",
+    ],
+)
+
+_gen_plugin_xml_cmd = """
+cat > $@ << EOF
+<plugin>
+  <name>plugin</name>
+  <classname>plugin.Plugin</classname>
+</plugin>
+"""
+
+genrule(
+    name = "gen-scalac-plugin.xml",
+    outs = ["scalac-plugin.xml"],
+    cmd = _gen_plugin_xml_cmd,
+)

--- a/test/plugins/check_expand_location_plugin.scala
+++ b/test/plugins/check_expand_location_plugin.scala
@@ -1,0 +1,25 @@
+package plugin
+
+import scala.tools.nsc.Global
+import scala.tools.nsc.Phase
+import scala.tools.nsc.plugins.{ Plugin => NscPlugin}
+import scala.tools.nsc.plugins.PluginComponent
+
+import java.io.File
+
+final class Plugin(override val global: Global) extends NscPlugin {
+  override val name: String = "diablerie"
+  override val description: String = "just another plugin"
+  override val components: List[PluginComponent] = Nil
+
+  override def processOptions(options: List[String], error: String => Unit): Unit = {
+    options
+      .find(_.startsWith("location="))
+      .map(_.stripPrefix("location="))
+      .map(v => new File(v).exists) match {
+        case Some(true) => ()
+        case Some(false) => error("expanded location doesn't exist")
+        case None => error("missing location argument")
+      }
+  }
+}

--- a/test/plugins/trivial.scala
+++ b/test/plugins/trivial.scala
@@ -1,0 +1,5 @@
+package trivial
+
+object Trivial {
+  // feel free to reuse this file for other plugin tests
+}


### PR DESCRIPTION
https://github.com/bazelbuild/rules_scala/pull/890 but with an additional adjustment to support usages of the compile function from rules without the `plugins` attribute.

Specifically:

```python
scalacopts_expansion_targets = getattr(ctx.attr, 'plugins', [])
scalacopts = [ctx.expand_location(v, scalacopts_expansion_targets) for v in toolchain.scalacopts + in_scalacopts]
```

instead of

```python
scalacopts = [ctx.expand_location(v, ctx.attr.plugins) for v in toolchain.scalacopts + in_scalacopts]
```