### PR TITLE
Don't unnecessarily use fullyExploreTree

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -33,11 +33,6 @@ class AstUsedJarFinder(
       tpe.typeArgs.foreach(exploreType(_, pos))
     }
 
-    def fullyExploreTree(tree: Tree): Unit = {
-      exploreTree(tree)
-      tree.foreach(exploreTree)
-    }
-
     def exploreClassfileAnnotArg(arg: ClassfileAnnotArg, pos: Position): Unit = {
       arg match {
         case LiteralAnnotArg(value) =>
@@ -68,64 +63,68 @@ class AstUsedJarFinder(
       }
     }
 
-    def exploreTree(tree: Tree): Unit = {
-      tree match {
-        case node: TypeTree =>
-          if (node.original != null) {
-            node.original.foreach(fullyExploreTree)
-          }
-        case node: Literal =>
-          // We should examine OriginalTreeAttachment but that was only
-          // added in 2.12.4, so include a version check
-          ScalaVersion.conditional(
-            Some("2.12.4"),
-            None,
-            """
+    def fullyExploreTree(tree: Tree): Unit = {
+      def visitNode(tree: Tree): Unit = {
+        tree match {
+          case node: TypeTree =>
+            if (node.original != null) {
+              fullyExploreTree(node.original)
+            }
+          case node: Literal =>
+            // We should examine OriginalTreeAttachment but that was only
+            // added in 2.12.4, so include a version check
+            ScalaVersion.conditional(
+              Some("2.12.4"),
+              None,
+              """
               node.attachments
                 .get[global.treeChecker.OriginalTreeAttachment]
                 .foreach { attach =>
                   fullyExploreTree(attach.original)
                 }
             """
-          )
+            )
 
-          exploreConstant(node.value, tree.pos)
-        case _ =>
-      }
-
-      val shouldExamine =
-        tree match {
-          case select: Select if select.symbol.isDefaultGetter =>
-            false
+            exploreConstant(node.value, tree.pos)
           case _ =>
-            true
         }
 
-      if (shouldExamine) {
-        if (tree.hasSymbolField) {
-          tree.symbol.annotations
-            // We skip annotations without positions. The reason for
-            // this is the case of
-            //   @SomeAnnotation class A
-            //   class B extends A
-            // Now assuming A and B are in separate packages, while
-            // examining B we will examine A as well, and hence
-            // examine A's annotations. However we don't wish to examine
-            // A's annotations as we don't care about those details of A.
-            // Hence we only examine annotations with positions (hence,
-            // they were defined in the same compilation unit and thus
-            // matter).
-            .filter(_.pos.isDefined)
-            .foreach(exploreAnnotationInfo)
-        }
-        if (tree.tpe != null) {
-          exploreType(tree.tpe, tree.pos)
+        val shouldExamine =
+          tree match {
+            case select: Select if select.symbol.isDefaultGetter =>
+              false
+            case _ =>
+              true
+          }
+
+        if (shouldExamine) {
+          if (tree.hasSymbolField) {
+            tree.symbol.annotations
+              // We skip annotations without positions. The reason for
+              // this is the case of
+              //   @SomeAnnotation class A
+              //   class B extends A
+              // Now assuming A and B are in separate packages, while
+              // examining B we will examine A as well, and hence
+              // examine A's annotations. However we don't wish to examine
+              // A's annotations as we don't care about those details of A.
+              // Hence we only examine annotations with positions (hence,
+              // they were defined in the same compilation unit and thus
+              // matter).
+              .filter(_.pos.isDefined)
+              .foreach(exploreAnnotationInfo)
+          }
+          if (tree.tpe != null) {
+            exploreType(tree.tpe, tree.pos)
+          }
         }
       }
+
+      tree.foreach(visitNode)
     }
 
     currentRun.units.foreach { unit =>
-      unit.body.foreach(fullyExploreTree)
+      fullyExploreTree(unit.body)
     }
     jars.toMap
   }


### PR DESCRIPTION
### Description
We remove unnecessary usage of foreach with fullyExploreTree in the AST used jar finder and simplify the interface.

### Motivation
In two places in the code we were calling `Tree.foreach(fullyExploreTree)`. This is redundant because `fullyExploreTree` calls `foreach` on the tree already. So we change those usages to just `fullyExploreTree(Tree)`.

We also change `fullyExploreTree` to not call `exploreTree` on its parameter, because this is redundant with `tree.foreach`.

Nobody should be calling `exploreTree` as it only partially explores the tree and everyone should just be fully exploring the tree, so we move `exploreTree` into `fullyExploreTree` and rename it `visitNode` (which is still not the best of names).