### PR TITLE
Report macros as used

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -93,6 +93,19 @@ class AstUsedJarFinder(
         case _ =>
       }
 
+      // If this expression is the result of a macro, then we
+      // should also examine the original macro expression
+      tree.attachments
+        .get[global.treeChecker.MacroExpansionAttachment]
+        .foreach { attach =>
+          // When we explore the original, the original also has
+          // this attachment. So we should not examine the original
+          // again if so.
+          if (attach.expandee != tree) {
+            fullyExploreTree(attach.expandee)
+          }
+        }
+
       val shouldExamine =
         tree match {
           case select: Select if select.symbol.isDefaultGetter =>

--- a/third_party/dependency_analyzer/src/test/BUILD
+++ b/third_party/dependency_analyzer/src/test/BUILD
@@ -5,6 +5,7 @@ load("//scala:scala.bzl", "scala_junit_test", "scala_test")
 common_jvm_flags = [
     "-Dplugin.jar.location=$(location //third_party/dependency_analyzer/src/main:dependency_analyzer)",
     "-Dscala.library.location=$(location //external:io_bazel_rules_scala/dependency/scala/scala_library)",
+    "-Dscala.reflect.location=$(location //external:io_bazel_rules_scala/dependency/scala/scala_reflect)",
 ]
 
 scala_test(

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -395,6 +395,32 @@ class AstUsedJarFinderTest extends FunSuite {
     )
   }
 
+  test("macro is direct") {
+    checkDirectDependencyRecognized(
+      aCode =
+        s"""
+           |import scala.language.experimental.macros
+           |import scala.reflect.macros.blackbox.Context
+           |
+           |object A {
+           |  def foo(): Unit = macro fooImpl
+           |  def fooImpl(
+           |    c: Context
+           |  )(): c.universe.Tree = {
+           |    import c.universe._
+           |    q""
+           |  }
+           |}
+           |""".stripMargin,
+      bCode =
+        s"""
+           |object B {
+           |  A.foo()
+           |}
+           |""".stripMargin
+    )
+  }
+
   test("java interface method argument is direct") {
     withSandbox { sandbox =>
       sandbox.compileJava(

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
@@ -65,8 +65,8 @@ object TestUtil {
 
   private def getClasspathArguments(extraClasspath: List[String]): String = {
     val classpathEntries = {
-      val toolboxClasspathOpt = if (toolboxClasspath.isEmpty) { None } else Some(toolboxClasspath)
-      extraClasspath ++ toolboxClasspathOpt
+      val builtinClassPaths = builtinClasspaths.filterNot(_.isEmpty)
+      extraClasspath ++ builtinClassPaths
     }
     if (classpathEntries.isEmpty) {
       ""
@@ -131,8 +131,11 @@ object TestUtil {
 
   private lazy val baseDir = System.getProperty("user.dir")
 
-  private lazy val toolboxClasspath: String =
-    pathOf("scala.library.location")
+  private lazy val builtinClasspaths: Vector[String] =
+    Vector(
+      pathOf("scala.library.location"),
+      pathOf("scala.reflect.location")
+    )
 
   lazy val guavaClasspath: String =
     pathOf("guava.jar.location")


### PR DESCRIPTION
### Description
In the dependency analyzer ast-mode, we now report macros as used.

### Motivation
If a macro is used then the macro should be considered a strict dep for obvious reasons.

Relates to https://github.com/bazelbuild/rules_scala/issues/679