### PR TITLE
Use correct delimiter for jvm_flags launcher parameter

### DIFF
--- a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+++ b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
@@ -36,7 +36,7 @@ public class LauncherFileWriter {
             .addKeyValuePair("jar_bin_path", jarBinPath)
             .addKeyValuePair("java_start_class", javaStartClass)
             .addKeyValuePair("classpath", classpath)
-            .addJoinedValues("jvm_flags", " ", jvmFlags)
+            .addJoinedValues("jvm_flags", "\t", jvmFlags)
             .build();
 
     Path launcher = Paths.get(Runfiles.create().rlocation("bazel_tools/tools/launcher/launcher.exe"));


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Fix for https://github.com/bazelbuild/rules_scala/issues/796

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

As per [java_launcher.cc](https://source.bazel.build/bazel/+/master:src/tools/launcher/java_launcher.cc;l=364) the jvm args should be delimited by a tab character.
