### PR TITLE
Bundle input protos together with generated/compiled classes

### DIFF
--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -3,7 +3,6 @@
 #
 # DOCUMENT THIS
 #
-load("@bazel_skylib//lib:paths.bzl", _paths = "paths")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_runtime_toolchain", "find_java_toolchain")
 load(

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -11,10 +11,10 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    _adjust_resources_path = "adjust_resources_path",
     _compile_scala = "compile_scala",
     _expand_location = "expand_location",
 )
+load(":resources.bzl", _resource_paths = "paths")
 
 _java_extension = ".java"
 
@@ -491,18 +491,9 @@ def _try_to_compile_java_jar(
     )
 
 def _add_resources_cmd(ctx):
-    res_cmd = []
-    for f in ctx.files.resources:
-        target_path = _adjust_resources_path(
-            f,
-            ctx.attr.resource_strip_prefix,
-        )
-        line = "{target_path}={res_path}\n".format(
-            target_path = target_path,
-            res_path = f.path,
-        )
-        res_cmd.extend([line])
-    return "".join(res_cmd)
+    paths = _resource_paths(ctx.files.resources, ctx.attr.resource_strip_prefix)
+    lines = ["{target}={source}\n".format(target = p[0], source = p[1]) for p in paths]
+    return "".join(lines)
 
 def _collect_java_providers_of(deps):
     providers = []

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -498,8 +498,6 @@ def _add_resources_cmd(ctx):
             f,
             ctx.attr.resource_strip_prefix,
         )
-        if target_path[0] == "/":
-            target_path = target_path[1:]
         line = "{target_path}={res_path}\n".format(
             target_path = target_path,
             res_path = f.path,

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -12,7 +12,7 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    _adjust_resources_path_by_default_prefixes = "adjust_resources_path_by_default_prefixes",
+    _adjust_resources_path = "adjust_resources_path",
     _compile_scala = "compile_scala",
     _expand_location = "expand_location",
 )
@@ -491,12 +491,6 @@ def _try_to_compile_java_jar(
         java_compilation_provider = provider,
     )
 
-def _adjust_resources_path(resource, resource_strip_prefix):
-    if resource_strip_prefix:
-        return _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix)
-    else:
-        return _adjust_resources_path_by_default_prefixes(resource.path)
-
 def _add_resources_cmd(ctx):
     res_cmd = []
     for f in ctx.files.resources:
@@ -507,22 +501,12 @@ def _add_resources_cmd(ctx):
         target_path = res_path
         if target_path[0] == "/":
             target_path = target_path[1:]
