### PR TITLE
Add fetch_source parameter to scala_repositories

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -17,7 +17,7 @@ buildifier_dependencies()
 
 load("//scala:scala.bzl", "scala_repositories")
 
-scala_repositories()
+scala_repositories(fetch_sources = True)
 
 load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//scala:scala_maven_import_external.bzl", "scala_maven_import_external")

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -58,7 +58,8 @@ def scala_repositories(
             _default_scala_version_jar_shas(),
         ),
         maven_servers = _default_maven_server_urls(),
-        scala_extra_jars = _default_scala_extra_jars()):
+        scala_extra_jars = _default_scala_extra_jars(),
+        fetch_sources = False):
     (scala_version, scala_version_jar_shas) = scala_version_shas
     major_version = _extract_major_version(scala_version)
 
@@ -66,6 +67,7 @@ def scala_repositories(
         maven_servers = maven_servers,
         scala_version = scala_version,
         scala_version_jar_shas = scala_version_jar_shas,
+        fetch_sources = fetch_sources,
     )
 
     scala_version_extra_jars = scala_extra_jars[major_version]
@@ -79,6 +81,7 @@ def scala_repositories(
         artifact_sha256 = scala_version_extra_jars["scalatest"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_scalactic",
@@ -89,6 +92,7 @@ def scala_repositories(
         artifact_sha256 = scala_version_extra_jars["scalactic"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     _scala_maven_import_external(
@@ -100,6 +104,7 @@ def scala_repositories(
         artifact_sha256 = scala_version_extra_jars["scala_xml"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     _scala_maven_import_external(
@@ -112,6 +117,7 @@ def scala_repositories(
         artifact_sha256 = scala_version_extra_jars["scala_parser_combinators"]["sha256"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     # used by ScalacProcessor
@@ -121,6 +127,7 @@ def scala_repositories(
         artifact_sha256 = "f877d304660ac2a142f3865badfc971dec7ed73c747c7f8d5d2f5139ca736513",
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     _scala_maven_import_external(
@@ -129,6 +136,7 @@ def scala_repositories(
         artifact_sha256 = "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
 
     if not native.existing_rule("com_google_protobuf"):

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -64,13 +64,15 @@ def scala_mvn_artifact(
 def new_scala_default_repository(
         scala_version,
         scala_version_jar_shas,
-        maven_servers):
+        maven_servers,
+        fetch_sources):
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_scala_library",
         artifact = "org.scala-lang:scala-library:{}".format(scala_version),
         artifact_sha256 = scala_version_jar_shas["scala_library"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_scala_compiler",
@@ -78,6 +80,7 @@ def new_scala_default_repository(
         artifact_sha256 = scala_version_jar_shas["scala_compiler"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_scala_reflect",
@@ -85,4 +88,5 @@ def new_scala_default_repository(
         artifact_sha256 = scala_version_jar_shas["scala_reflect"],
         licenses = ["notice"],
         server_urls = maven_servers,
+        fetch_sources = fetch_sources,
     )

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -11,9 +11,12 @@ scala_version = "${scala_version}"
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
-scala_repositories((scala_version, {
-${scala_version_shas}
-}))
+scala_repositories(
+    (scala_version, {
+    ${scala_version_shas}
+    }),
+    fetch_sources = True
+)
 
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge", "scrooge_scala_library")
 


### PR DESCRIPTION
### Description
This PR exposes the fetch_sources to scala_repositories.
https://github.com/bazelbuild/rules_scala/issues/908


### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Being able to inspect sources can be really helpful to understanding how Scala works.

See more reasons: https://github.com/bazelbuild/rules_scala/issues/908