### PR TITLE
Ignore scalatest in unused dependency checker

### DIFF
--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -99,7 +99,7 @@ def phase_compile_scalatest(ctx, p):
         unused_dependency_checker_ignored_targets = [
             target.label
             for target in p.scalac_provider.default_classpath +
-	                      [ctx.attr._scalatest] +
+                          [ctx.attr._scalatest] +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
     )

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -99,6 +99,7 @@ def phase_compile_scalatest(ctx, p):
         unused_dependency_checker_ignored_targets = [
             target.label
             for target in p.scalac_provider.default_classpath +
+	                      [ctx.attr._scalatest] +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
     )


### PR DESCRIPTION
### Description
For the scalatest rule, we add the scalatest library to the unused dependency checker ignore list, as that library is always imported by the rule itself.

### Motivation
This removes a false positive in unused dependency checker.