### PR TITLE
Handle default args in AST walker

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -45,13 +45,23 @@ class AstUsedJarFinder(
         case _ =>
       }
 
-      if (tree.hasSymbolField) {
-        tree.symbol.annotations.foreach { annot =>
-          annot.tree.foreach(fullyExploreTree)
+      val shouldExamine =
+        tree match {
+          case select: Select if select.symbol.isDefaultGetter =>
+            false
+          case _ =>
+            true
         }
-      }
-      if (tree.tpe != null) {
-        exploreType(tree.tpe)
+
+      if (shouldExamine) {
+        if (tree.hasSymbolField) {
+          tree.symbol.annotations.foreach { annot =>
+            annot.tree.foreach(fullyExploreTree)
+          }
+        }
+        if (tree.tpe != null) {
+          exploreType(tree.tpe)
+        }
       }
     }
 

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -302,6 +302,19 @@ class AstUsedJarFinderTest extends FunSuite {
     )
   }
 
+  test("unspecified default argument type is indirect") {
+    checkIndirectDependencyDetected(
+      aCode = "class A",
+      bCode = "class B(a: A = new A())",
+      cCode =
+        s"""
+           |class C {
+           |  new B()
+           |}
+           |""".stripMargin
+    )
+  }
+
   test("java interface method argument is direct") {
     withSandbox { sandbox =>
       sandbox.compileJava(


### PR DESCRIPTION
### Description
Remove a false positive in AST walker where a never-provided default argument is flagged.

For a default argument that a caller doesn't supply, we shouldn't record the caller as needing that argument's type. Hence we detect such cases and skip them.

### Motivation
We wish to reduce false positives in the AST checker.
