### PR TITLE
Use https to access central.maven.org

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -157,7 +157,7 @@ java_import_external(
     name = "org_apache_commons_commons_lang_3_5_without_file",
     generated_linkable_rule_name = "linkable_org_apache_commons_commons_lang_3_5_without_file",
     jar_sha256 = "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
-    jar_urls = ["http://central.maven.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"],
+    jar_urls = ["https://repo.maven.apache.org/maven2/org/apache/commons/commons-lang3/3.5/commons-lang3-3.5.jar"],
     licenses = ["notice"],  # Apache 2.0
     neverlink = True,
 )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -4,7 +4,7 @@ load(
     _scala_maven_import_external = "scala_maven_import_external",
 )
 
-def jmh_repositories(maven_servers = ["http://central.maven.org/maven2"]):
+def jmh_repositories(maven_servers = ["https://repo.maven.apache.org/maven2"]):
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_org_openjdk_jmh_jmh_core",
         artifact = "org.openjdk.jmh:jmh-core:1.20",

--- a/junit/junit.bzl
+++ b/junit/junit.bzl
@@ -3,7 +3,7 @@ load(
     _scala_maven_import_external = "scala_maven_import_external",
 )
 
-def junit_repositories(maven_servers = ["http://central.maven.org/maven2"]):
+def junit_repositories(maven_servers = ["https://repo.maven.apache.org/maven2"]):
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_junit_junit",
         artifact = "junit:junit:4.12",

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -56,7 +56,7 @@ def scala_repositories(
             _default_scala_version(),
             _default_scala_version_jar_shas(),
         ),
-        maven_servers = ["http://central.maven.org/maven2"],
+        maven_servers = ["https://repo.maven.apache.org/maven2"],
         scala_extra_jars = _default_scala_extra_jars()):
     (scala_version, scala_version_jar_shas) = scala_version_shas
     major_version = _extract_major_version(scala_version)

--- a/scala_proto/private/scala_proto_default_repositories.bzl
+++ b/scala_proto/private/scala_proto_default_repositories.bzl
@@ -11,7 +11,7 @@ load(
 
 def scala_proto_default_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     scala_jar_shas = {

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -29,7 +29,7 @@ def register_default_proto_dependencies():
 
 def scala_proto_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     ret = scala_proto_default_repositories(scala_version, maven_servers)
     register_default_proto_dependencies()
     return ret

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -14,7 +14,7 @@ def specs2_version():
 
 def specs2_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     scala_jar_shas = {

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -18,7 +18,7 @@ load(
 
 def specs2_junit_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     specs2_repositories(scala_version, maven_servers)

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -23,7 +23,7 @@ _jar_extension = ".jar"
 
 def twitter_scrooge(
         scala_version = _default_scala_version(),
-        maven_servers = ["http://central.maven.org/maven2"]):
+        maven_servers = ["https://repo.maven.apache.org/maven2"]):
     major_version = _extract_major_version(scala_version)
 
     _scala_maven_import_external(


### PR DESCRIPTION
### Description
Use https to access central.maven.org.

Closes https://github.com/bazelbuild/rules_scala/issues/918

Maven now requires to use https instead of http. See https://support.sonatype.com/hc/en-us/articles/360041287334

This replaces all instances of http://central.maven.org by https://central.maven.org.

### Motivation
Code using rules_scala fails to build due to 501 errors.