### PR TITLE
Scalafmt 2.12 support

### DIFF
--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -19,9 +19,9 @@ scala_binary(
     visibility = ["//visibility:public"],
     deps = [
         "//src/java/io/bazel/rulesscala/worker",
-        "@com_geirsson_metaconfig_core_2_11",
-        "@org_scalameta_parsers_2_11",
-        "@org_scalameta_scalafmt_core_2_11",
+        "@com_geirsson_metaconfig_core",
+        "@org_scalameta_parsers",
+        "@org_scalameta_scalafmt_core",
     ],
 )
 

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -23,8 +23,8 @@ def _default_scala_extra_jars():
     return {
         "2.11": {
             "org_scalameta_common": {
-                "version": "4.2.0",
-                "sha256": "c2921b10ef2a06cafa48d4e0a6be4ff42c9135b5c5cf51ec3fdd9b66077f66cb",
+                "version": "4.3.0",
+                "sha256": "6330798bcbd78d14d371202749f32efda0465c3be5fd057a6055a67e21335ba0",
             },
             "org_scalameta_fastparse": {
                 "version": "1.0.1",
@@ -34,25 +34,29 @@ def _default_scala_extra_jars():
                 "version": "1.0.1",
                 "sha256": "93f58db540e53178a686621f7a9c401307a529b68e051e38804394a2a86cea94",
             },
+            "org_scala_lang_modules_scala_collection_compat": {
+                "version": "2.1.2",
+                "sha256": "e9667b8b7276aeb42599f536fe4d7caab06eabc55e9995572267ad60c7a11c8b",
+            },
             "org_scalameta_parsers": {
-                "version": "4.2.0",
-                "sha256": "acde4faa648c61f1d76f7a1152116738c0b0b80ae2fab8ceae83c061c29aadf1",
+                "version": "4.3.0",
+                "sha256": "724382abfac27b32dec6c21210562bc7e1b09b5268ccb704abe66dcc8844beeb",
             },
             "org_scalameta_scalafmt_core": {
-                "version": "2.0.0",
-                "sha256": "84bac5ed8c85e61851ef427f045b7bfd149d857cb543b41c85b8353fb8c47aff",
+                "version": "2.3.2",
+                "sha256": "6bf391e0e1d7369fda83ddaf7be4d267bf4cbccdf2cc31ff941999a78c30e67f",
             },
             "org_scalameta_scalameta": {
-                "version": "4.2.0",
-                "sha256": "b56038c03fcad7397c571fbbc44562a3231e275aedc7a6ad15163ddcdfaed61a",
+                "version": "4.3.0",
+                "sha256": "94fe739295447cd3ae877c279ccde1def06baea02d9c76a504dda23de1d90516",
             },
             "org_scalameta_trees": {
-                "version": "4.2.0",
-                "sha256": "7daf84bd9a66257e42900ac940bd6df2037f09d33ca93e619ee37377d10ee34a",
+                "version": "4.3.0",
+                "sha256": "d24d5d63d8deafe646d455c822593a66adc6fdf17c8373754a3834a6e92a8a72",
             },
             "org_typelevel_paiges_core": {
-                "version": "0.2.0",
-                "sha256": "dec1b60448c9ac7bd4a55a4fcf68e0ce6e202d0fad1a896d4501c3ebd8052b2d",
+                "version": "0.2.4",
+                "sha256": "aa66fbe0457ca5cb5b9e522d4cb873623bb376a2e1ff58c464b5194c1d87c241",
             },
             "org_scala_lang_scalap": {
                 "version": "2.11.12",
@@ -79,22 +83,22 @@ def _default_scala_extra_jars():
                 "sha256": "fb5e4921e7dff734d049e752a482d3a031380d3eea5caa76c991312dee9e6991",
             },
             "com_lihaoyi_sourcecode": {
-                "version": "0.1.4",
-                "sha256": "e0edffec93ddef29c40b7c65580960062a3fa9d781eddb8c64e19e707c4a8e7c",
+                "version": "0.1.7",
+                "sha256": "33516d7fd9411f74f05acfd5274e1b1889b7841d1993736118803fc727b2d5fc",
             },
             "com_geirsson_metaconfig_core": {
-                "version": "0.8.3",
-                "sha256": "8abb4e48507486d0b323b440bb021bddd56366e502002025fdaf10025d2650c2",
+                "version": "0.9.4",
+                "sha256": "5d5704a1f1c4f74aed26248eeb9b577274d570b167cec0bf51d2908609c29118",
             },
             "com_geirsson_metaconfig_typesafe_config": {
-                "version": "0.8.3",
-                "sha256": "410c29b2ebc842591627588d8980df507dc0eb48a0a7df312fa529fa0fe90d42",
+                "version": "0.9.4",
+                "sha256": "52d2913640f4592402aeb2f0cec5004893d02acf26df4aa1cf8d4dcb0d2b21c7",
             },
         },
         "2.12": {
             "org_scalameta_common": {
-                "version": "4.2.0",
-                "sha256": "6af050ec30d42bce48f9824aeb90de6ae7a8de30c400d7bfa678c91cbb12b80c",
+                "version": "4.3.0",
+                "sha256": "3bdb2ff71d3e86f94b4d31d2c40442f533655860749a92fd17e1f29b8deb8baa",
             },
             "org_scalameta_fastparse": {
                 "version": "1.0.1",
@@ -104,25 +108,29 @@ def _default_scala_extra_jars():
                 "version": "1.0.1",
                 "sha256": "9d8ad97778ef9aedef5d4190879ed0ec54969e2fc951576fe18746ae6ce6cfcf",
             },
+            "org_scala_lang_modules_scala_collection_compat": {
+                "version": "2.1.2",
+                "sha256": "8aab3e1f9dd7bc392a2e27cf168af94fdc7cc2752131fc852192302fb21efdb4",
+            },
             "org_scalameta_parsers": {
-                "version": "4.2.0",
-                "sha256": "9dc726dab95870b193dee3ed4d11985fa38ca09640768a7c86d8f80c715c5567",
+                "version": "4.3.0",
+                "sha256": "d9f87d03b6b5e942f263db6dab75937493bfcb0fe7cfe2cda6567bf30f23ff3a",
             },
             "org_scalameta_scalafmt_core": {
-                "version": "2.0.0",
-                "sha256": "02562f176a7d070230ef2da6192f2d15afd62ea173eaf8ca02a7afb89262d233",
+                "version": "2.3.2",
+                "sha256": "4788e2045e99f4624162d3182016a05032a7ab1324c4a28af433aa070f916773",
             },
             "org_scalameta_scalameta": {
-                "version": "4.2.0",
-                "sha256": "e5eabc44577f14a4bc312e5b5844592d2d53b3971d08f13974de5991ed5897f7",
+                "version": "4.3.0",
+                "sha256": "4d9487b434cbe9d89033824a4fc902dc7c782eea94961e8575df91ae96b10d6a",
             },
             "org_scalameta_trees": {
-                "version": "4.2.0",
-                "sha256": "af09f59540b53504686d9975dc05474dc9c3cc6dca95f7609f910929c1a33001",
+                "version": "4.3.0",
+                "sha256": "020b53681dd8e148d74ffa282276994bcb0f06c3425fb9a4bb9f8d161e22187a",
             },
             "org_typelevel_paiges_core": {
-                "version": "0.2.0",
-                "sha256": "0051e89bfcb1efd0498c6a95cb1583bc1d097230da9627da76de0b416692e703",
+                "version": "0.2.4",
+                "sha256": "594ca130526023e80549484e45400d09810fa39d9fd6b4663830a00be2a8556a",
             },
             "org_scala_lang_scalap": {
                 "version": "2.12.10",
@@ -149,16 +157,16 @@ def _default_scala_extra_jars():
                 "sha256": "2e18aa0884870537bf5c562255fc759d4ebe360882b5cb2141b30eda4034c71d",
             },
             "com_lihaoyi_sourcecode": {
-                "version": "0.1.4",
-                "sha256": "9a3134484e596205d0acdcccd260e0854346f266cb4d24e1b8a31be54fbaf6d9",
+                "version": "0.1.7",
+                "sha256": "f07d79f0751ac275cc09b92caf3618f0118d153da7868b8f0c9397ce93c5f926",
             },
             "com_geirsson_metaconfig_core": {
-                "version": "0.8.3",
-                "sha256": "495817d90ecb4c432ee0afa7e79b4d005e6a6f90a270e113e15fe7d2d5559dfd",
+                "version": "0.9.4",
+                "sha256": "970b3d74fc9b2982d9fb31d93f460000b41fff21c0b9d9ef9476ed333a010b2a",
             },
             "com_geirsson_metaconfig_typesafe_config": {
-                "version": "0.8.3",
-                "sha256": "d9eed8472acbd4508ab25ca7bb78f1931d1d34729dfefc5f5f4c6a6e5c0aa47f",
+                "version": "0.9.4",
+                "sha256": "3165f30a85d91de7f8ba714e685a6b822bd1cbb365946f5d708163725df3ef5d",
             },
         },
     }
