### PR TITLE
Return providers array instead of legacy struct

### DIFF
--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -7,8 +7,8 @@ def phase_binary_final(ctx, p):
     defaultInfo = DefaultInfo(
         executable = p.declare_executable,
         files = depset([p.declare_executable, ctx.outputs.jar]),
-        runfiles= p.runfiles.runfiles
-        )
+        runfiles = p.runfiles.runfiles,
+    )
     return struct(
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
@@ -16,8 +16,8 @@ def phase_binary_final(ctx, p):
 def phase_library_final(ctx, p):
     defaultInfo = DefaultInfo(
         files = depset([ctx.outputs.jar] + p.compile.full_jars),  # Here is the default output
-        runfiles= p.runfiles.runfiles
-        )
+        runfiles = p.runfiles.runfiles,
+    )
     return struct(
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
@@ -28,8 +28,8 @@ def phase_scalatest_final(ctx, p):
     defaultInfo = DefaultInfo(
         executable = p.declare_executable,
         files = depset([p.declare_executable, ctx.outputs.jar]),
-        runfiles= ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files)
-        )
+        runfiles = ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
+    )
     return struct(
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -5,11 +5,11 @@
 #
 def phase_binary_final(ctx, p):
     defaultInfo = DefaultInfo(
+        executable = p.declare_executable,
         files = depset([p.declare_executable, ctx.outputs.jar]),
         runfiles= p.runfiles.runfiles
         )
     return struct(
-        executable = p.declare_executable,
         coverage = p.compile.coverage,
         instrumented_files = p.compile.coverage.instrumented_files,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
@@ -30,11 +30,11 @@ def phase_scalatest_final(ctx, p):
     coverage_runfiles = p.coverage_runfiles.coverage_runfiles
     coverage_runfiles.extend(p.write_executable)
     defaultInfo = DefaultInfo(
+        executable = p.declare_executable,
         files = depset([p.declare_executable, ctx.outputs.jar]),
         runfiles= ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files)
         )
     return struct(
-        executable = p.declare_executable,
         instrumented_files = p.compile.coverage.instrumented_files,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -13,7 +13,6 @@ def phase_binary_final(ctx, p):
         coverage = p.compile.coverage,
         instrumented_files = p.compile.coverage.instrumented_files,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-        transitive_rjars = p.compile.rjars,  #calling rules need this for the classpath in the launcher
     )
 
 def phase_library_final(ctx, p):

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -10,7 +10,6 @@ def phase_binary_final(ctx, p):
         runfiles= p.runfiles.runfiles
         )
     return struct(
-        coverage = p.compile.coverage,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
 
@@ -20,7 +19,6 @@ def phase_library_final(ctx, p):
         runfiles= p.runfiles.runfiles
         )
     return struct(
-        jars_to_labels = p.collect_jars.jars2labels,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
 

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -9,18 +9,14 @@ def phase_binary_final(ctx, p):
         files = depset([p.declare_executable, ctx.outputs.jar]),
         runfiles = p.runfiles.runfiles,
     )
-    return struct(
-        providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-    )
+    return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers
 
 def phase_library_final(ctx, p):
     defaultInfo = DefaultInfo(
         files = depset([ctx.outputs.jar] + p.compile.full_jars),  # Here is the default output
         runfiles = p.runfiles.runfiles,
     )
-    return struct(
-        providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-    )
+    return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers
 
 def phase_scalatest_final(ctx, p):
     coverage_runfiles = p.coverage_runfiles.coverage_runfiles
@@ -30,6 +26,4 @@ def phase_scalatest_final(ctx, p):
         files = depset([p.declare_executable, ctx.outputs.jar]),
         runfiles = ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
     )
