### PR TITLE
Unify all maven urls

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -19,6 +19,7 @@ load("//scala:scala.bzl", "scala_repositories")
 
 scala_repositories()
 
+load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")
 load("//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library", "twitter_scrooge")
 
@@ -48,10 +49,7 @@ scalafmt_repositories()
 
 load("//scala:scala_cross_version.bzl", "default_scala_major_version", "scala_mvn_artifact")
 
-MAVEN_SERVER_URLS = [
-    "https://jcenter.bintray.com",
-    "https://repo1.maven.org/maven2",
-]
+MAVEN_SERVER_URLS = default_maven_server_urls()
 
 # test adding a scala jar:
 jvm_maven_import_external(
@@ -106,9 +104,7 @@ scala_maven_import_external(
     artifact_sha256 = "4eb582bc99d96c8df92fc6f0f608fd123d278223982555ba16219bf8be9f75a9",
     fetch_sources = True,
     licenses = ["notice"],
-    server_urls = [
-        "https://repo.maven.apache.org/maven2/",
-    ],
+    server_urls = MAVEN_SERVER_URLS,
     srcjar_sha256 = "5e586357a289f5fe896f7b48759e1c16d9fa419333156b496696887e613d7a19",
 )
 
@@ -151,10 +147,7 @@ scala_maven_import_external(
     artifact_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
     fetch_sources = True,
     licenses = ["notice"],  # Apache 2.0
-    server_urls = [
-        "https://repo1.maven.org/maven2/",
-        "https://mirror.bazel.build/repo1.maven.org/maven2",
-    ],
+    server_urls = MAVEN_SERVER_URLS,
     srcjar_sha256 = "b186965c9af0a714632fe49b33378c9670f8f074797ab466f49a67e918e116ea",
 )
 
@@ -224,10 +217,7 @@ scala_maven_import_external(
     artifact = "org.springframework:spring-core:5.1.5.RELEASE",
     artifact_sha256 = "f771b605019eb9d2cf8f60c25c050233e39487ff54d74c93d687ea8de8b7285a",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = [
-        "https://repo1.maven.org/maven2/",
-        "https://mirror.bazel.build/repo1.maven.org/maven2",
-    ],
+    server_urls = MAVEN_SERVER_URLS,
 )
 
 scala_maven_import_external(
@@ -235,10 +225,7 @@ scala_maven_import_external(
     artifact = "org.springframework:spring-tx:5.1.5.RELEASE",
     artifact_sha256 = "666f72b73c7e6b34e5bb92a0d77a14cdeef491c00fcb07a1e89eb62b08500135",
     licenses = ["notice"],  # Apache 2.0
-    server_urls = [
-        "https://repo1.maven.org/maven2/",
-        "https://mirror.bazel.build/repo1.maven.org/maven2",
-    ],
+    server_urls = MAVEN_SERVER_URLS,
     deps = [
         "@org_springframework_spring_core",
     ],
@@ -254,7 +241,5 @@ scala_maven_import_external(
     artifact_sha256 = "897460d4488b7dd6ac9198937d6417b36cc6ec8ab3693fdf2c532652f26c4373",
     fetch_sources = False,
     licenses = ["notice"],
-    server_urls = [
-        "https://repo.maven.apache.org/maven2/",
-    ],
+    server_urls = MAVEN_SERVER_URLS,
 )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -1,10 +1,14 @@
 load("//scala:scala.bzl", "scala_binary", "scala_library")
 load(
+    "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
+)
+load(
     "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
     _scala_maven_import_external = "scala_maven_import_external",
 )
 
-def jmh_repositories(maven_servers = ["https://repo.maven.apache.org/maven2"]):
+def jmh_repositories(maven_servers = _default_maven_server_urls()):
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_org_openjdk_jmh_jmh_core",
         artifact = "org.openjdk.jmh:jmh-core:1.20",

--- a/junit/junit.bzl
+++ b/junit/junit.bzl
@@ -1,9 +1,13 @@
 load(
+    "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
+)
+load(
     "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
     _scala_maven_import_external = "scala_maven_import_external",
 )
 
-def junit_repositories(maven_servers = ["https://repo.maven.apache.org/maven2"]):
+def junit_repositories(maven_servers = _default_maven_server_urls()):
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_junit_junit",
         artifact = "junit:junit:4.12",

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -1,6 +1,7 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
     _default_scala_version = "default_scala_version",
     _default_scala_version_jar_shas = "default_scala_version_jar_shas",
     _extract_major_version = "extract_major_version",
@@ -56,10 +57,7 @@ def scala_repositories(
             _default_scala_version(),
             _default_scala_version_jar_shas(),
         ),
-        maven_servers = [
-            "https://repo.maven.apache.org/maven2",
-            "https://maven-central.storage-download.googleapis.com/maven2",
-        ],
+        maven_servers = _default_maven_server_urls(),
         scala_extra_jars = _default_scala_extra_jars()):
     (scala_version, scala_version_jar_shas) = scala_version_shas
     major_version = _extract_major_version(scala_version)

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -31,6 +31,14 @@ def default_scala_version_jar_shas():
         "scala_reflect": "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
     }
 
+def default_maven_server_urls():
+    return [
+        "https://repo.maven.apache.org/maven2",
+        "https://maven-central.storage-download.googleapis.com/maven2",
+        "https://mirror.bazel.build/repo1.maven.org/maven2",
+        "https://jcenter.bintray.com",
+    ]
+
 def extract_major_version(scala_version):
     """Return major Scala version given a full version, e.g. "2.11.11" -> "2.11" """
     return scala_version[:scala_version.find(".", 2)]

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -1,4 +1,8 @@
 load(
+    "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
+)
+load(
     "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
     _scala_maven_import_external = "scala_maven_import_external",
 )
@@ -12,11 +16,7 @@ def scalafmt_default_config(path = ".scalafmt.conf"):
     build.append(")")
     native.new_local_repository(name = "scalafmt_default", build_file_content = "\n".join(build), path = "")
 
-def scalafmt_repositories(
-        maven_servers = [
-            "https://repo.maven.apache.org/maven2",
-            "https://maven-central.storage-download.googleapis.com/maven2",
-        ]):
+def scalafmt_repositories(maven_servers = _default_maven_server_urls()):
     _scala_maven_import_external(
         name = "com_geirsson_metaconfig_core_2_11",
         artifact = "com.geirsson:metaconfig-core_2.11:0.8.3",

--- a/scala_proto/private/scala_proto_default_repositories.bzl
+++ b/scala_proto/private/scala_proto_default_repositories.bzl
@@ -1,5 +1,6 @@
 load(
     "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
     _default_scala_version = "default_scala_version",
     _extract_major_version = "extract_major_version",
     _scala_mvn_artifact = "scala_mvn_artifact",
@@ -11,7 +12,7 @@ load(
 
 def scala_proto_default_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["https://repo.maven.apache.org/maven2"]):
+        maven_servers = _default_maven_server_urls()):
     major_version = _extract_major_version(scala_version)
 
     scala_jar_shas = {

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -1,5 +1,6 @@
 load(
     "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
     _default_scala_version = "default_scala_version",
     _extract_major_version = "extract_major_version",
     _scala_mvn_artifact = "scala_mvn_artifact",
@@ -14,7 +15,7 @@ def specs2_version():
 
 def specs2_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["https://repo.maven.apache.org/maven2"]):
+        maven_servers = _default_maven_server_urls()):
     major_version = _extract_major_version(scala_version)
 
     scala_jar_shas = {

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -7,6 +7,7 @@ load(
 load("//junit:junit.bzl", "junit_repositories")
 load(
     "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
     _default_scala_version = "default_scala_version",
     _extract_major_version = "extract_major_version",
     _scala_mvn_artifact = "scala_mvn_artifact",
@@ -18,7 +19,7 @@ load(
 
 def specs2_junit_repositories(
         scala_version = _default_scala_version(),
-        maven_servers = ["https://repo.maven.apache.org/maven2"]):
+        maven_servers = _default_maven_server_urls()):
     major_version = _extract_major_version(scala_version)
 
     specs2_repositories(scala_version, maven_servers)

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -1,5 +1,6 @@
 load(
     "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
     _default_scala_version = "default_scala_version",
     _extract_major_version = "extract_major_version",
     _scala_mvn_artifact = "scala_mvn_artifact",
@@ -23,7 +24,7 @@ _jar_extension = ".jar"
 
 def twitter_scrooge(
         scala_version = _default_scala_version(),
-        maven_servers = ["https://repo.maven.apache.org/maven2"]):
+        maven_servers = _default_maven_server_urls()):
     major_version = _extract_major_version(scala_version)
 
     _scala_maven_import_external(


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Unify all maven server urls in one place.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Travis CI constantly get `GET returned 403 Forbidden`. Using multiple urls helps downloading artifacts from Maven to be more resilient.