### PR TITLE
Phases can override providers from previous phases

### DIFF
--- a/docs/customizable_phase.md
+++ b/docs/customizable_phase.md
@@ -128,9 +128,12 @@ Currently phase architecture is used by 7 rules:
  - scala_junit_test
  - scala_repl
 
-If you need to expose providers to downstream targets you need to return an array of providers from your phase under the `external_providers` attribute.
+If you need to expose providers to downstream targets you need to return a dict of providers (provider-name to provider instance) from your phase under the `external_providers` attribute.
 
-In each of the rule implementations, it calls `run_phases` and returns an accumulated `external_providers` array declared by the phases.
+If you need to override a provider returned by a previous phase you can adjust your phase to be after it and return the same key from your phase and it will override it.
+Note you probably have a good reason to override since you're meddling with the public return value of a different phase.
+
+In each of the rule implementations, it calls `run_phases` and returns the accumulated values of the `external_providers` dict declared by the phases.
 
 To make a new phase, you have to define a new `phase_<PHASE_NAME>.bzl` in `scala/private/phases/`. Function definition should have 2 arguments, `ctx` and `p`. You may expose the information for later phases by returning a `struct`. In some phases, there are multiple phase functions since different rules may take slightly different input arguemnts. You may want to re-expose the phase definition in `scala/private/phases/phases.bzl`, so it's more convenient to access in rule files.
 

--- a/scala/private/phases/phase_collect_jars.bzl
+++ b/scala/private/phases/phase_collect_jars.bzl
@@ -108,7 +108,7 @@ def _phase_collect_jars(
         transitive_compile_jars = transitive_compile_jars,
         transitive_runtime_jars = transitive_rjars,
         deps_providers = deps_providers,
-        external_providers = [jars2labels],
+        external_providers = {"JarsToLabelsInfo": jars2labels},
     )
 
 def _collect_runtime_jars(dep_targets):

