### PR TITLE
Custom phases expose custom providers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -49,19 +49,11 @@ jobs:
       env: TEST_SCRIPT=test_lint
 # Test
     - <<: *linux
-      env: TEST_SCRIPT=test_rules_scala BAZEL_VERSION=1.1.0
-    - <<: *linux
       env: TEST_SCRIPT=test_rules_scala BAZEL_VERSION=2.0.0
-    - <<: *linux
-      env: TEST_SCRIPT=test_reproducibility BAZEL_VERSION=1.1.0
     - <<: *linux
       env: TEST_SCRIPT=test_reproducibility BAZEL_VERSION=2.0.0
     - <<: *osx
-      env: TEST_SCRIPT=test_rules_scala BAZEL_VERSION=1.1.0
-    - <<: *osx
       env: TEST_SCRIPT=test_rules_scala BAZEL_VERSION=2.0.0
-    - <<: *osx
-      env: TEST_SCRIPT=test_reproducibility BAZEL_VERSION=1.1.0
     - <<: *osx
       env: TEST_SCRIPT=test_reproducibility BAZEL_VERSION=2.0.0
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ for an example workspace using another scala version.
 | bazel  | rules_scala gitsha |
 |--------|--------------------|
 | 2.0.0  | HEAD               |
-| 1.1.0  | HEAD               |
+| 1.1.0  | d681a952da74fc61a49fc3167b03548f42fc5dde |
 | 0.28.1 | bd0c388125e12f4f173648fc4474f73160a5c628 |
 | 0.23.x | ca655e5a330cbf1d66ce1d9baa63522752ec6011 |
 | 0.22.x | f3113fb6e9e35cb8f441d2305542026d98afc0a2 |

--- a/scala/private/phases/api.bzl
+++ b/scala/private/phases/api.bzl
@@ -31,10 +31,13 @@ def _adjust_phases(phases, adjustments):
                 if needle == peer_name:
                     if relation in ["-", "before"]:
                         phases.insert(idx, (phase_name, phase_function))
+                        break
                     elif relation in ["+", "after"]:
                         phases.insert(idx + 1, (phase_name, phase_function))
+                        break
                     elif relation in ["=", "replace"]:
                         phases[idx] = (phase_name, phase_function)
+                        break
     return phases
 
 # Execute phases

--- a/scala/private/phases/api.bzl
+++ b/scala/private/phases/api.bzl
@@ -63,7 +63,7 @@ def run_phases(ctx, builtin_customizable_phases, fixed_phase):
     # A placeholder for data shared with later phases
     global_provider = {}
     current_provider = struct(**global_provider)
-    rule_providers = []
+    acculmulated_external_providers = []
     for (name, function) in adjusted_phases + [fixed_phase]:
         # Run a phase
         new_provider = function(ctx, current_provider)
@@ -71,13 +71,13 @@ def run_phases(ctx, builtin_customizable_phases, fixed_phase):
         # If a phase returns data, append it to global_provider
         # for later phases to access
         if new_provider != None:
-            if (hasattr(new_provider, "rule_providers")):
-                rule_providers.extend(new_provider.rule_providers)
+            if (hasattr(new_provider, "external_providers")):
+                acculmulated_external_providers.extend(new_provider.external_providers)
             global_provider[name] = new_provider
             current_provider = struct(**global_provider)
 
     # The final return of rules implementation
-    return rule_providers + current_provider.final
+    return acculmulated_external_providers + current_provider.final
 
 # A method to pass in phase provider
 def extras_phases(extras):

--- a/scala/private/phases/api.bzl
+++ b/scala/private/phases/api.bzl
@@ -22,18 +22,19 @@ def _adjust_phases(phases, adjustments):
     # phase_name: the name of the new phase, also used to access phase information
     # phase_function: the function of the new phase
     for (relation, peer_name, phase_name, phase_function) in adjustments:
-        for idx, (needle, _) in enumerate(phases):
-            if relation in ["^", "first"]:
-                phases.insert(0, (phase_name, phase_function))
-            elif relation in ["$", "last"]:
-                phases.append((phase_name, phase_function))
-            elif needle == peer_name:
-                if relation in ["-", "before"]:
-                    phases.insert(idx, (phase_name, phase_function))
-                elif relation in ["+", "after"]:
-                    phases.insert(idx + 1, (phase_name, phase_function))
-                elif relation in ["=", "replace"]:
-                    phases[idx] = (phase_name, phase_function)
+        if relation in ["^", "first"]:
+            phases.insert(0, (phase_name, phase_function))
+        elif relation in ["$", "last"]:
+            phases.append((phase_name, phase_function))
+        else:
+            for idx, (needle, _) in enumerate(phases):
+                if needle == peer_name:
+                    if relation in ["-", "before"]:
+                        phases.insert(idx, (phase_name, phase_function))
+                    elif relation in ["+", "after"]:
+                        phases.insert(idx + 1, (phase_name, phase_function))
+                    elif relation in ["=", "replace"]:
+                        phases[idx] = (phase_name, phase_function)
     return phases
 
 # Execute phases
