### PR TITLE
scalatest final-remove redundant coverage handling

### DIFF
--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -19,11 +19,9 @@ def phase_library_final(ctx, p):
     return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers
 
 def phase_scalatest_final(ctx, p):
-    coverage_runfiles = p.coverage_runfiles.coverage_runfiles
-    coverage_runfiles.extend(p.write_executable)
     defaultInfo = DefaultInfo(
         executable = p.declare_executable,
         files = depset([p.declare_executable, ctx.outputs.jar]),
-        runfiles = ctx.runfiles(coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
+        runfiles = ctx.runfiles(p.coverage_runfiles.coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
     )
     return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers


### PR DESCRIPTION
### Description
Remove redundant coverage handling in scalatest final

### Motivation
Clean-up
Was looking over the phase architecture follow up tasks and saw the coverage smell issue.
Wanted to understand complexity and noticed that the call chain ends up leading to a constant `[]` so I just dropped it.
https://github.com/bazelbuild/rules_scala/blob/master/scala/private/phases/phase_write_executable.bzl#L28
https://github.com/bazelbuild/rules_scala/blob/master/scala/private/phases/phase_write_executable.bzl#L48
https://github.com/bazelbuild/rules_scala/blob/master/scala/private/phases/phase_write_executable.bzl#L67
https://github.com/bazelbuild/rules_scala/blob/6c16cff213b76a4126bdc850956046da5db1daaa/scala/private/rule_impls.bzl#L662