### PR TITLE
load python rules explicitly

### DIFF
--- a/test/BUILD
+++ b/test/BUILD
@@ -1,3 +1,4 @@
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@rules_java//java:defs.bzl", "java_binary", "java_import", "java_library")
 
 package(default_testonly = 1)


### PR DESCRIPTION
### Description
load py_binary explicitly

This PR was created by running buildifier --lint=fix -warnings=native-py -r . on the repo thanks to https://github.com/bazelbuild/buildtools/blob/master/WARNINGS.md


### Motivation
fixes #894 


Stacked PR on top of #999 (will rebase after it's merged)