### PR TITLE
Get files with extension

### DIFF
--- a/scala/private/paths.bzl
+++ b/scala/private/paths.bzl
@@ -1,0 +1,12 @@
+java_extension = ".java"
+
+scala_extension = ".scala"
+
+srcjar_extension = ".srcjar"
+
+def get_files_with_extension(ctx, extension):
+    return [
+        f
+        for f in ctx.files.srcs
+        if f.basename.endswith(extension)
+    ]

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -14,14 +14,11 @@ load(
     _compile_scala = "compile_scala",
     _expand_location = "expand_location",
     _get_files_with_extension = "get_files_with_extension",
+    _java_extension = "java_extension",
+    _scala_extension = "scala_extension",
+    _srcjar_extension = "srcjar_extension",
 )
 load(":resources.bzl", _resource_paths = "paths")
-
-_java_extension = ".java"
-
-_scala_extension = ".scala"
-
-_srcjar_extension = ".srcjar"
 
 _empty_coverage_struct = struct(
     external = struct(

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -10,13 +10,16 @@ load(
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    _compile_scala = "compile_scala",
-    _expand_location = "expand_location",
+    "@io_bazel_rules_scala//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
     _java_extension = "java_extension",
     _scala_extension = "scala_extension",
     _srcjar_extension = "srcjar_extension",
+)
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    _compile_scala = "compile_scala",
+    _expand_location = "expand_location",
 )
 load(":resources.bzl", _resource_paths = "paths")
 

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -3,6 +3,11 @@
 #
 # Outputs to format the scala files when it is explicitly specified
 #
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    _scala_extension = "scala_extension",
+)
+
 def phase_scalafmt(ctx, p):
     if ctx.attr.format:
         manifest, files = _build_format(ctx)
@@ -17,7 +22,7 @@ def _build_format(ctx):
     manifest_content = []
     for src in ctx.files.srcs:
         # only format scala source files, not generated files
-        if src.path.endswith(".scala") and src.is_source:
+        if src.path.endswith(_scala_extension) and src.is_source:
             file = ctx.actions.declare_file("{}.fmt.output".format(src.short_path))
             files.append(file)
             ctx.actions.run(

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -4,7 +4,7 @@
 # Outputs to format the scala files when it is explicitly specified
 #
 load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "@io_bazel_rules_scala//scala/private:paths.bzl",
     _scala_extension = "scala_extension",
 )
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -23,6 +23,13 @@ load(
 )
 load(":resources.bzl", _resource_paths = "paths")
 
+def get_files_with_extension(ctx, extension):
+    return [
+        f
+        for f in ctx.files.srcs
+        if f.basename.endswith(extension)
+    ]
+
 def expand_location(ctx, flags):
     if hasattr(ctx.attr, "data"):
         data = ctx.attr.data

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -23,19 +23,6 @@ load(
 )
 load(":resources.bzl", _resource_paths = "paths")
 
-java_extension = ".java"
-
-scala_extension = ".scala"
-
-srcjar_extension = ".srcjar"
-
-def get_files_with_extension(ctx, extension):
-    return [
-        f
-        for f in ctx.files.srcs
-        if f.basename.endswith(extension)
-    ]
-
 def expand_location(ctx, flags):
     if hasattr(ctx.attr, "data"):
         data = ctx.attr.data

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -23,6 +23,12 @@ load(
 )
 load(":resources.bzl", _resource_paths = "paths")
 
+java_extension = ".java"
+
+scala_extension = ".scala"
+
+srcjar_extension = ".srcjar"
+
 def get_files_with_extension(ctx, extension):
     return [
         f


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Move "get files with extension" logic to a helper function.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
We have a conversation https://github.com/bazelbuild/rules_scala/pull/975#discussion_r373098148 of possible ways to reduce the use of `dependency.bzl`. We can have a helper function, which can be used in `dependency.bzl` in the future, lives in `rule_impls.bzl` to reuse duplicate code.