### PR TITLE
toolchain which turns on coverage is part of API

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ to your command line, or to enable by default for building/testing add it to you
 rules_scala supports coverage, but it's disabled by default. You need to enable it with an extra toolchain:
 
 ```
-bazel coverage --extra_toolchains="@io_bazel_rules_scala//test/coverage:enable_code_coverage_aspect" //...
+bazel coverage --extra_toolchains="@io_bazel_rules_scala//scala:code_coverage_toolchain" //...
 ```
 
 It will produce several .dat files with results for your targets.
@@ -97,7 +97,7 @@ You can also add more options to receive a combined coverage report:
 
 ```
 bazel coverage \
-  --extra_toolchains="@io_bazel_rules_scala//test/coverage:enable_code_coverage_aspect" \
+  --extra_toolchains="@io_bazel_rules_scala//scala:code_coverage_toolchain" \
   --combined_report=lcov \
   --coverage_report_generator="@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main" \
   //...

--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -5,7 +5,7 @@
 rules_scala supports coverage, but it's disabled by default. You need to enable it with an extra toolchain:
 
 ```
-bazel coverage --extra_toolchains="@io_bazel_rules_scala//test/coverage:enable_code_coverage_aspect" //...
+bazel coverage --extra_toolchains="@io_bazel_rules_scala//scala:code_coverage_toolchain" //...
 ```
 
 It will produce several .dat files with results for your targets.
@@ -14,7 +14,7 @@ You can also add more options to receive a combined coverage report:
 
 ```
 bazel coverage \
-  --extra_toolchains="@io_bazel_rules_scala//test/coverage:enable_code_coverage_aspect" \
+  --extra_toolchains="@io_bazel_rules_scala//scala:code_coverage_toolchain" \
   --combined_report=lcov \
   --coverage_report_generator="@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main" \
   //...

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -36,6 +36,19 @@ toolchain(
     visibility = ["//visibility:public"],
 )
 
+scala_toolchain(
+    name = "code_coverage_toolchain_impl",
+    enable_code_coverage_aspect = "on",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "code_coverage_toolchain",
+    toolchain = "code_coverage_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 java_import(
     name = "bazel_test_runner_deploy",
     jars = ["@bazel_tools//tools/jdk:TestRunner_deploy.jar"],

--- a/test/coverage/BUILD
+++ b/test/coverage/BUILD
@@ -2,19 +2,6 @@ load("@rules_java//java:defs.bzl", "java_library", "java_test")
 load("//scala:scala.bzl", "scala_library", "scala_test")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
-scala_toolchain(
-    name = "enable_code_coverage_aspect_impl",
-    enable_code_coverage_aspect = "on",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "enable_code_coverage_aspect",
-    toolchain = "enable_code_coverage_aspect_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
 scala_test(
     name = "test-all",
     srcs = [

--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -119,7 +119,7 @@ test_override_javabin() {
 
 test_coverage_on() {
     bazel coverage \
-          --extra_toolchains="//test/coverage:enable_code_coverage_aspect" \
+          --extra_toolchains="//scala:code_coverage_toolchain" \
           //test/coverage/...
     diff test/coverage/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
 }


### PR DESCRIPTION
### Description
toolchain which turns on coverage is part of API

### Motivation
followup on #1017 
Don't want documentation to point to test code which can easily change and break