### PR TITLE
Revert "remove spotify from adopters"

### DIFF
--- a/README.md
+++ b/README.md
@@ -317,6 +317,7 @@ Here's a (non-exhaustive) list of companies that use `rules_scala` in production
 * [Grand Rounds](http://grandrounds.com/)
 * [Kitty Hawk](https://kittyhawk.aero/)
 * [Meetup](https://meetup.com/)
+* [Spotify](https://www.spotify.com/)
 * [Stripe](https://stripe.com/)
 * [VSCO](https://vsco.co)
 * [Wix](https://www.wix.com/)


### PR DESCRIPTION
Reverts bazelbuild/rules_scala#1001
Apparently I was wrong in removing them:
https://github.com/bazelbuild/rules_scala/pull/1001#issuecomment-587464520