-    return struct(
-        providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-    )
+    return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -11,7 +11,6 @@ def phase_binary_final(ctx, p):
         )
     return struct(
         coverage = p.compile.coverage,
-        instrumented_files = p.compile.coverage.instrumented_files,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
 
@@ -21,7 +20,6 @@ def phase_library_final(ctx, p):
         runfiles= p.runfiles.runfiles
         )
     return struct(
-        instrumented_files = p.compile.coverage.instrumented_files,
         jars_to_labels = p.collect_jars.jars2labels,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
@@ -35,6 +33,5 @@ def phase_scalatest_final(ctx, p):
         runfiles= ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files)
         )
     return struct(
-        instrumented_files = p.compile.coverage.instrumented_files,
         providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -4,32 +4,38 @@
 # DOCUMENT THIS
 #
 def phase_binary_final(ctx, p):
+    defaultInfo = DefaultInfo(
+        files = depset([p.declare_executable, ctx.outputs.jar]),
+        runfiles= p.runfiles.runfiles
+        )
     return struct(
         executable = p.declare_executable,
         coverage = p.compile.coverage,
-        files = depset([p.declare_executable, ctx.outputs.jar]),
         instrumented_files = p.compile.coverage.instrumented_files,
-        providers = [p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-        runfiles = p.runfiles.runfiles,
+        providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
         transitive_rjars = p.compile.rjars,  #calling rules need this for the classpath in the launcher
     )
 
 def phase_library_final(ctx, p):
-    return struct(
+    defaultInfo = DefaultInfo(
         files = depset([ctx.outputs.jar] + p.compile.full_jars),  # Here is the default output
+        runfiles= p.runfiles.runfiles
+        )
+    return struct(
         instrumented_files = p.compile.coverage.instrumented_files,
         jars_to_labels = p.collect_jars.jars2labels,
-        providers = [p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-        runfiles = p.runfiles.runfiles,
+        providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )
 
 def phase_scalatest_final(ctx, p):
     coverage_runfiles = p.coverage_runfiles.coverage_runfiles
     coverage_runfiles.extend(p.write_executable)
+    defaultInfo = DefaultInfo(
+        files = depset([p.declare_executable, ctx.outputs.jar]),
+        runfiles= ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files)
+        )
     return struct(
         executable = p.declare_executable,
-        files = depset([p.declare_executable, ctx.outputs.jar]),
         instrumented_files = p.compile.coverage.instrumented_files,
-        providers = [p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
-        runfiles = ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
+        providers = [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers,
     )

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -40,7 +40,7 @@ _scala_extension = ".scala"
 _srcjar_extension = ".srcjar"
 
 _empty_coverage_struct = struct(
-    instrumented_files = struct(),
+    instrumented_files = None,
     providers = [],
     replacements = {},
 )
@@ -871,14 +871,13 @@ def _jacoco_offline_instrument(ctx, input_jar):
     provider = _coverage_replacements_provider.create(
         replacements = replacements,
     )
-
+    instrumented_files_provider = coverage_common.instrumented_files_info(
+                                          ctx,
+                                          source_attributes = ["srcs"],
+                                          dependency_attributes = _coverage_replacements_provider.dependency_attributes,
+                                          extensions = ["scala", "java"])
     return struct(
-        instrumented_files = struct(
-            dependency_attributes = _coverage_replacements_provider.dependency_attributes,
-            extensions = ["scala", "java"],
-            source_attributes = ["srcs"],
-        ),
-        providers = [provider],
+        providers = [provider, instrumented_files_provider],
         replacements = replacements,
     )
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -872,10 +872,11 @@ def _jacoco_offline_instrument(ctx, input_jar):
         replacements = replacements,
     )
     instrumented_files_provider = coverage_common.instrumented_files_info(
-                                          ctx,
-                                          source_attributes = ["srcs"],
-                                          dependency_attributes = _coverage_replacements_provider.dependency_attributes,
-                                          extensions = ["scala", "java"])
+        ctx,
+        source_attributes = ["srcs"],
+        dependency_attributes = _coverage_replacements_provider.dependency_attributes,
+        extensions = ["scala", "java"],
+    )
     return struct(
         providers = [provider, instrumented_files_provider],
         replacements = replacements,

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -32,18 +32,13 @@ def _scala_import_impl(ctx):
         # TODO(#8867): Migrate away from the placeholder jar hack when #8867 is fixed.
         current_target_providers = [_new_java_info(ctx, ctx.file._placeholder_jar)]
 
-    return struct(
-        scala = struct(
-            outputs = struct(jars = intellij_metadata),
+    return [
+        java_common.merge(current_target_providers),
+        DefaultInfo(
+            files = current_jars,
         ),
-        providers = [
-            java_common.merge(current_target_providers),
-            DefaultInfo(
-                files = current_jars,
-            ),
-            JarsToLabelsInfo(jars_to_labels = jars2labels),
-        ],
-    )
+        JarsToLabelsInfo(jars_to_labels = jars2labels),
+    ]
 
 def _new_java_info(ctx, jar):
     return JavaInfo(


### PR DESCRIPTION
### Description
Remove remaining attributes.

This is part of a larger effort of removing all attributes we're returning and return only providers. 
Attributes were either:
1. Moved to DefaultInfo provider
2. Removed because they were redundant (pre phases they were needed in internal communication)
3. Coverage which moved to its own provider

Followup on #913 
Supersedes #914 (more accurate name and better git history)

### Motivation
Be Bazel 3.0.0 compliant per this bazel [issue](https://github.com/bazelbuild/bazel/issues/7347) and unifying on JavaInfo.
The above issue is also where I got the recommendation of how to move coverage to a provider from