### PR TITLE
exposing java jar to BEP from all binary rules

### DIFF
--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -6,7 +6,7 @@
 def phase_binary_final(ctx, p):
     defaultInfo = DefaultInfo(
         executable = p.declare_executable,
-        files = depset([p.declare_executable, ctx.outputs.jar]),
+        files = depset([p.declare_executable] + p.compile.full_jars),
         runfiles = p.runfiles.runfiles,
     )
     return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers
@@ -21,7 +21,7 @@ def phase_library_final(ctx, p):
 def phase_scalatest_final(ctx, p):
     defaultInfo = DefaultInfo(
         executable = p.declare_executable,
-        files = depset([p.declare_executable, ctx.outputs.jar]),
+        files = depset([p.declare_executable] + p.compile.full_jars),
         runfiles = ctx.runfiles(p.coverage_runfiles.coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
     )
     return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers

--- a/scala/private/phases/phase_final.bzl
+++ b/scala/private/phases/phase_final.bzl
@@ -13,7 +13,7 @@ def phase_binary_final(ctx, p):
 
 def phase_library_final(ctx, p):
     defaultInfo = DefaultInfo(
-        files = depset([ctx.outputs.jar] + p.compile.full_jars),  # Here is the default output
+        files = depset(p.compile.full_jars),
         runfiles = p.runfiles.runfiles,
     )
     return [defaultInfo, p.compile.merged_provider, p.collect_jars.jars2labels] + p.compile.coverage.providers

--- a/test/BUILD
+++ b/test/BUILD
@@ -303,6 +303,33 @@ sh_test(
     data = ["MixJavaScalaLibTestOutputs"],
 )
 
+scala_binary(
+    name = "MixJavaScalaBinary",
+    srcs = ["src/main/scala/scalarules/test/MixJavaScalaLibBinary.scala"] +
+    glob(["src/main/scala/scalarules/test/mix_java_scala/*.scala"]) +
+    glob(["src/main/scala/scalarules/test/mix_java_scala/*.java"]),
+    main_class = "scalarules.test.JavaBinary",
+)
+
+scala_test(
+    name = "MixJavaScalaScalaTest",
+    size = "small",
+    srcs = ["HelloLibTest.scala"] + glob(["src/main/scala/scalarules/test/mix_java_scala/*.scala"]) +
+    glob(["src/main/scala/scalarules/test/mix_java_scala/*.java"]),
+    deps = [
+        ":HelloLib",
+    ],
+)
+
+scala_junit_test(
+    name = "MixJavaScalaJunitTest",
+    size = "small",
+    srcs = ["src/main/scala/scalarules/test/junit/JunitTests.scala", "OtherJavaLib.java"],
+    suffixes = ["Test"],
+    runtime_deps = [":JUnitRuntimeDep"],
+    deps = [":JUnitCompileTimeDep"],
+)
+
 #needed to test java sources are compiled
 scala_binary(
     name = "MixJavaScalaLibBinary",

--- a/test/BUILD
+++ b/test/BUILD
@@ -305,16 +305,21 @@ sh_test(
 
 scala_binary(
     name = "MixJavaScalaBinary",
-    srcs = ["src/main/scala/scalarules/test/MixJavaScalaLibBinary.scala"] +
-    glob(["src/main/scala/scalarules/test/mix_java_scala/*.scala"]) +
-    glob(["src/main/scala/scalarules/test/mix_java_scala/*.java"]),
+    srcs = ["src/main/scala/scalarules/test/MixJavaScalaLibBinary.scala"] + glob([
+        "src/main/scala/scalarules/test/mix_java_scala/*.scala",
+    ]) + glob([
+        "src/main/scala/scalarules/test/mix_java_scala/*.java",
+    ]),
     main_class = "scalarules.test.JavaBinary",
 )
 
 scala_test(
     name = "MixJavaScalaScalaTest",
     size = "small",
-    srcs = ["HelloLibTest.scala", "OtherJavaLib.java"],
+    srcs = [
+        "HelloLibTest.scala",
+        "OtherJavaLib.java",
+    ],
     deps = [
         ":HelloLib",
     ],
@@ -323,7 +328,10 @@ scala_test(
 scala_junit_test(
     name = "MixJavaScalaJunitTest",
     size = "small",
-    srcs = ["src/main/scala/scalarules/test/junit/HelloWorldJunitTest.scala", "OtherJavaLib.java"],
+    srcs = [
+        "OtherJavaLib.java",
+        "src/main/scala/scalarules/test/junit/HelloWorldJunitTest.scala",
+    ],
     suffixes = ["Test"],
 )
 

--- a/test/BUILD
+++ b/test/BUILD
@@ -314,8 +314,7 @@ scala_binary(
 scala_test(
     name = "MixJavaScalaScalaTest",
     size = "small",
-    srcs = ["HelloLibTest.scala"] + glob(["src/main/scala/scalarules/test/mix_java_scala/*.scala"]) +
-    glob(["src/main/scala/scalarules/test/mix_java_scala/*.java"]),
+    srcs = ["HelloLibTest.scala", "OtherJavaLib.java"],
     deps = [
         ":HelloLib",
     ],
@@ -324,10 +323,8 @@ scala_test(
 scala_junit_test(
     name = "MixJavaScalaJunitTest",
     size = "small",
-    srcs = ["src/main/scala/scalarules/test/junit/JunitTests.scala", "OtherJavaLib.java"],
+    srcs = ["src/main/scala/scalarules/test/junit/HelloWorldJunitTest.scala", "OtherJavaLib.java"],
     suffixes = ["Test"],
-    runtime_deps = [":JUnitRuntimeDep"],
-    deps = [":JUnitCompileTimeDep"],
 )
 
 #needed to test java sources are compiled

--- a/test/shell/test_build_event_protocol.sh
+++ b/test/shell/test_build_event_protocol.sh
@@ -5,11 +5,12 @@ runner=$(get_test_runner "${1:-local}")
 
 scala_binary_common_jar_is_exposed_in_build_event_protocol() {
   local target=$1
+  local target_suffix=${2:-""}
   set +e
   bazel build test:$target --build_event_text_file=$target_bes.txt
-  cat $target_bes.txt | grep "test/$target.jar"
+  cat $target_bes.txt | grep "test/$target$target_suffix.jar"
   if [ $? -ne 0 ]; then
-    echo "test/$target.jar was not found in build event protocol:"
+    echo "test/$target$target_suffix.jar was not found in build event protocol:"
     cat $target_bes.txt
     rm $target_bes.txt
     exit 1
@@ -31,6 +32,26 @@ scala_junit_test_jar_is_exposed_in_build_event_protocol() {
   scala_binary_common_jar_is_exposed_in_build_event_protocol JunitTestWithDeps
 }
 
+scala_binary_java_jar_is_exposed_in_build_event_protocol() {
+  scala_binary_common_jar_is_exposed_in_build_event_protocol MixJavaScalaBinary _java
+}
+
+scala_library_java_jar_is_exposed_in_build_event_protocol() {
+  scala_binary_common_jar_is_exposed_in_build_event_protocol MixJavaScalaLib _java
+}
+
+scala_test_java_jar_is_exposed_in_build_event_protocol() {
+  scala_binary_common_jar_is_exposed_in_build_event_protocol MixJavaScalaScalaTest _java
+}
+
+junit_test_java_jar_is_exposed_in_build_event_protocol() {
+  scala_binary_common_jar_is_exposed_in_build_event_protocol MixJavaScalaJunitTest _java
+}
+
 $runner scala_binary_jar_is_exposed_in_build_event_protocol
 $runner scala_test_jar_is_exposed_in_build_event_protocol
 $runner scala_junit_test_jar_is_exposed_in_build_event_protocol
+$runner scala_binary_java_jar_is_exposed_in_build_event_protocol
+$runner scala_library_java_jar_is_exposed_in_build_event_protocol
+$runner scala_test_java_jar_is_exposed_in_build_event_protocol
+$runner junit_test_java_jar_is_exposed_in_build_event_protocol

--- a/test/src/main/scala/scalarules/test/junit/HelloWorldJunitTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/HelloWorldJunitTest.scala
@@ -1,0 +1,12 @@
+package scalarules.test.junit
+
+import org.junit.Test
+
+class HelloWorldJunitTest {
+
+  @Test
+  def helloWorld: Unit = {
+    println("hello world")
+  }
+
+}


### PR DESCRIPTION
added a passing e2e for java jar of scala library for symmetry

### Description
exposing java jar to BEP from all binary rules

added a passing e2e for java jar of scala library for symmetry

### Motivation
When working on my bazelcon talk I realized we only expose the scala jar from binary targets. Anyone using java and scala and leveraging the BEP file will feel this. We (at Wix) mainly separate compilation from test targets so we don't feel it a lot but I expect that as people become more liberal with using scala_binary it might pop up more.