@@ -59,6 +60,7 @@ def run_phases(ctx, builtin_customizable_phases, fixed_phase):
     # A placeholder for data shared with later phases
     global_provider = {}
     current_provider = struct(**global_provider)
+    rule_providers = []
     for (name, function) in adjusted_phases + [fixed_phase]:
         # Run a phase
         new_provider = function(ctx, current_provider)
@@ -66,11 +68,13 @@ def run_phases(ctx, builtin_customizable_phases, fixed_phase):
         # If a phase returns data, append it to global_provider
         # for later phases to access
         if new_provider != None:
+            if (hasattr(new_provider, "rule_providers")):
+                rule_providers.extend(new_provider.rule_providers)
             global_provider[name] = new_provider
             current_provider = struct(**global_provider)
 
     # The final return of rules implementation
-    return current_provider
+    return rule_providers + current_provider.final
 
 # A method to pass in phase provider
 def extras_phases(extras):

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -45,7 +45,7 @@ def _scala_binary_impl(ctx):
         ],
         # fixed phase
         ("final", phase_binary_final),
-    ).final
+    )
 
 _scala_binary_attrs = {
     "main_class": attr.string(mandatory = True),

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -50,7 +50,7 @@ def _scala_junit_test_impl(ctx):
         ],
         # fixed phase
         ("final", phase_binary_final),
-    ).final
+    )
 
 _scala_junit_test_attrs = {
     "prefixes": attr.string_list(default = []),

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -69,7 +69,7 @@ def _scala_library_impl(ctx):
         ],
         # fixed phase
         ("final", phase_library_final),
-    ).final
+    )
 
 _scala_library_attrs = {}
 
@@ -146,7 +146,7 @@ def _scala_library_for_plugin_bootstrapping_impl(ctx):
         ],
         # fixed phase
         ("final", phase_library_final),
-    ).final
+    )
 
 # the scala compiler plugin used for dependency analysis is compiled using `scala_library`.
 # in order to avoid cyclic dependencies `scala_library_for_plugin_bootstrapping` was created for this purpose,
@@ -202,7 +202,7 @@ def _scala_macro_library_impl(ctx):
         ],
         # fixed phase
         ("final", phase_library_final),
-    ).final
+    )
 
 _scala_macro_library_attrs = {
     "main_class": attr.string(),

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -46,7 +46,7 @@ def _scala_repl_impl(ctx):
         ],
         # fixed phase
         ("final", phase_binary_final),
-    ).final
+    )
 
 _scala_repl_attrs = {
     "jvm_flags": attr.string_list(),

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -47,7 +47,7 @@ def _scala_test_impl(ctx):
         ],
         # fixed phase
         ("final", phase_scalatest_final),
-    ).final
+    )
 
 _scala_test_attrs = {
     "main_class": attr.string(

--- a/test/phase/providers/BUILD.bazel
+++ b/test/phase/providers/BUILD.bazel
@@ -1,0 +1,15 @@
+load(":phase_providers_expose.bzl", "phase_expose_provider_singleton", "rule_that_needs_custom_provider", "scala_library_that_exposes_custom_provider")
+
+scala_library_that_exposes_custom_provider(
+    name = "scala_library_that_exposes_custom_provider",
+)
+
+rule_that_needs_custom_provider(
+    name = "rule_that_needs_custom_provider",
+    dep = ":scala_library_that_exposes_custom_provider",
+)
+
+phase_expose_provider_singleton(
+    name = "phase_expose_provider_singleton_target",
+    visibility = ["//visibility:public"],
+)

--- a/test/phase/providers/phase_providers_expose.bzl
+++ b/test/phase/providers/phase_providers_expose.bzl
@@ -28,7 +28,7 @@ CustomProviderExposedByPhase = provider()
 
 def _phase_expose_provider(ctx, p):
     return struct(
-        rule_providers = [CustomProviderExposedByPhase()],
+        external_providers = [CustomProviderExposedByPhase()],
     )
 
 def _rule_that_needs_custom_provider_impl(ctx):

--- a/test/phase/providers/phase_providers_expose.bzl
+++ b/test/phase/providers/phase_providers_expose.bzl
@@ -1,0 +1,42 @@
+load("@io_bazel_rules_scala//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("@io_bazel_rules_scala//scala:advanced_usage/scala.bzl", "make_scala_library")
+
+ext_phase_expose_provider = {
+    "phase_providers": [
+        "//test/phase/providers:phase_expose_provider_singleton_target",
+    ],
+}
+
+scala_library_that_exposes_custom_provider = make_scala_library(ext_phase_expose_provider)
+
+_some_position = "last"  #last position is just because a location is mandatory, not important
+
+def _phase_expose_provider_singleton_implementation(ctx):
+    return [
+        ScalaRulePhase(
+            custom_phases = [
+                (_some_position, "", "phase_expose_provider", _phase_expose_provider),
+            ],
+        ),
+    ]
+
+phase_expose_provider_singleton = rule(
+    implementation = _phase_expose_provider_singleton_implementation,
+)
+
+CustomProviderExposedByPhase = provider()
+
+def _phase_expose_provider(ctx, p):
+    return struct(
+        rule_providers = [CustomProviderExposedByPhase()],
+    )
+
+def _rule_that_needs_custom_provider_impl(ctx):
+    return []
+
+rule_that_needs_custom_provider = rule(
+    implementation = _rule_that_needs_custom_provider_impl,
+    attrs = {
+        "dep": attr.label(providers = [CustomProviderExposedByPhase]),
+    },
+)

--- a/tools/bazel
+++ b/tools/bazel
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -e
 
-default_bazel_version='1.1.0'
+default_bazel_version='2.0.0'
 
 if [ "$BUILDKITE" = true ]; then
     bazel_version='host'
@@ -30,6 +30,10 @@ case "$bazel_version" in
     '1.1.0')
         darwin_sha='1a552f4ce194860fbbd50eeb319f81788ddf50a849e92378eec72231cc64ef65'
         linux_sha='14301099c87568db302d59a5d3585f5eb8a6250ac2c6bb0367c56e623ff6e65f'
+        ;;
+    '1.2.1')
+        darwin_sha='59e469bf1d8d1615b67856ea17e761be05e9c92b462e55c0354cd78145b480d5'
+        linux_sha='ae6249e25b0f5a06d79fad90325477dd56275657951cf7aa6a3cbcd79fc4d749'
         ;;
     '2.0.0')
         darwin_sha='c675fa27d99a3114d681db10eb03ded547c40f702b2048c99b8f4ea8e89b9356'

