### PR TITLE
ignore the .metals dir created by VSCode/Emacs with metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ hash2
 .DS_store
 .bazel_cache
 .ijwb
+.metals


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Ignores the .metals directory created by Emacs (for me) and VSCode if you've got Metals installed.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
We ignore the IntelliJ dir, we should ignore the Metals dir too.