### PR TITLE
Plugin expansion- Use input plugins param instead of ctx

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -238,7 +238,7 @@ CurrentTarget: {current_target}
     compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
-    scalacopts_expansion_targets = getattr(ctx.attr, "plugins", [])
+    scalacopts_expansion_targets = []
     scalacopts = [ctx.expand_location(v, scalacopts_expansion_targets) for v in toolchain.scalacopts + in_scalacopts]
 
     scalac_args = """

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -167,6 +167,7 @@ def compile_scala(
         unused_dependency_checker_mode = "off",
         unused_dependency_checker_ignored_targets = []):
     # look for any plugins:
+    input_plugins = plugins
     plugins = collect_plugin_paths(plugins)
     internal_plugin_jars = []
     dependency_analyzer_mode = "off"
@@ -238,8 +239,7 @@ CurrentTarget: {current_target}
     compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
-    scalacopts_expansion_targets = []
-    scalacopts = [ctx.expand_location(v, scalacopts_expansion_targets) for v in toolchain.scalacopts + in_scalacopts]
+    scalacopts = [ctx.expand_location(v, input_plugins) for v in toolchain.scalacopts + in_scalacopts]
 
     scalac_args = """
 Classpath: {cp}


### PR DESCRIPTION
### Description
Plugin expansion- Use input plugins param instead of ctx

### Motivation
Reduce usage of ctx in inner methods.
This also allows custom logic in the rules to which attributes they use