--- a/tools/bazel
+++ b/tools/bazel
@@ -27,10 +27,6 @@ case "$bazel_version" in
         bazel_version=$("$BAZEL_REAL" version | awk '/Build label/ {print $3}' | cut -d '-' -f 1)
         bazel="$BAZEL_REAL"
         ;;
-    '1.1.0')
-        darwin_sha='1a552f4ce194860fbbd50eeb319f81788ddf50a849e92378eec72231cc64ef65'
-        linux_sha='14301099c87568db302d59a5d3585f5eb8a6250ac2c6bb0367c56e623ff6e65f'
-        ;;
     '2.0.0')
         darwin_sha='c675fa27d99a3114d681db10eb03ded547c40f702b2048c99b8f4ea8e89b9356'
         linux_sha='2fbdc9c0e3d376697caf0ee3673b7c9475214068c55a01b9744891e131f90b87'

--- a/tools/bazel
+++ b/tools/bazel
@@ -31,10 +31,6 @@ case "$bazel_version" in
         darwin_sha='1a552f4ce194860fbbd50eeb319f81788ddf50a849e92378eec72231cc64ef65'
         linux_sha='14301099c87568db302d59a5d3585f5eb8a6250ac2c6bb0367c56e623ff6e65f'
         ;;
-    '1.2.1')
-        darwin_sha='59e469bf1d8d1615b67856ea17e761be05e9c92b462e55c0354cd78145b480d5'
-        linux_sha='ae6249e25b0f5a06d79fad90325477dd56275657951cf7aa6a3cbcd79fc4d749'
-        ;;
     '2.0.0')
         darwin_sha='c675fa27d99a3114d681db10eb03ded547c40f702b2048c99b8f4ea8e89b9356'
         linux_sha='2fbdc9c0e3d376697caf0ee3673b7c9475214068c55a01b9744891e131f90b87'


### PR DESCRIPTION
### Description
Custom phases expose custom providers  

While doing it I found and fixed a bug in phases adjustments of first/last (they were duplicated).
I tried to send a fix for this separately but since actions are de-duped and the info passed between phases via structs is also de-duped I couldn't get a failing test. I could do it with `print` statements but I think that's too hacky.
I stumbled on to the issue in this change because Bazel forbids multiple providers of the same type. 
Btw, main implication (apart from providers) of this specific bug is a perf hit for analysis case (when adjusting phases).
Additionally this mandates bazel 2.0.0 as they have some kind of bug with providers before that (don't have an issue to ref but couldn't get the build to pass with lower bazel version)

### Motivation
Allow custom phases to expose custom providers. At the end of the day providers are a basic and powerful tool for sharing info between different rules (for example if someone writes a publishing rule internally and need metadata from our rules which only they care about).



Note:
1. This lays the ground to the removal of `phase_final`. I didn't do it here because I wanted to keep it small and will follow-up in a separate PR.
2. The mutable array of providers is so-so and what I really want is to allow for phases to also override providers of previous phases. I'll do it in a follow-up PR (again to keep it small) and then I'll change the array to be a dict.

cc @borkaehw @andyscott 