-        line = "{target_path}={c_dir}{res_path}\n".format(
-            res_path = res_path,
+        line = "{target_path}={res_path}\n".format(
             target_path = target_path,
-            c_dir = c_dir,
+            res_path = f.path,
         )
         res_cmd.extend([line])
     return "".join(res_cmd)
-
-def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
-    path = resource.path
-    prefix = _paths.join(resource.owner.workspace_root, resource_strip_prefix)
-    if not path.startswith(prefix):
-        fail("Resource file %s is not under the specified prefix %s to strip" % (path, prefix))
-
-    clean_path = path[len(prefix):]
-    return prefix, clean_path
 
 def _collect_java_providers_of(deps):
     providers = []

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -494,11 +494,10 @@ def _try_to_compile_java_jar(
 def _add_resources_cmd(ctx):
     res_cmd = []
     for f in ctx.files.resources:
-        c_dir, res_path = _adjust_resources_path(
+        target_path = _adjust_resources_path(
             f,
             ctx.attr.resource_strip_prefix,
         )
-        target_path = res_path
         if target_path[0] == "/":
             target_path = target_path[1:]
         line = "{target_path}={res_path}\n".format(

--- a/scala/private/resources.bzl
+++ b/scala/private/resources.bzl
@@ -1,0 +1,49 @@
+load("@bazel_skylib//lib:paths.bzl", _paths = "paths")
+
+def paths(resources, resource_strip_prefix):
+    """Return a list of path tuples (target, source) where:
+        target - is a path in the archive (with given prefix stripped off)
+        source - is an absolute path of the resource file
+
+    Tuple ordering is aligned with zipper format ie zip_path=file
+
+    Args:
+        resources: list of file objects
+        resource_strip_prefix: string to strip from resource path
+    """
+    return [(_target_path(resource, resource_strip_prefix), resource.path) for resource in resources]
+
+def _target_path(resource, resource_strip_prefix):
+    path = _target_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else _target_path_by_default_prefixes(resource.path)
+    return _strip_prefix(path, "/")
+
+def _target_path_by_strip_prefix(resource, resource_strip_prefix):
+    # Start from absolute resource path and then strip roots so we get to correct short path
+    # resource.short_path sometimes give weird results ie '../' prefix
+    path = resource.path
+    path = _strip_prefix(path, resource.owner.workspace_root + "/")
+    path = _strip_prefix(path, resource.root.path + "/")
+
+    # proto_library translates strip_import_prefix to proto_source_root which includes root so we have to strip it
+    prefix = _strip_prefix(resource_strip_prefix, resource.root.path + "/")
+    if not path.startswith(prefix):
+        fail("Resource file %s is not under the specified prefix %s to strip" % (path, prefix))
+    return path[len(prefix):]
+
+def _target_path_by_default_prefixes(path):
+    #  Here we are looking to find out the offset of this resource inside
+    #  any resources folder. We want to return the root to the resources folder
+    #  and then the sub path inside it
+    dir_1, dir_2, rel_path = path.partition("resources")
+    if rel_path:
+        return rel_path
+
+    #  The same as the above but just looking for java
+    (dir_1, dir_2, rel_path) = path.partition("java")
+    if rel_path:
+        return rel_path
+
+    return path
+
+def _strip_prefix(path, prefix):
+    return path[len(prefix):] if path.startswith(prefix) else path

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -197,7 +197,6 @@ ResourceDests: {resource_dest}
 ResourceJars: {resource_jars}
 ResourceSrcs: {resource_src}
 ResourceShortPaths: {resource_short_paths}
-ResourceStripPrefix: {resource_strip_prefix}
 ScalacOpts: {scala_opts}
 SourceJars: {srcjars}
 DependencyAnalyzerMode: {dependency_analyzer_mode}
@@ -221,7 +220,6 @@ StatsfileOutput: {statsfile_output}
             adjust_resources_path(f, resource_strip_prefix)
             for f in resources
         ]),
-        resource_strip_prefix = resource_strip_prefix,
         resource_jars = _join_path(resource_jars),
         dependency_analyzer_mode = dependency_analyzer_mode,
         unused_dependency_checker_mode = unused_dependency_checker_mode,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -53,7 +53,7 @@ def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
     clean_path = path[len(prefix):]
     print("clean-path: " + clean_path)
     print("clean-prefix: " + prefix)
-    return prefix, clean_path
+    return clean_path
 
 def adjust_resources_path_by_default_prefixes(path):
     #  Here we are looking to find out the offset of this resource inside
@@ -61,14 +61,14 @@ def adjust_resources_path_by_default_prefixes(path):
     #  and then the sub path inside it
     dir_1, dir_2, rel_path = path.partition("resources")
     if rel_path:
-        return dir_1 + dir_2, rel_path
+        return rel_path
 
     #  The same as the above but just looking for java
     (dir_1, dir_2, rel_path) = path.partition("java")
     if rel_path:
-        return dir_1 + dir_2, rel_path
+        return rel_path
 
-    return "", path
+    return path
 
 def expand_location(ctx, flags):
     if hasattr(ctx.attr, "data"):
@@ -218,7 +218,7 @@ StatsfileOutput: {statsfile_output}
         resource_src = ",".join([f.path for f in resources]),
         resource_short_paths = ",".join([f.short_path for f in resources]),
         resource_dest = ",".join([
-            adjust_resources_path(f, resource_strip_prefix)[1]
+            adjust_resources_path(f, resource_strip_prefix)
             for f in resources
         ]),
         resource_strip_prefix = resource_strip_prefix,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -29,16 +29,30 @@ def adjust_resources_path(resource, resource_strip_prefix):
     else:
         return adjust_resources_path_by_default_prefixes(resource.path)
 
+def _strip_prefix(target, prefix):
+    return target[len(prefix):] if target.startswith(prefix) else target
+
 def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
     # TODO: should be a better way how to strip prefix
 #    root = (resource.owner.workspace_root if (resource.owner) else resource.root.path) + "/"
+    print("-------------------")
+    print("workspace-root: " + resource.owner.workspace_root)
+    print("root-path: " + resource.root.path)
+    print("res-path: " + resource.path)
+    print("res-short-path: " + resource.short_path)
+    print("given-prefix: " + resource_strip_prefix)
     root = resource.root.path + "/"
-    path = resource.path[len(root):] if resource.path.startswith(root) else resource.path
-    prefix = resource_strip_prefix[len(root):] if resource_strip_prefix.startswith(root) else resource_strip_prefix
+    path = resource.path
+    path = _strip_prefix(path, resource.owner.workspace_root + "/")
+    print("resolved-path: " + path)
+    path = _strip_prefix(path, root)
+    prefix = _strip_prefix(resource_strip_prefix, resource.root.path + "/")
     if not path.startswith(prefix):
         fail("Resource file %s is not under the specified prefix %s to strip" % (path, prefix))
 
     clean_path = path[len(prefix):]
+    print("clean-path: " + clean_path)
+    print("clean-prefix: " + prefix)
     return prefix, clean_path
 
 def adjust_resources_path_by_default_prefixes(path):

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -31,9 +31,12 @@ def adjust_resources_path(resource, resource_strip_prefix):
     return _strip_prefix(path, "/")
 
 def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
+    # Start from absolute resource path and then strip roots so we get to correct short path
+    # resource.short_path sometimes give weird results ie '../' prefix
     path = resource.path
     path = _strip_prefix(path, resource.owner.workspace_root + "/")
     path = _strip_prefix(path, resource.root.path + "/")
+    # proto_library translates strip_import_prefix to proto_source_root which includes root so we have to strip it
     prefix = _strip_prefix(resource_strip_prefix, resource.root.path + "/")
     if not path.startswith(prefix):
         fail("Resource file %s is not under the specified prefix %s to strip" % (path, prefix))

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -24,7 +24,7 @@ load(
 )
 
 def adjust_resources_path(resource, resource_strip_prefix):
-    path = _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else adjust_resources_path_by_default_prefixes(resource.path)
+    path = _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else _adjust_resources_path_by_default_prefixes(resource.path)
     return _strip_prefix(path, "/")
 
 def _strip_prefix(target, prefix):
@@ -53,7 +53,7 @@ def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
     print("clean-prefix: " + prefix)
     return clean_path
 
-def adjust_resources_path_by_default_prefixes(path):
+def _adjust_resources_path_by_default_prefixes(path):
     #  Here we are looking to find out the offset of this resource inside
     #  any resources folder. We want to return the root to the resources folder
     #  and then the sub path inside it

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -36,6 +36,7 @@ def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
     path = resource.path
     path = _strip_prefix(path, resource.owner.workspace_root + "/")
     path = _strip_prefix(path, resource.root.path + "/")
+
     # proto_library translates strip_import_prefix to proto_source_root which includes root so we have to strip it
     prefix = _strip_prefix(resource_strip_prefix, resource.root.path + "/")
     if not path.startswith(prefix):

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -200,10 +200,7 @@ StatsfileOutput: {statsfile_output}
         # the resource paths need to be aligned in order
         resource_src = ",".join([f.path for f in resources]),
         resource_short_paths = ",".join([f.short_path for f in resources]),
-        resource_dest = ",".join([
-            adjust_resources_path(f, resource_strip_prefix)
-            for f in resources
-        ]),
+        resource_dest = ",".join([adjust_resources_path(f, resource_strip_prefix) for f in resources]),
         resource_jars = _join_path(resource_jars),
         dependency_analyzer_mode = dependency_analyzer_mode,
         unused_dependency_checker_mode = unused_dependency_checker_mode,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -23,35 +23,21 @@ load(
     _collect_plugin_paths = "collect_plugin_paths",
 )
 
+def _strip_prefix(target, prefix):
+    return target[len(prefix):] if target.startswith(prefix) else target
+
 def adjust_resources_path(resource, resource_strip_prefix):
     path = _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else _adjust_resources_path_by_default_prefixes(resource.path)
     return _strip_prefix(path, "/")
 
-def _strip_prefix(target, prefix):
-    return target[len(prefix):] if target.startswith(prefix) else target
-
 def _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix):
-    # TODO: should be a better way how to strip prefix
-#    root = (resource.owner.workspace_root if (resource.owner) else resource.root.path) + "/"
-    print("-------------------")
-    print("workspace-root: " + resource.owner.workspace_root)
-    print("root-path: " + resource.root.path)
-    print("res-path: " + resource.path)
-    print("res-short-path: " + resource.short_path)
-    print("given-prefix: " + resource_strip_prefix)
-    root = resource.root.path + "/"
     path = resource.path
     path = _strip_prefix(path, resource.owner.workspace_root + "/")
-    print("resolved-path: " + path)
-    path = _strip_prefix(path, root)
+    path = _strip_prefix(path, resource.root.path + "/")
     prefix = _strip_prefix(resource_strip_prefix, resource.root.path + "/")
     if not path.startswith(prefix):
         fail("Resource file %s is not under the specified prefix %s to strip" % (path, prefix))
-
-    clean_path = path[len(prefix):]
-    print("clean-path: " + clean_path)
-    print("clean-prefix: " + prefix)
-    return clean_path
+    return path[len(prefix):]
 
 def _adjust_resources_path_by_default_prefixes(path):
     #  Here we are looking to find out the offset of this resource inside

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -24,10 +24,8 @@ load(
 )
 
 def adjust_resources_path(resource, resource_strip_prefix):
-    if resource_strip_prefix:
-        return _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix)
-    else:
-        return adjust_resources_path_by_default_prefixes(resource.path)
+    path = _adjust_resources_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else adjust_resources_path_by_default_prefixes(resource.path)
+    return _strip_prefix(path, "/")
 
 def _strip_prefix(target, prefix):
     return target[len(prefix):] if target.startswith(prefix) else target

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -51,7 +51,10 @@ def _compile_scala(
         output,
         scalapb_jar,
         deps_java_info,
-        implicit_deps):
+        implicit_deps,
+        resources,
+        resource_strip_prefix
+        ):
     manifest = ctx.actions.declare_file(
         label.name + "_MANIFEST.MF",
         sibling = scalapb_jar,
@@ -78,8 +81,8 @@ def _compile_scala(
         all_srcjars = depset([scalapb_jar]),
         transitive_compile_jars = merged_deps.transitive_compile_time_jars,
         plugins = [],
-        resource_strip_prefix = "",
-        resources = [],
+        resource_strip_prefix = resource_strip_prefix,
+        resources = resources,
         resource_jars = [],
         labels = {},
         in_scalacopts = [],
@@ -193,6 +196,8 @@ def _scalapb_aspect_impl(target, ctx):
                 scalapb_file,
                 deps,
                 imps,
+                compile_protos,
+                "" if target_ti.proto_source_root == "." else target_ti.proto_source_root
             )
         else:
             # this target is only an aggregation target

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -53,8 +53,7 @@ def _compile_scala(
         deps_java_info,
         implicit_deps,
         resources,
-        resource_strip_prefix
-        ):
+        resource_strip_prefix):
     manifest = ctx.actions.declare_file(
         label.name + "_MANIFEST.MF",
         sibling = scalapb_jar,
@@ -197,7 +196,7 @@ def _scalapb_aspect_impl(target, ctx):
                 deps,
                 imps,
                 compile_protos,
-                "" if target_ti.proto_source_root == "." else target_ti.proto_source_root
+                "" if target_ti.proto_source_root == "." else target_ti.proto_source_root,
             )
         else:
             # this target is only an aggregation target

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -1,5 +1,6 @@
 package io.bazel.rulesscala.scalac;
 
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -15,7 +16,7 @@ public class CompileOptions {
   public final String[] files;
   public final String[] sourceJars;
   public final String[] javaFiles;
-  public final Map<String, Resource> resourceFiles;
+  public final List<Resource> resourceFiles;
   public final String[] resourceJars;
   public final String[] classpathResourceFiles;
   public final String[] directJars;
@@ -65,29 +66,21 @@ public class CompileOptions {
     statsfile = getOrError(argMap, "StatsfileOutput", "Missing required arg StatsfileOutput");
   }
 
-  private static Map<String, Resource> getResources(Map<String, String> args) {
-    String[] keys = getCommaList(args, "ResourceSrcs");
-    String[] dests = getCommaList(args, "ResourceDests");
-    String[] shortPaths = getCommaList(args, "ResourceShortPaths");
+  private static List<Resource> getResources(Map<String, String> args) {
+    String[] targets = getCommaList(args, "ResourceTargets");
+    String[] sources = getCommaList(args, "ResourceSources");
 
-    if (keys.length != dests.length)
+    if (targets.length != sources.length)
       throw new RuntimeException(
           String.format(
-              "mismatch in resources: keys: %s dests: %s",
-              getOrEmpty(args, "ResourceSrcs"), getOrEmpty(args, "ResourceDests")));
+              "mismatch in resources: targets: %s sources: %s",
+              getOrEmpty(args, "ResourceTargets"), getOrEmpty(args, "ResourceSources")));
 
-    if (keys.length != shortPaths.length)
-      throw new RuntimeException(
-          String.format(
-              "mismatch in resources: keys: %s shortPaths: %s",
-              getOrEmpty(args, "ResourceSrcs"), getOrEmpty(args, "ResourceShortPaths")));
-
-    HashMap<String, Resource> res = new HashMap();
-    for (int idx = 0; idx < keys.length; idx++) {
-      Resource resource = new Resource(dests[idx], shortPaths[idx]);
-      res.put(keys[idx], resource);
+    List<Resource> resources = new ArrayList<Resource>();
+    for (int idx = 0; idx < targets.length; idx++) {
+      resources.add(new Resource(targets[idx], sources[idx]));
     }
-    return res;
+    return resources;
   }
 
   private static HashMap<String, String> buildArgMap(List<String> lines) {

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -16,7 +16,6 @@ public class CompileOptions {
   public final String[] sourceJars;
   public final String[] javaFiles;
   public final Map<String, Resource> resourceFiles;
-  public final String resourceStripPrefix;
   public final String[] resourceJars;
   public final String[] classpathResourceFiles;
   public final String[] directJars;
@@ -50,7 +49,6 @@ public class CompileOptions {
 
     sourceJars = getCommaList(argMap, "SourceJars");
     resourceFiles = getResources(argMap);
-    resourceStripPrefix = getOrEmpty(argMap, "ResourceStripPrefix");
     resourceJars = getCommaList(argMap, "ResourceJars");
     classpathResourceFiles = getCommaList(argMap, "ClasspathResourceSrcs");
 

--- a/src/java/io/bazel/rulesscala/scalac/Resource.java
+++ b/src/java/io/bazel/rulesscala/scalac/Resource.java
@@ -1,11 +1,11 @@
 package io.bazel.rulesscala.scalac;
 
 public class Resource {
-  public final String destination;
-  public final String shortPath;
+  public final String target;
+  public final String source;
 
-  public Resource(String destination, String shortPath) {
-    this.destination = destination;
-    this.shortPath = shortPath;
+  public Resource(String target, String source) {
+    this.target = target;
+    this.source = source;
   }
 }

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -70,7 +70,7 @@ class ScalacProcessor implements Processor {
       }
 
       /** Copy the resources */
-      copyResources(ops.resourceFiles, ops.resourceStripPrefix, tmpPath);
+      copyResources(ops.resourceFiles, tmpPath);
 
       /** Extract and copy resources from resource jars */
       copyResourceJars(ops.resourceJars, tmpPath);
@@ -268,30 +268,10 @@ class ScalacProcessor implements Processor {
     }
   }
 
-  private static void copyResources(
-      Map<String, Resource> resources, String resourceStripPrefix, Path dest) throws IOException {
+  private static void copyResources(Map<String, Resource> resources, Path dest) throws IOException {
     for (Entry<String, Resource> e : resources.entrySet()) {
       Path source = Paths.get(e.getKey());
-      Resource resource = e.getValue();
-      Path shortPath = Paths.get(resource.shortPath);
-      String dstr = resource.destination;
-      // Check if we need to modify resource destination path
-//      if (!"".equals(resourceStripPrefix)) {
-        /**
-         * NOTE: We are not using the Resource Hash Value as the destination path when
-         * `resource_strip_prefix` present. The path in the hash value is computed by the
-         * `_adjust_resources_path` in `scala.bzl`. These are the default paths, ie, path that are
-         * automatically computed when there is no `resource_strip_prefix` present. But when
-         * `resource_strip_prefix` is present, we need to strip the prefix from the Source Path and
-         * use that as the new destination path Refer Bazel -> BazelJavaRuleClasses.java#L227 for
-         * details
-         */
-//        dstr = getResourcePath(shortPath, resourceStripPrefix);
-//      } else {
-//        dstr = resource.destination;
-//      }
-
-      dstr = resource.destination;
+      String dstr = e.getValue().destination;
 
       if (dstr.charAt(0) == '/') {
         // we don't want to copy to an absolute destination

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -310,24 +310,6 @@ class ScalacProcessor implements Processor {
     }
   }
 
-  private static String getResourcePath(Path source, String resourceStripPrefix)
-      throws RuntimeException {
-    String sourcePath = source.toString();
-    // convert strip prefix to a Path first and back to handle different file systems
-    String resourceStripPrefixPath = Paths.get(resourceStripPrefix).toString();
-    // check if the Resource file is under the specified prefix to strip
-    if (!sourcePath.startsWith(resourceStripPrefixPath)) {
-      // Resource File is not under the specified prefix to strip
-      throw new RuntimeException(
-          "Resource File "
-              + sourcePath
-              + " is not under the specified strip prefix "
-              + resourceStripPrefix);
-    }
-    String newResPath = sourcePath.substring(resourceStripPrefix.length());
-    return newResPath;
-  }
-
   private static void copyResourceJars(String[] resourceJars, Path dest) throws IOException {
     for (String jarPath : resourceJars) {
       extractJar(jarPath, dest.toString(), null);

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -271,23 +271,8 @@ class ScalacProcessor implements Processor {
   private static void copyResources(Map<String, Resource> resources, Path dest) throws IOException {
     for (Entry<String, Resource> e : resources.entrySet()) {
       Path source = Paths.get(e.getKey());
-      String dstr = e.getValue().destination;
-
-      if (dstr.charAt(0) == '/') {
-        // we don't want to copy to an absolute destination
-        dstr = dstr.substring(1);
-      }
-      if (dstr.startsWith("../")) {
-        // paths to external repositories, for some reason, start with a leading ../
-        // we don't want to copy the resource out of our temporary directory, so
-        // instead we replace ../ with external/
-        // since "external" is a bit of reserved directory in bazel for these kinds
-        // of purposes, we don't expect a collision in the paths.
-        dstr = "external" + dstr.substring(2);
-      }
-      Path target = dest.resolve(dstr);
-      File tfile = target.getParent().toFile();
-      tfile.mkdirs();
+      Path target = dest.resolve(e.getValue().destination);
+      target.getParent().toFile().mkdirs();
       Files.copy(source, target);
     }
   }

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -268,10 +268,10 @@ class ScalacProcessor implements Processor {
     }
   }
 
-  private static void copyResources(Map<String, Resource> resources, Path dest) throws IOException {
-    for (Entry<String, Resource> e : resources.entrySet()) {
-      Path source = Paths.get(e.getKey());
-      Path target = dest.resolve(e.getValue().destination);
+  private static void copyResources(List<Resource> resources, Path dest) throws IOException {
+    for (Resource r : resources) {
+      Path source = Paths.get(r.source);
+      Path target = dest.resolve(r.target);
       target.getParent().toFile().mkdirs();
       Files.copy(source, target);
     }

--- a/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacProcessor.java
@@ -274,9 +274,9 @@ class ScalacProcessor implements Processor {
       Path source = Paths.get(e.getKey());
       Resource resource = e.getValue();
       Path shortPath = Paths.get(resource.shortPath);
-      String dstr;
+      String dstr = resource.destination;
       // Check if we need to modify resource destination path
-      if (!"".equals(resourceStripPrefix)) {
+//      if (!"".equals(resourceStripPrefix)) {
         /**
          * NOTE: We are not using the Resource Hash Value as the destination path when
          * `resource_strip_prefix` present. The path in the hash value is computed by the
@@ -286,10 +286,12 @@ class ScalacProcessor implements Processor {
          * use that as the new destination path Refer Bazel -> BazelJavaRuleClasses.java#L227 for
          * details
          */
-        dstr = getResourcePath(shortPath, resourceStripPrefix);
-      } else {
-        dstr = resource.destination;
-      }
+//        dstr = getResourcePath(shortPath, resourceStripPrefix);
+//      } else {
+//        dstr = resource.destination;
+//      }
+
+      dstr = resource.destination;
 
       if (dstr.charAt(0) == '/') {
         // we don't want to copy to an absolute destination

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -168,13 +168,78 @@ scala_test(
     ],
 )
 
+proto_library(
+    name = "standalone_proto",
+    srcs = ["standalone.proto"],
+)
+
+proto_library(
+    name = "standalone_proto_strip_import_prefix_partial",
+    srcs = ["standalone.proto"],
+    strip_import_prefix = "/test",
+)
+
+proto_library(
+    name = "standalone_proto_strip_import_prefix_package",
+    srcs = ["standalone.proto"],
+    strip_import_prefix = "/" + package_name(),
+)
+
+proto_library(
+    name = "standalone_proto_with_import_prefix",
+    srcs = ["standalone.proto"],
+    import_prefix = "prefix"
+)
+
+proto_library(
+    name = "standalone_proto_with_custom_prefix",
+    srcs = ["standalone.proto"],
+    strip_import_prefix = "/test",
+    import_prefix = "prefix"
+)
+
+proto_library(
+    name = "nested_proto",
+    srcs = ["some/path/nested.proto"],
+)
+
+proto_library(
+    name = "nested_proto_strip_import_prefix_relative",
+    srcs = ["some/path/nested.proto"],
+    strip_import_prefix = "some",
+)
+
+proto_library(
+    name = "nested_proto_with_import_prefix",
+    srcs = ["some/path/nested.proto"],
+    import_prefix = "prefix"
+)
+
+proto_library(
+    name = "nested_proto_with_custom_prefix",
+    srcs = ["some/path/nested.proto"],
+    strip_import_prefix = "some",
+    import_prefix = "prefix"
+)
+
+scala_proto_library(
+    name = "pack_protos_lib",
+    deps = [
+        ":standalone_proto",
+        ":standalone_proto_strip_import_prefix_partial",
+        ":standalone_proto_strip_import_prefix_package",
+        ":standalone_proto_with_import_prefix",
+        ":standalone_proto_with_custom_prefix",
+        ":nested_proto",
+        ":nested_proto_strip_import_prefix_relative",
+        ":nested_proto_with_import_prefix",
+        ":nested_proto_with_custom_prefix"
+    ]
+)
+
 scala_test(
     name = "test_pack_protos",
-    srcs = [
-        "PackProtosTest.scala",
-    ],
-    deps = [
-        ":test_proto_nogrpc",
-    ],
+    srcs = ["PackProtosTest.scala"],
+    deps = [":pack_protos_lib"],
     unused_dependency_checker_mode = "off",
 )

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -188,14 +188,14 @@ proto_library(
 proto_library(
     name = "standalone_proto_with_import_prefix",
     srcs = ["standalone.proto"],
-    import_prefix = "prefix"
+    import_prefix = "prefix",
 )
 
 proto_library(
     name = "standalone_proto_with_custom_prefix",
     srcs = ["standalone.proto"],
+    import_prefix = "prefix",
     strip_import_prefix = "/test",
-    import_prefix = "prefix"
 )
 
 proto_library(
@@ -212,34 +212,34 @@ proto_library(
 proto_library(
     name = "nested_proto_with_import_prefix",
     srcs = ["some/path/nested.proto"],
-    import_prefix = "prefix"
+    import_prefix = "prefix",
 )
 
 proto_library(
     name = "nested_proto_with_custom_prefix",
     srcs = ["some/path/nested.proto"],
+    import_prefix = "prefix",
     strip_import_prefix = "some",
-    import_prefix = "prefix"
 )
 
 scala_proto_library(
     name = "pack_protos_lib",
     deps = [
-        ":standalone_proto",
-        ":standalone_proto_strip_import_prefix_partial",
-        ":standalone_proto_strip_import_prefix_package",
-        ":standalone_proto_with_import_prefix",
-        ":standalone_proto_with_custom_prefix",
         ":nested_proto",
         ":nested_proto_strip_import_prefix_relative",
+        ":nested_proto_with_custom_prefix",
         ":nested_proto_with_import_prefix",
-        ":nested_proto_with_custom_prefix"
-    ]
+        ":standalone_proto",
+        ":standalone_proto_strip_import_prefix_package",
+        ":standalone_proto_strip_import_prefix_partial",
+        ":standalone_proto_with_custom_prefix",
+        ":standalone_proto_with_import_prefix",
+    ],
 )
 
 scala_test(
     name = "test_pack_protos",
     srcs = ["PackProtosTest.scala"],
-    deps = [":pack_protos_lib"],
     unused_dependency_checker_mode = "off",
+    deps = [":pack_protos_lib"],
 )

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -167,3 +167,14 @@ scala_test(
         ":test_external_dep",
     ],
 )
+
+scala_test(
+    name = "test_pack_protos",
+    srcs = [
+        "PackProtosTest.scala",
+    ],
+    deps = [
+        ":test_proto_nogrpc",
+    ],
+    unused_dependency_checker_mode = "off",
+)

--- a/test/proto/PackProtosTest.scala
+++ b/test/proto/PackProtosTest.scala
@@ -1,0 +1,7 @@
+
+class PackProtosTest extends org.scalatest.FlatSpec {
+
+  "scala_proto_library" should "pack input proto next to generated code" in {
+    assert(getClass.getResource("test/proto/test2.proto") != null)
+  }
+}

--- a/test/proto/PackProtosTest.scala
+++ b/test/proto/PackProtosTest.scala
@@ -1,7 +1,13 @@
-
 class PackProtosTest extends org.scalatest.FlatSpec {
-
   "scala_proto_library" should "pack input proto next to generated code" in {
-    assert(getClass.getResource("test/proto/test2.proto") != null)
+    assert(getClass.getResource("test/proto/standalone.proto") != null)
+    assert(getClass.getResource("proto/standalone.proto") != null)
+    assert(getClass.getResource("standalone.proto") != null)
+    assert(getClass.getResource("prefix/test/proto/standalone.proto") != null)
+    assert(getClass.getResource("prefix/proto/standalone.proto") != null)
+    assert(getClass.getResource("test/proto/some/path/nested.proto") != null)
+    assert(getClass.getResource("path/nested.proto") != null)
+    assert(getClass.getResource("prefix/test/proto/some/path/nested.proto") != null)
+    assert(getClass.getResource("prefix/path/nested.proto") != null)
   }
 }

--- a/test/proto/some/path/nested.proto
+++ b/test/proto/some/path/nested.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+
+message Message {
+}

--- a/test/proto/standalone.proto
+++ b/test/proto/standalone.proto
@@ -1,0 +1,4 @@
+syntax = "proto3";
+
+message Message {
+}


### PR DESCRIPTION
### Description
Bundle input protos together with generated/compiled classes

### Motivation
We have lots of unresolved proto imports in intellij and this happens because intellij's protobuf plugin cannot find imported proto files on the classpath.

Bundling proto files with compiled code doesn't look like unusual practice. I mean jars produced by google carries both class files and proto files for example [protobuf-java](https://repo1.maven.org/maven2/com/google/protobuf/protobuf-java/3.11.1/)

Implementation might look a bit aggressive on resource prefix handling but I had two options ie touch only `scala/private/rule_impls.bzl` or align it with `scala/private/phases/phase_compile.bzl` and I chose later. I could do it in separate PR but I'm afraid it would look like a random refactoring by a random guy without clear purpose.

I'm not sure there is a real need for so many distinct proto_library in tests but I wasn't sure how each combination of `strip_import_prefix` and `import_prefix` work.

`PackProtosTest` could be more strict in the sense that it could check if particular proto entry exist in particular jar. On the other hand we care only that those files are on the classpath.