@@ -225,6 +233,21 @@ def scalafmt_repositories(
     )
 
     _scala_maven_import_external(
+        name = "org_scala_lang_modules_scala_collection_compat",
+        artifact = "org.scala-lang.modules:scala-collection-compat_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scala_lang_modules_scala_collection_compat"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scala_lang_modules_scala_collection_compat"]["sha256"],
+        fetch_sources = True,
+        licenses = ["notice"],  # Apache 2.0
+        deps = [
+            "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+        ],
+        server_urls = maven_servers,
+    )
+
+    _scala_maven_import_external(
         name = "org_scalameta_parsers",
         artifact = "org.scalameta:parsers_{major_version}:{extra_jar_version}".format(
             major_version = major_version,
@@ -255,6 +278,7 @@ def scalafmt_repositories(
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
             "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
             "@org_scalameta_scalameta",
+            "@org_scala_lang_modules_scala_collection_compat",
         ],
         server_urls = maven_servers,
     )
@@ -452,6 +476,7 @@ def scalafmt_repositories(
             "@com_lihaoyi_pprint",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
             "@org_typelevel_paiges_core",
+            "@org_scala_lang_modules_scala_collection_compat",
         ],
         server_urls = maven_servers,
     )
@@ -469,6 +494,7 @@ def scalafmt_repositories(
             "@com_geirsson_metaconfig_core",
             "@com_typesafe_config",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
+            "@org_scala_lang_modules_scala_collection_compat",
         ],
         server_urls = maven_servers,
     )

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -1,6 +1,9 @@
 load(
     "//scala:scala_cross_version.bzl",
     _default_maven_server_urls = "default_maven_server_urls",
+    _default_scala_version = "default_scala_version",
+    _default_scala_version_jar_shas = "default_scala_version_jar_shas",
+    _extract_major_version = "extract_major_version",
 )
 load(
     "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
@@ -16,125 +19,288 @@ def scalafmt_default_config(path = ".scalafmt.conf"):
     build.append(")")
     native.new_local_repository(name = "scalafmt_default", build_file_content = "\n".join(build), path = "")
 
-def scalafmt_repositories(maven_servers = _default_maven_server_urls()):
-    _scala_maven_import_external(
-        name = "com_geirsson_metaconfig_core_2_11",
-        artifact = "com.geirsson:metaconfig-core_2.11:0.8.3",
-        artifact_sha256 = "8abb4e48507486d0b323b440bb021bddd56366e502002025fdaf10025d2650c2",
-        licenses = ["notice"],
-        server_urls = maven_servers,
-    )
+def _default_scala_extra_jars():
+    return {
+        "2.11": {
+            "org_scalameta_common": {
+                "version": "4.2.0",
+                "sha256": "c2921b10ef2a06cafa48d4e0a6be4ff42c9135b5c5cf51ec3fdd9b66077f66cb",
+            },
+            "org_scalameta_fastparse": {
+                "version": "1.0.1",
+                "sha256": "49ecc30a4b47efc0038099da0c97515cf8f754ea631ea9f9935b36ca7d41b733",
+            },
+            "org_scalameta_fastparse_utils": {
+                "version": "1.0.1",
+                "sha256": "93f58db540e53178a686621f7a9c401307a529b68e051e38804394a2a86cea94",
+            },
+            "org_scalameta_parsers": {
+                "version": "4.2.0",
+                "sha256": "acde4faa648c61f1d76f7a1152116738c0b0b80ae2fab8ceae83c061c29aadf1",
+            },
+            "org_scalameta_scalafmt_core": {
+                "version": "2.0.0",
+                "sha256": "84bac5ed8c85e61851ef427f045b7bfd149d857cb543b41c85b8353fb8c47aff",
+            },
+            "org_scalameta_scalameta": {
+                "version": "4.2.0",
+                "sha256": "b56038c03fcad7397c571fbbc44562a3231e275aedc7a6ad15163ddcdfaed61a",
+            },
+            "org_scalameta_trees": {
+                "version": "4.2.0",
+                "sha256": "7daf84bd9a66257e42900ac940bd6df2037f09d33ca93e619ee37377d10ee34a",
+            },
+            "org_typelevel_paiges_core": {
+                "version": "0.2.0",
+                "sha256": "dec1b60448c9ac7bd4a55a4fcf68e0ce6e202d0fad1a896d4501c3ebd8052b2d",
+            },
+            "org_scala_lang_scalap": {
+                "version": "2.11.12",
+                "sha256": "a6dd7203ce4af9d6185023d5dba9993eb8e80584ff4b1f6dec574a2aba4cd2b7",
+            },
+            "com_thesamet_scalapb_lenses": {
+                "version": "0.9.0",
+                "sha256": "f4809760edee6abc97a7fe9b7fd6ae5fe1006795b1dc3963ab4e317a72f1a385",
+            },
+            "com_thesamet_scalapb_scalapb_runtime": {
+                "version": "0.9.0",
+                "sha256": "ab1e449a18a9ce411eb3fec31bdbca5dd5fae4475b1557bb5e235a7b54738757",
+            },
+            "com_lihaoyi_fansi": {
+                "version": "0.2.5",
+                "sha256": "1ff0a8304f322c1442e6bcf28fab07abf3cf560dd24573dbe671249aee5fc488",
+            },
+            "com_lihaoyi_fastparse": {
+                "version": "2.1.2",
+                "sha256": "5c5d81f90ada03ac5b21b161864a52558133951031ee5f6bf4d979e8baa03628",
+            },
+            "com_lihaoyi_pprint": {
+                "version": "0.5.3",
+                "sha256": "fb5e4921e7dff734d049e752a482d3a031380d3eea5caa76c991312dee9e6991",
+            },
+            "com_lihaoyi_sourcecode": {
+                "version": "0.1.4",
+                "sha256": "e0edffec93ddef29c40b7c65580960062a3fa9d781eddb8c64e19e707c4a8e7c",
+            },
+            "com_geirsson_metaconfig_core": {
+                "version": "0.8.3",
+                "sha256": "8abb4e48507486d0b323b440bb021bddd56366e502002025fdaf10025d2650c2",
+            },
+            "com_geirsson_metaconfig_typesafe_config": {
+                "version": "0.8.3",
+                "sha256": "410c29b2ebc842591627588d8980df507dc0eb48a0a7df312fa529fa0fe90d42",
+            },
+        },
+        "2.12": {
+            "org_scalameta_common": {
+                "version": "4.2.0",
+                "sha256": "6af050ec30d42bce48f9824aeb90de6ae7a8de30c400d7bfa678c91cbb12b80c",
+            },
+            "org_scalameta_fastparse": {
+                "version": "1.0.1",
+                "sha256": "387ced762e93915c5f87fed59d8453e404273f49f812d413405696ce20273aa5",
+            },
+            "org_scalameta_fastparse_utils": {
+                "version": "1.0.1",
+                "sha256": "9d8ad97778ef9aedef5d4190879ed0ec54969e2fc951576fe18746ae6ce6cfcf",
+            },
+            "org_scalameta_parsers": {
+                "version": "4.2.0",
+                "sha256": "9dc726dab95870b193dee3ed4d11985fa38ca09640768a7c86d8f80c715c5567",
+            },
+            "org_scalameta_scalafmt_core": {
+                "version": "2.0.0",
+                "sha256": "02562f176a7d070230ef2da6192f2d15afd62ea173eaf8ca02a7afb89262d233",
+            },
+            "org_scalameta_scalameta": {
+                "version": "4.2.0",
+                "sha256": "e5eabc44577f14a4bc312e5b5844592d2d53b3971d08f13974de5991ed5897f7",
+            },
+            "org_scalameta_trees": {
+                "version": "4.2.0",
+                "sha256": "af09f59540b53504686d9975dc05474dc9c3cc6dca95f7609f910929c1a33001",
+            },
+            "org_typelevel_paiges_core": {
+                "version": "0.2.0",
+                "sha256": "0051e89bfcb1efd0498c6a95cb1583bc1d097230da9627da76de0b416692e703",
+            },
+            "org_scala_lang_scalap": {
+                "version": "2.12.10",
+                "sha256": "4641b0a55fe1ebec995b4daea9183c21651c03f77d2ed08b345507474eeabe72",
+            },
+            "com_thesamet_scalapb_lenses": {
+                "version": "0.9.0",
+                "sha256": "0a2fff4de17d270cea561618090c21d50bc891d82c6f9dfccdc20568f18d0260",
+            },
+            "com_thesamet_scalapb_scalapb_runtime": {
+                "version": "0.9.0",
+                "sha256": "b905fa66b3fd0fabf3114105cd73ae2bdddbb6e13188a6538a92ae695e7ad6ed",
+            },
+            "com_lihaoyi_fansi": {
+                "version": "0.2.5",
+                "sha256": "7d752240ec724e7370903c25b69088922fa3fb6831365db845cd72498f826eca",
+            },
+            "com_lihaoyi_fastparse": {
+                "version": "2.1.2",
+                "sha256": "92a98f89c4f9559715124599ee5ce8f0d36ee326f5c7ef88b51487de39a3602e",
+            },
+            "com_lihaoyi_pprint": {
+                "version": "0.5.3",
+                "sha256": "2e18aa0884870537bf5c562255fc759d4ebe360882b5cb2141b30eda4034c71d",
+            },
+            "com_lihaoyi_sourcecode": {
+                "version": "0.1.4",
+                "sha256": "9a3134484e596205d0acdcccd260e0854346f266cb4d24e1b8a31be54fbaf6d9",
+            },
+            "com_geirsson_metaconfig_core": {
+                "version": "0.8.3",
+                "sha256": "495817d90ecb4c432ee0afa7e79b4d005e6a6f90a270e113e15fe7d2d5559dfd",
+            },
+            "com_geirsson_metaconfig_typesafe_config": {
+                "version": "0.8.3",
+                "sha256": "d9eed8472acbd4508ab25ca7bb78f1931d1d34729dfefc5f5f4c6a6e5c0aa47f",
+            },
+        },
+    }
+
+def scalafmt_repositories(
+        scala_version_shas = (
+            _default_scala_version(),
+            _default_scala_version_jar_shas(),
+        ),
+        maven_servers = _default_maven_server_urls(),
+        scala_extra_jars = _default_scala_extra_jars()):
+    (scala_version, scala_version_jar_shas) = scala_version_shas
+    major_version = _extract_major_version(scala_version)
+
+    scala_version_extra_jars = scala_extra_jars[major_version]
 
     _scala_maven_import_external(
-        name = "org_scalameta_common_2_11",
-        artifact = "org.scalameta:common_2.11:4.2.0",
-        artifact_sha256 = "c2921b10ef2a06cafa48d4e0a6be4ff42c9135b5c5cf51ec3fdd9b66077f66cb",
-        srcjar_sha256 = "373ee3a734ae1ca8cb3361812f0702ed52d5d2fbff95e7406752be408a2d9a59",
+        name = "org_scalameta_common",
+        artifact = "org.scalameta:common_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_common"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_common"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_sourcecode_2_11",
+            "@com_lihaoyi_sourcecode",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_scalameta_fastparse_2_11",
-        artifact = "org.scalameta:fastparse_2.11:1.0.1",
-        artifact_sha256 = "49ecc30a4b47efc0038099da0c97515cf8f754ea631ea9f9935b36ca7d41b733",
-        srcjar_sha256 = "9769781eeb2980be3379c2cf6aced31f60ad32fe903a830687185e9ffc223d84",
+        name = "org_scalameta_fastparse",
+        artifact = "org.scalameta:fastparse_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_fastparse"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_fastparse"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_sourcecode_2_11",
+            "@com_lihaoyi_sourcecode",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-            "@org_scalameta_fastparse_utils_2_11",
+            "@org_scalameta_fastparse_utils",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_scalameta_fastparse_utils_2_11",
-        artifact = "org.scalameta:fastparse-utils_2.11:1.0.1",
-        artifact_sha256 = "93f58db540e53178a686621f7a9c401307a529b68e051e38804394a2a86cea94",
-        srcjar_sha256 = "f1c28e408d8309f6f96ea9ed0f2e0bc5661fb84d3730d1bde06207a93a3d091b",
+        name = "org_scalameta_fastparse_utils",
+        artifact = "org.scalameta:fastparse-utils_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_fastparse_utils"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_fastparse_utils"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_sourcecode_2_11",
+            "@com_lihaoyi_sourcecode",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_scalameta_parsers_2_11",
-        artifact = "org.scalameta:parsers_2.11:4.2.0",
-        artifact_sha256 = "acde4faa648c61f1d76f7a1152116738c0b0b80ae2fab8ceae83c061c29aadf1",
-        srcjar_sha256 = "212e7e9070c80fbba4680f6d0355036b6486189289515a52b013d36c6070ff1a",
+        name = "org_scalameta_parsers",
+        artifact = "org.scalameta:parsers_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_parsers"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_parsers"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-            "@org_scalameta_trees_2_11",
+            "@org_scalameta_trees",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_scalameta_scalafmt_core_2_11",
-        artifact = "org.scalameta:scalafmt-core_2.11:2.0.0",
-        artifact_sha256 = "84bac5ed8c85e61851ef427f045b7bfd149d857cb543b41c85b8353fb8c47aff",
-        srcjar_sha256 = "6ea863beba530b8eabbb648143387f5ccba6299d0fc331046ab30dc493c984ca",
+        name = "org_scalameta_scalafmt_core",
+        artifact = "org.scalameta:scalafmt-core_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_scalafmt_core"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_scalafmt_core"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_geirsson_metaconfig_core_2_11",
-            "@com_geirsson_metaconfig_typesafe_config_2_11",
+            "@com_geirsson_metaconfig_core",
+            "@com_geirsson_metaconfig_typesafe_config",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
             "//external:io_bazel_rules_scala/dependency/scala/scala_reflect",
-            "@org_scalameta_scalameta_2_11",
+            "@org_scalameta_scalameta",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_scalameta_scalameta_2_11",
-        artifact = "org.scalameta:scalameta_2.11:4.2.0",
-        artifact_sha256 = "b56038c03fcad7397c571fbbc44562a3231e275aedc7a6ad15163ddcdfaed61a",
-        srcjar_sha256 = "fa57cb1b1800dee3dee970250012ebf1f95b7a3f6ee7b26c7d3dd0df971ac1cb",
+        name = "org_scalameta_scalameta",
+        artifact = "org.scalameta:scalameta_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_scalameta"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_scalameta"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
             "@org_scala_lang_scalap",
-            "@org_scalameta_parsers_2_11",
+            "@org_scalameta_parsers",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_scalameta_trees_2_11",
-        artifact = "org.scalameta:trees_2.11:4.2.0",
-        artifact_sha256 = "7daf84bd9a66257e42900ac940bd6df2037f09d33ca93e619ee37377d10ee34a",
-        srcjar_sha256 = "13a8be06f350100754cff19c776b2d03b954677b816c0e4888752845480be358",
+        name = "org_scalameta_trees",
+        artifact = "org.scalameta:trees_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_scalameta_trees"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scalameta_trees"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_thesamet_scalapb_scalapb_runtime_2_11",
+            "@com_thesamet_scalapb_scalapb_runtime",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-            "@org_scalameta_common_2_11",
-            "@org_scalameta_fastparse_2_11",
+            "@org_scalameta_common",
+            "@org_scalameta_fastparse",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "org_typelevel_paiges_core_2_11",
-        artifact = "org.typelevel:paiges-core_2.11:0.2.0",
-        artifact_sha256 = "dec1b60448c9ac7bd4a55a4fcf68e0ce6e202d0fad1a896d4501c3ebd8052b2d",
-        srcjar_sha256 = "952fd039b04e06cc52daf2f8232e5b3adc2009bf287a688e4c82edf3cc37d3d0",
+        name = "org_typelevel_paiges_core",
+        artifact = "org.typelevel:paiges-core_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["org_typelevel_paiges_core"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_typelevel_paiges_core"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
@@ -155,9 +321,10 @@ def scalafmt_repositories(maven_servers = _default_maven_server_urls()):
 
     _scala_maven_import_external(
         name = "org_scala_lang_scalap",
-        artifact = "org.scala-lang:scalap:2.11.12",
-        artifact_sha256 = "a6dd7203ce4af9d6185023d5dba9993eb8e80584ff4b1f6dec574a2aba4cd2b7",
-        srcjar_sha256 = "50df9e4b4c996cda761f35cbc603cf145a21157a72a82d023d44b0eeeb293e29",
+        artifact = "org.scala-lang:scalap:{extra_jar_version}".format(
+            extra_jar_version = scala_version_extra_jars["org_scala_lang_scalap"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["org_scala_lang_scalap"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
@@ -167,10 +334,12 @@ def scalafmt_repositories(maven_servers = _default_maven_server_urls()):
     )
 
     _scala_maven_import_external(
-        name = "com_thesamet_scalapb_lenses_2_11",
-        artifact = "com.thesamet.scalapb:lenses_2.11:0.9.0",
-        artifact_sha256 = "f4809760edee6abc97a7fe9b7fd6ae5fe1006795b1dc3963ab4e317a72f1a385",
-        srcjar_sha256 = "57753e022b607b63a4f60a4570fbd1e524ffc76f389a444033cdea5e83424402",
+        name = "com_thesamet_scalapb_lenses",
+        artifact = "com.thesamet.scalapb:lenses_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_thesamet_scalapb_lenses"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_thesamet_scalapb_lenses"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
@@ -180,68 +349,78 @@ def scalafmt_repositories(maven_servers = _default_maven_server_urls()):
     )
 
     _scala_maven_import_external(
-        name = "com_thesamet_scalapb_scalapb_runtime_2_11",
-        artifact = "com.thesamet.scalapb:scalapb-runtime_2.11:0.9.0",
-        artifact_sha256 = "ab1e449a18a9ce411eb3fec31bdbca5dd5fae4475b1557bb5e235a7b54738757",
-        srcjar_sha256 = "41d3c78eac7f4cadc9a785539a29730aa78432b110975ab857656804b4ca0344",
+        name = "com_thesamet_scalapb_scalapb_runtime",
+        artifact = "com.thesamet.scalapb:scalapb-runtime_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_thesamet_scalapb_scalapb_runtime"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_thesamet_scalapb_scalapb_runtime"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
             "@com_google_protobuf_protobuf_java",
-            "@com_lihaoyi_fastparse_2_11",
-            "@com_thesamet_scalapb_lenses_2_11",
+            "@com_lihaoyi_fastparse",
+            "@com_thesamet_scalapb_lenses",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "com_lihaoyi_fansi_2_11",
-        artifact = "com.lihaoyi:fansi_2.11:0.2.5",
-        artifact_sha256 = "1ff0a8304f322c1442e6bcf28fab07abf3cf560dd24573dbe671249aee5fc488",
-        srcjar_sha256 = "960df264aac81442d68bfdee9385a8af3e38e979bd568a3f9477de9e978f6d24",
+        name = "com_lihaoyi_fansi",
+        artifact = "com.lihaoyi:fansi_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_lihaoyi_fansi"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_lihaoyi_fansi"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_sourcecode_2_11",
+            "@com_lihaoyi_sourcecode",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "com_lihaoyi_fastparse_2_11",
-        artifact = "com.lihaoyi:fastparse_2.11:2.1.2",
-        artifact_sha256 = "5c5d81f90ada03ac5b21b161864a52558133951031ee5f6bf4d979e8baa03628",
-        srcjar_sha256 = "1f4509b44b9de440400b949993277d22440033bf42425f93f5b13b94dc41f63b",
+        name = "com_lihaoyi_fastparse",
+        artifact = "com.lihaoyi:fastparse_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_lihaoyi_fastparse"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_lihaoyi_fastparse"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_sourcecode_2_11",
+            "@com_lihaoyi_sourcecode",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "com_lihaoyi_pprint_2_11",
-        artifact = "com.lihaoyi:pprint_2.11:0.5.3",
-        artifact_sha256 = "fb5e4921e7dff734d049e752a482d3a031380d3eea5caa76c991312dee9e6991",
-        srcjar_sha256 = "99bf854d4e5495161ec9bc6d3bb8d0c274973c0f7c607151c4848c1f85b6c82e",
+        name = "com_lihaoyi_pprint",
+        artifact = "com.lihaoyi:pprint_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_lihaoyi_pprint"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_lihaoyi_pprint"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_fansi_2_11",
-            "@com_lihaoyi_sourcecode_2_11",
+            "@com_lihaoyi_fansi",
+            "@com_lihaoyi_sourcecode",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "com_lihaoyi_sourcecode_2_11",
-        artifact = "com.lihaoyi:sourcecode_2.11:0.1.4",
-        artifact_sha256 = "e0edffec93ddef29c40b7c65580960062a3fa9d781eddb8c64e19e707c4a8e7c",
-        srcjar_sha256 = "b6a282beaca27092692197c017cbd349dccf526100af1bbd7f78cf462219f7f9",
+        name = "com_lihaoyi_sourcecode",
+        artifact = "com.lihaoyi:sourcecode_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_lihaoyi_sourcecode"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_lihaoyi_sourcecode"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
@@ -261,29 +440,33 @@ def scalafmt_repositories(maven_servers = _default_maven_server_urls()):
     )
 
     _scala_maven_import_external(
-        name = "com_geirsson_metaconfig_core_2_11",
-        artifact = "com.geirsson:metaconfig-core_2.11:0.8.3",
-        artifact_sha256 = "8abb4e48507486d0b323b440bb021bddd56366e502002025fdaf10025d2650c2",
-        srcjar_sha256 = "5a4a2e1ec9153f79ae2747172b1ec4596b8a7788c7ac7bc3aed2b698dc0594a1",
+        name = "com_geirsson_metaconfig_core",
+        artifact = "com.geirsson:metaconfig-core_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_geirsson_metaconfig_core"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_geirsson_metaconfig_core"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_lihaoyi_pprint_2_11",
+            "@com_lihaoyi_pprint",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
-            "@org_typelevel_paiges_core_2_11",
+            "@org_typelevel_paiges_core",
         ],
         server_urls = maven_servers,
     )
 
     _scala_maven_import_external(
-        name = "com_geirsson_metaconfig_typesafe_config_2_11",
-        artifact = "com.geirsson:metaconfig-typesafe-config_2.11:0.8.3",
-        artifact_sha256 = "410c29b2ebc842591627588d8980df507dc0eb48a0a7df312fa529fa0fe90d42",
-        srcjar_sha256 = "494109a773bb4470cb2f2b31831eb7582acbf30e1f0db3a88362f69ebd55a854",
+        name = "com_geirsson_metaconfig_typesafe_config",
+        artifact = "com.geirsson:metaconfig-typesafe-config_{major_version}:{extra_jar_version}".format(
+            major_version = major_version,
+            extra_jar_version = scala_version_extra_jars["com_geirsson_metaconfig_typesafe_config"]["version"],
+        ),
+        artifact_sha256 = scala_version_extra_jars["com_geirsson_metaconfig_typesafe_config"]["sha256"],
         fetch_sources = True,
         licenses = ["notice"],  # Apache 2.0
         deps = [
-            "@com_geirsson_metaconfig_core_2_11",
+            "@com_geirsson_metaconfig_core",
             "@com_typesafe_config",
             "//external:io_bazel_rules_scala/dependency/scala/scala_library",
         ],


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Scalafmt supports Scala 2.12.

I also upgrade the Scalafmt version to `2.3.2`.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Users should be able to run formatting on Scala 2.12.