### PR TITLE
load java rules explicitly

### DIFF
--- a/private/BUILD
+++ b/private/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 java_binary(
     name = "java_format",
     main_class = "com.google.googlejavaformat.java.Main",

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_import", "java_library")
 load(
     "@io_bazel_rules_scala//scala:providers.bzl",
     _declare_scalac_provider = "declare_scalac_provider",

--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
 load("//scala_proto:default_dep_sets.bzl", "DEFAULT_SCALAPB_COMPILE_DEPS", "DEFAULT_SCALAPB_GRPC_DEPS")
 

--- a/specs2/BUILD
+++ b/specs2/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 package(default_visibility = ["//visibility:public"])
 
 java_import(

--- a/src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD
+++ b/src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary")
+
 java_binary(
     name = "instrumenter",
     srcs = [

--- a/src/java/io/bazel/rulesscala/exe/BUILD
+++ b/src/java/io/bazel/rulesscala/exe/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "exe-lib",
     srcs = [

--- a/src/java/io/bazel/rulesscala/io_utils/BUILD
+++ b/src/java/io/bazel/rulesscala/io_utils/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "io_utils",
     srcs = glob(["*.java"]),

--- a/src/java/io/bazel/rulesscala/jar/BUILD
+++ b/src/java/io/bazel/rulesscala/jar/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 java_library(
     name = "jar",
     srcs = [

--- a/src/java/io/bazel/rulesscala/scala_test/BUILD
+++ b/src/java/io/bazel/rulesscala/scala_test/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "runner",
     srcs = ["Runner.java"],

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_binary")
 load(
     ":jvm_export_toolchain.bzl",
     _export_scalac_repositories_from_toolchain_to_jvm = "export_scalac_repositories_from_toolchain_to_jvm",

--- a/src/java/io/bazel/rulesscala/worker/BUILD
+++ b/src/java/io/bazel/rulesscala/worker/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 java_library(
     name = "worker",
     srcs = [

--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library")
+
 package(default_testonly = 1)
 
 load(

--- a/test/coverage/BUILD
+++ b/test/coverage/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("//scala:scala.bzl", "scala_library", "scala_test")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 

--- a/test/example_jars/BUILD
+++ b/test/example_jars/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_import")
+
 java_import(
     name = "example_jar1",
     jars = [

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//scala:scala.bzl", "scala_library")
 load("//jmh:jmh.bzl", "scala_benchmark_jmh")
 

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//scala_proto:scala_proto.bzl",

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_import")
 load("//scala:scala.bzl", "scala_library", "scala_specs2_junit_test")
 load("//scala:scala_import.bzl", "scala_import")
 

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/BUILD
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_import")
 load("//thrift:thrift.bzl", "thrift_library")
 
 java_import(

--- a/test_expect_failure/missing_direct_deps/internal_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/internal_deps/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_library")
+
 package(default_visibility = ["//visibility:public"])
 
 load("//scala:scala.bzl", "scala_binary", "scala_library", "scala_test")

--- a/test_expect_failure/transitive/java_to_scala/BUILD
+++ b/test_expect_failure/transitive/java_to_scala/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//scala:scala.bzl", "scala_export_to_java", "scala_library")
 
 scala_library(

--- a/test_expect_failure/transitive/scala_to_java/BUILD
+++ b/test_expect_failure/transitive/scala_to_java/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_library")
 load("//scala:scala.bzl", "scala_library")
 
 java_library(

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -1,3 +1,5 @@
+load("@rules_java//java:defs.bzl", "java_binary", "java_library")
+
 package(default_testonly = 1)
 
 load(

--- a/test_version/version_specific_tests_dir/proto/BUILD
+++ b/test_version/version_specific_tests_dir/proto/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
 load(
     "@io_bazel_rules_scala//scala_proto:scala_proto.bzl",
     "scala_proto_library",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_import")
 load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
 
 java_import(

--- a/third_party/bazel/src/main/protobuf/BUILD
+++ b/third_party/bazel/src/main/protobuf/BUILD
@@ -1,3 +1,4 @@
+load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 
 licenses(["notice"])


### PR DESCRIPTION
### Description
load java_library/java_binary_java_import explicitly

This PR was created by running `buildifier --lint=fix -warnings=native-java -r  .` on the repo thanks to https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md
 
### Motivation
fixes #893 

I'll send a few more based on everything the buildifier automatic fixes can