### PR TITLE
update to the latest worker protobuf file

### DIFF
--- a/third_party/bazel/src/main/protobuf/worker_protocol.proto
+++ b/third_party/bazel/src/main/protobuf/worker_protocol.proto
@@ -38,14 +38,25 @@ message WorkRequest {
   // The inputs that the worker is allowed to read during execution of this
   // request.
   repeated Input inputs = 2;
+
+  // To support multiplex worker, each WorkRequest must have an unique ID. This
+  // ID should be attached unchanged to the WorkResponse.
+  int32 request_id = 3;
 }
 
-// The worker sends this message to Blaze when it finished its work on the WorkRequest message.
+// The worker sends this message to Blaze when it finished its work on the
+// WorkRequest message.
 message WorkResponse {
   int32 exit_code = 1;
 
-  // This is printed to the user after the WorkResponse has been received and is supposed to contain
-  // compiler warnings / errors etc. - thus we'll use a string type here, which gives us UTF-8
-  // encoding.
+  // This is printed to the user after the WorkResponse has been received and is
+  // supposed to contain compiler warnings / errors etc. - thus we'll use a
+  // string type here, which gives us UTF-8 encoding.
   string output = 2;
+
+  // To support multiplex worker, each WorkResponse must have an unique ID.
+  // Since worker processes which support multiplex worker will handle multiple
+  // WorkRequests in parallel, this ID will be used to determined which
+  // WorkerProxy does this WorkResponse belong to.
+  int32 request_id = 3;
 }


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Updates our copy of the worker protobuf file from ~https://github.com/bazelbuild/rules_scala/blob/master/third_party/bazel/src/main/protobuf/worker_protocol.proto~ https://github.com/bazelbuild/bazel/blob/master/src/main/protobuf/worker_protocol.proto.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
The worker protobuf protocol has been updated to support multiplexing workers which can handle multiple concurrent requests in a single process. We can eventually leverage this to support parallel Scalac unit compilation without running extra JVM processes.