--- a/scala/private/phases/phase_default_info.bzl
+++ b/scala/private/phases/phase_default_info.bzl
@@ -5,32 +5,32 @@
 #
 def phase_binary_default_info(ctx, p):
     return struct(
-        external_providers = [
-            DefaultInfo(
+        external_providers = {
+            "DefaultInfo": DefaultInfo(
                 executable = p.declare_executable,
                 files = depset([p.declare_executable] + p.compile.full_jars),
                 runfiles = p.runfiles.runfiles,
             ),
-        ],
+        },
     )
 
 def phase_library_default_info(ctx, p):
     return struct(
-        external_providers = [
-            DefaultInfo(
+        external_providers = {
+            "DefaultInfo": DefaultInfo(
                 files = depset(p.compile.full_jars),
                 runfiles = p.runfiles.runfiles,
             ),
-        ],
+        },
     )
 
 def phase_scalatest_default_info(ctx, p):
     return struct(
-        external_providers = [
-            DefaultInfo(
+        external_providers = {
+            "DefaultInfo": DefaultInfo(
                 executable = p.declare_executable,
                 files = depset([p.declare_executable] + p.compile.full_jars),
                 runfiles = ctx.runfiles(p.coverage_runfiles.coverage_runfiles, transitive_files = p.runfiles.runfiles.files),
             ),
-        ],
+        },
     )

--- a/test/phase/providers/BUILD.bazel
+++ b/test/phase/providers/BUILD.bazel
@@ -21,7 +21,7 @@ rule_that_has_phases_which_override_providers(
 
 rule_that_verifies_providers_are_overriden(
     name = "PhaseOverridesProviderTest",
-    dep = ":PhaseOverridesProvider"
+    dep = ":PhaseOverridesProvider",
 )
 
 phase_override_provider_singleton(

--- a/test/phase/providers/BUILD.bazel
+++ b/test/phase/providers/BUILD.bazel
@@ -1,4 +1,5 @@
 load(":phase_providers_expose.bzl", "phase_expose_provider_singleton", "rule_that_needs_custom_provider", "scala_library_that_exposes_custom_provider")
+load(":phase_providers_override.bzl", "phase_override_provider_singleton", "rule_that_has_phases_which_override_providers", "rule_that_verifies_providers_are_overriden")
 
 scala_library_that_exposes_custom_provider(
     name = "scala_library_that_exposes_custom_provider",
@@ -11,5 +12,19 @@ rule_that_needs_custom_provider(
 
 phase_expose_provider_singleton(
     name = "phase_expose_provider_singleton_target",
+    visibility = ["//visibility:public"],
+)
+
+rule_that_has_phases_which_override_providers(
+    name = "PhaseOverridesProvider",
+)
+
+rule_that_verifies_providers_are_overriden(
+    name = "PhaseOverridesProviderTest",
+    dep = ":PhaseOverridesProvider"
+)
+
+phase_override_provider_singleton(
+    name = "phase_override_provider_singleton_target",
     visibility = ["//visibility:public"],
 )

--- a/test/phase/providers/phase_providers_expose.bzl
+++ b/test/phase/providers/phase_providers_expose.bzl
@@ -28,7 +28,7 @@ CustomProviderExposedByPhase = provider()
 
 def _phase_expose_provider(ctx, p):
     return struct(
-        external_providers = [CustomProviderExposedByPhase()],
+        external_providers = {"CustomProviderExposedByPhase": CustomProviderExposedByPhase()},
     )
 
 def _rule_that_needs_custom_provider_impl(ctx):

--- a/test/phase/providers/phase_providers_override.bzl
+++ b/test/phase/providers/phase_providers_override.bzl
@@ -1,0 +1,61 @@
+load("@io_bazel_rules_scala//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("@io_bazel_rules_scala//scala:advanced_usage/scala.bzl", "make_scala_library")
+
+ext_phase_override_provider = {
+    "phase_providers": [
+        "//test/phase/providers:phase_override_provider_singleton_target",
+    ],
+}
+
+rule_that_has_phases_which_override_providers = make_scala_library(ext_phase_override_provider)
+
+def _phase_override_provider_singleton_implementation(ctx):
+    return [
+        ScalaRulePhase(
+            custom_phases = [
+                ("last", "", "first_custom", _phase_original),
+                ("after", "first_custom", "second_custom", _phase_override),
+            ],
+        ),
+    ]
+
+phase_override_provider_singleton = rule(
+    implementation = _phase_override_provider_singleton_implementation,
+)
+
+OverrideProvider = provider(fields = ["content"])
+
+def _phase_original(ctx, p):
+    return struct(
+        external_providers = [
+            OverrideProvider(
+                content = "original"
+            ),
+        ],
+    )
+
+def _phase_override(ctx, p):
+    return struct(
+        external_providers = [
+            OverrideProvider(
+                content = "override"
+            ),
+        ],
+    )
+
+def _rule_that_verifies_providers_are_overriden_impl(ctx):
+    if (ctx.attr.dep[OverrideProvider].content != "override"):
+        fail(
+            "expected OverrideProvider of {label} to have content 'override' but got '{content}'".format(
+                    label = ctx.label,
+                    content = ctx.attr.dep[OverrideProvider].content
+            )
+        )
+    return []
+
+rule_that_verifies_providers_are_overriden = rule(
+    implementation = _rule_that_verifies_providers_are_overriden_impl,
+    attrs = {
+        "dep": attr.label(providers = [OverrideProvider]),
+    },
+)

--- a/test/phase/providers/phase_providers_override.bzl
+++ b/test/phase/providers/phase_providers_override.bzl
@@ -27,29 +27,29 @@ OverrideProvider = provider(fields = ["content"])
 
 def _phase_original(ctx, p):
     return struct(
-        external_providers = [
-            OverrideProvider(
-                content = "original"
+        external_providers = {
+            "OverrideProvider": OverrideProvider(
+                content = "original",
             ),
-        ],
+        },
     )
 
 def _phase_override(ctx, p):
     return struct(
-        external_providers = [
-            OverrideProvider(
-                content = "override"
+        external_providers = {
+            "OverrideProvider": OverrideProvider(
+                content = "override",
             ),
-        ],
+        },
     )
 
 def _rule_that_verifies_providers_are_overriden_impl(ctx):
     if (ctx.attr.dep[OverrideProvider].content != "override"):
         fail(
             "expected OverrideProvider of {label} to have content 'override' but got '{content}'".format(
-                    label = ctx.label,
-                    content = ctx.attr.dep[OverrideProvider].content
-            )
+                label = ctx.label,
+                content = ctx.attr.dep[OverrideProvider].content,
+            ),
         )
     return []
 


### PR DESCRIPTION
### Description
Phases can override providers from previous phases

external_phases now return a dict and not an array.

### Motivation
Full customizability of phases require them to be able to override providers from previous phases to control what ever is being exposed