### PR TITLE
Make rules_scala compatible with --incompatible_load_proto_rules_from_bzl

### DIFF
--- a/manual_test/scalac_jvm_opts/BUILD
+++ b/manual_test/scalac_jvm_opts/BUILD
@@ -1,9 +1,7 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:scala.bzl", "scala_library")
-load(
-    "//scala_proto:scala_proto.bzl",
-    "scala_proto_library",
-)
+load("//scala_proto:scala_proto.bzl", "scala_proto_library")
 
 scala_toolchain(
     name = "failing_toolchain_impl",

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -154,7 +154,7 @@ def scala_repositories(
         http_archive(
             name = "rules_java",
             sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
-            urls = ["https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",],
+            urls = ["https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz"],
         )
 
     if not native.existing_rule("rules_proto"):

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -134,13 +134,47 @@ def scala_repositories(
     if not native.existing_rule("com_google_protobuf"):
         http_archive(
             name = "com_google_protobuf",
-            sha256 = "d82eb0141ad18e98de47ed7ed415daabead6d5d1bef1b8cccb6aa4d108a9008f",
-            strip_prefix = "protobuf-b4f193788c9f0f05d7e0879ea96cd738630e5d51",
-            # Commit from 2019-05-15, update to protobuf 3.8 when available.
+            sha256 = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
+            strip_prefix = "protobuf-3.11.3",
             urls = [
-                "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
-                "https://github.com/protocolbuffers/protobuf/archive/b4f193788c9f0f05d7e0879ea96cd738630e5d51.tar.gz",
+                "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
+                "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
             ],
+        )
+
+    if not native.existing_rule("rules_cc"):
+        http_archive(
+            name = "rules_cc",
+            sha256 = "29daf0159f0cf552fcff60b49d8bcd4f08f08506d2da6e41b07058ec50cfeaec",
+            strip_prefix = "rules_cc-b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e",
+            urls = ["https://github.com/bazelbuild/rules_cc/archive/b7fe9697c0c76ab2fd431a891dbb9a6a32ed7c3e.tar.gz"],
+        )
+
+    if not native.existing_rule("rules_java"):
+        http_archive(
+            name = "rules_java",
+            sha256 = "f5a3e477e579231fca27bf202bb0e8fbe4fc6339d63b38ccb87c2760b533d1c3",
+            strip_prefix = "rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd",
+            urls = ["https://github.com/bazelbuild/rules_java/archive/981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz"],
+        )
+
+    if not native.existing_rule("rules_proto"):
+        http_archive(
+            name = "rules_proto",
+            sha256 = "4d421d51f9ecfe9bf96ab23b55c6f2b809cbaf0eea24952683e397decfbd0dd0",
+            strip_prefix = "rules_proto-f6b8d89b90a7956f6782a4a3609b2f0eee3ce965",
+            urls = [
+                "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+                "https://github.com/bazelbuild/rules_proto/archive/f6b8d89b90a7956f6782a4a3609b2f0eee3ce965.tar.gz",
+            ],
+        )
+
+    if not native.existing_rule("rules_python"):
+        http_archive(
+            name = "rules_python",
+            sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
+            strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
+            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
         )
 
     if not native.existing_rule("zlib"):  # needed by com_google_protobuf

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -153,9 +153,8 @@ def scala_repositories(
     if not native.existing_rule("rules_java"):
         http_archive(
             name = "rules_java",
-            sha256 = "f5a3e477e579231fca27bf202bb0e8fbe4fc6339d63b38ccb87c2760b533d1c3",
-            strip_prefix = "rules_java-981f06c3d2bd10225e85209904090eb7b5fb26bd",
-            urls = ["https://github.com/bazelbuild/rules_java/archive/981f06c3d2bd10225e85209904090eb7b5fb26bd.tar.gz"],
+            sha256 = "220b87d8cfabd22d1c6d8e3cdb4249abd4c93dcc152e0667db061fb1b957ee68",
+            urls = ["https://github.com/bazelbuild/rules_java/releases/download/0.1.1/rules_java-0.1.1.tar.gz",],
         )
 
     if not native.existing_rule("rules_proto"):
@@ -180,7 +179,7 @@ def scala_repositories(
     if not native.existing_rule("zlib"):  # needed by com_google_protobuf
         http_archive(
             name = "zlib",
-            build_file = "@com_google_protobuf//:third_party/zlib.BUILD",
+            build_file = "@com_google_protobuf//third_party:zlib.BUILD",
             sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
             strip_prefix = "zlib-1.2.11",
             urls = [

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -1,15 +1,7 @@
-load(
-    "//scala/private:common.bzl",
-    "write_manifest_file",
-)
-load(
-    "//scala/private:dependency.bzl",
-    "legacy_unclear_dependency_info_for_protobuf_scrooge",
-)
-load(
-    "//scala/private:rule_impls.bzl",
-    "compile_scala",
-)
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
+load("//scala/private:common.bzl", "write_manifest_file")
+load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_protobuf_scrooge")
+load("//scala/private:rule_impls.bzl", "compile_scala")
 load("//scala_proto/private:proto_to_scala_src.bzl", "proto_to_scala_src")
 
 ScalaPBAspectInfo = provider(fields = [

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -1,4 +1,8 @@
 load(
+    "@rules_proto//proto:defs.bzl",
+    "ProtoInfo",
+)
+load(
     "//scala:scala_cross_version.bzl",
     _default_maven_server_urls = "default_maven_server_urls",
     _default_scala_version = "default_scala_version",

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//scala_proto:scala_proto.bzl",
     "scala_proto_library",

--- a/test/proto2/BUILD
+++ b/test/proto2/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "test",
     srcs = ["test.proto"],

--- a/test/proto3/BUILD
+++ b/test/proto3/BUILD
@@ -2,6 +2,7 @@ load(
     "//scala_proto:scala_proto.bzl",
     "scala_proto_library",
 )
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 genrule(
     name = "generated",

--- a/test_expect_failure/proto_source_root/dependency/BUILD
+++ b/test_expect_failure/proto_source_root/dependency/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "dependency",
     srcs = glob(["*.proto"]),

--- a/test_expect_failure/proto_source_root/user/BUILD
+++ b/test_expect_failure/proto_source_root/user/BUILD
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//scala_proto:scala_proto.bzl",
     "scala_proto_library",

--- a/test_version/version_specific_tests_dir/proto/BUILD
+++ b/test_version/version_specific_tests_dir/proto/BUILD
@@ -2,6 +2,7 @@ load(
     "@io_bazel_rules_scala//scala_proto:scala_proto.bzl",
     "scala_proto_library",
 )
+load("@rules_proto//proto:defs.bzl", "proto_library")
 
 proto_library(
     name = "test2",

--- a/test_version/version_specific_tests_dir/proto2/BUILD
+++ b/test_version/version_specific_tests_dir/proto2/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 proto_library(
     name = "test",
     srcs = ["test.proto"],

--- a/third_party/bazel/src/main/protobuf/BUILD
+++ b/third_party/bazel/src/main/protobuf/BUILD
@@ -1,3 +1,5 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+
 licenses(["notice"])
 
 package(default_visibility = ["//visibility:public"])


### PR DESCRIPTION
Bazel will rewrite Protobuf rules in Starlark and remove their native equivalents.
As a first step, everyone will be required to add load statements for `proto_library`.
This change adds them for rules_scala.

https://github.com/bazelbuild/bazel/issues/8922
https://buildkite.com/bazel/bazelisk-plus-incompatible-flags/builds/402#9082639a-6464-4821-bf47-3b93e00f37e0