### PR TITLE
Remove plus_one_deps_mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,6 @@ We recommend turning on strict_deps_mode first, as rule `A` might have an entry 
 
 There are a few deprecated configuration methods which we will be removing in the near future.
 
-- `plus_one_deps_mode = "on"` on the scala toolchain. Instead, set `dependency_mode = "plus-one"` on the scala toolchain. `plus_one_deps_mode` will be removed in the future.
 - The command line argument `--strict_java_deps=WARN/ERROR`. Instead, set `dependency_mode = "transitive"` on the scala toolchain, and if only a warning is desired set `strict_deps_mode = "warn"` on the toolchain. In the future, `strict_java_deps` will no longer affect how scala files are compiled. Note that `strict_java_deps` will still control java compilation.
 
 ## Advanced configurable rules

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -3,12 +3,6 @@ load(
     _ScalacProvider = "ScalacProvider",
 )
 
-def _compute_dependency_mode(input_dependency_mode):
-    if input_dependency_mode == "":
-        return "direct"
-
-    return input_dependency_mode
-
 def _compute_strict_deps_mode(input_strict_deps_mode, dependency_mode):
     if dependency_mode == "direct":
         return "off"
@@ -31,9 +25,7 @@ def _scala_toolchain_impl(ctx):
         unused_dependency_checker_mode = "off"
         dependency_tracking_method = "high-level"
     else:
-        dependency_mode = _compute_dependency_mode(
-            ctx.attr.dependency_mode
-        )
+        dependency_mode = ctx.attr.dependency_mode
         strict_deps_mode = _compute_strict_deps_mode(
             ctx.attr.strict_deps_mode,
             dependency_mode,
@@ -74,7 +66,8 @@ scala_toolchain = rule(
             providers = [_ScalacProvider],
         ),
         "dependency_mode": attr.string(
-            values = ["direct", "plus-one", "transitive", ""],
+            default = "direct",
+            values = ["direct", "plus-one", "transitive"],
         ),
         "strict_deps_mode": attr.string(
             default = "default",

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -3,10 +3,7 @@ load(
     _ScalacProvider = "ScalacProvider",
 )
 
-def _compute_dependency_mode(input_dependency_mode, input_plus_one_deps_mode):
-    if input_plus_one_deps_mode == "on":
-        return "plus-one"
-
+def _compute_dependency_mode(input_dependency_mode):
     if input_dependency_mode == "":
         return "direct"
 
@@ -28,14 +25,6 @@ def _compute_dependency_tracking_method(input_dependency_tracking_method):
     return input_dependency_tracking_method
 
 def _scala_toolchain_impl(ctx):
-    if ctx.attr.plus_one_deps_mode != "":
-        print(
-            "Setting plus_one_deps_mode on toolchain is deprecated." +
-            "Use 'dependency_mode = \"plus-one\"' instead",
-        )
-    if ctx.attr.dependency_mode != "" and ctx.attr.plus_one_deps_mode != "":
-        fail("Cannot set both dependency_mode and plus_one_deps_mode on toolchain")
-
     if ctx.fragments.java.strict_java_deps != "default" and ctx.fragments.java.strict_java_deps != "off":
         dependency_mode = "transitive"
         strict_deps_mode = ctx.fragments.java.strict_java_deps
@@ -43,8 +32,7 @@ def _scala_toolchain_impl(ctx):
         dependency_tracking_method = "high-level"
     else:
         dependency_mode = _compute_dependency_mode(
-            ctx.attr.dependency_mode,
-            ctx.attr.plus_one_deps_mode,
+            ctx.attr.dependency_mode
         )
         strict_deps_mode = _compute_strict_deps_mode(
             ctx.attr.strict_deps_mode,
@@ -99,9 +87,6 @@ scala_toolchain = rule(
         "dependency_tracking_method": attr.string(
             default = "default",
             values = ["ast", "high-level", "default"],
-        ),
-        "plus_one_deps_mode": attr.string(
-            values = ["off", "on", ""],
         ),
         "enable_code_coverage_aspect": attr.string(
             default = "off",

--- a/test_expect_failure/plus_one_deps/BUILD.bazel
+++ b/test_expect_failure/plus_one_deps/BUILD.bazel
@@ -2,7 +2,7 @@ load("//scala:scala_toolchain.bzl", "scala_toolchain")
 
 scala_toolchain(
     name = "plus_one_deps_impl",
-    plus_one_deps_mode = "on",
+    dependency_mode = "plus-one",
     visibility = ["//visibility:public"],
 )
 
@@ -15,7 +15,7 @@ toolchain(
 
 scala_toolchain(
     name = "plus_one_deps_with_unused_error_impl",
-    plus_one_deps_mode = "on",
+    dependency_mode = "plus-one",
     unused_dependency_checker_mode = "error",
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### Description
We remove `plus_one_deps_mode` from the toolchain, as it has been superseded by `dependency_checker_mode`.

### Motivation
We remove a deprecated construct since a sufficiently long period of time has passed.
