### PR TITLE
Ignore base class annotation

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -103,7 +103,20 @@ class AstUsedJarFinder(
 
       if (shouldExamine) {
         if (tree.hasSymbolField) {
-          tree.symbol.annotations.foreach(exploreAnnotationInfo)
+          tree.symbol.annotations
+            // We skip annotations without positions. The reason for
+            // this is the case of
+            //   @SomeAnnotation class A
+            //   class B extends A
+            // Now assuming A and B are in separate packages, while
+            // examining B we will examine A as well, and hence
+            // examine A's annotations. However we don't wish to examine
+            // A's annotations as we don't care about those details of A.
+            // Hence we only examine annotations with positions (hence,
+            // they were defined in the same compilation unit and thus
+            // matter).
+            .filter(_.pos.isDefined)
+            .foreach(exploreAnnotationInfo)
         }
         if (tree.tpe != null) {
           exploreType(tree.tpe, tree.pos)

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -293,6 +293,14 @@ class AstUsedJarFinderTest extends FunSuite {
     )
   }
 
+  test("static annotation of inherited class is indirect") {
+    checkIndirectDependencyDetected(
+      aCode = "class A extends scala.annotation.StaticAnnotation",
+      bCode = "@A class B",
+      cCode = "class C extends B"
+    )
+  }
+
   test("class type parameter bound is direct") {
     checkDirectDependencyRecognized(
       aCode =


### PR DESCRIPTION
### Description
We change the dependency analyzer AST mode to ignore annotations on base classes.

### Motivation

This removes a false positive for the dependency analyzer.