### PR TITLE
Add more tests which use ast_plus_one_deps_strict_deps_unused_deps_error toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,7 +228,7 @@ With these settings, we also will error on dependencies which are unneeded, and 
 
 The dependency tracking method `ast` is experimental but so far proves to be better than the default for computing the direct dependencies for `plus-one` mode code. In the future we hope to make this the default for `plus-one` mode and remove the option altogether.
 
-To try it out you can use the following toolchain: `//scala:ast_plus_one_deps_strict_deps_unused_deps_error`.
+To try it out you can use the following toolchain: `//scala:minimal_direct_source_deps`.
 
 ### [Experimental] Dependency mode
 

--- a/README.md
+++ b/README.md
@@ -228,6 +228,8 @@ With these settings, we also will error on dependencies which are unneeded, and 
 
 The dependency tracking method `ast` is experimental but so far proves to be better than the default for computing the direct dependencies for `plus-one` mode code. In the future we hope to make this the default for `plus-one` mode and remove the option altogether.
 
+To try it out you can use the following toolchain: `//scala:ast_plus_one_deps_strict_deps_unused_deps_error`.
+
 ### [Experimental] Dependency mode
 
 There are three dependency modes. The reason for the multiple modes is that often `scalac` depends on jars which seem unnecessary at first glance. Hence, in order to reduce the need to please `scalac`, we provide the following options.

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -37,6 +37,22 @@ toolchain(
 )
 
 scala_toolchain(
+    name = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
+    dependency_mode = "plus-one",
+    dependency_tracking_method = "ast",
+    strict_deps_mode = "error",
+    unused_dependency_checker_mode = "error",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "ast_plus_one_deps_strict_deps_unused_deps_error",
+    toolchain = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+scala_toolchain(
     name = "code_coverage_toolchain_impl",
     enable_code_coverage_aspect = "on",
     visibility = ["//visibility:public"],

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -46,7 +46,7 @@ scala_toolchain(
 )
 
 toolchain(
-    name = "ast_plus_one_deps_strict_deps_unused_deps_error",
+    name = "minimal_direct_source_deps",
     toolchain = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
     toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],

--- a/src/java/io/bazel/rulesscala/specs2/BUILD
+++ b/src/java/io/bazel/rulesscala/specs2/BUILD
@@ -7,6 +7,9 @@ scala_library(
         "Specs2RunnerBuilder.scala",
         "package.scala",
     ],
+    unused_dependency_checker_ignored_targets = [
+        "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//external:io_bazel_rules_scala/dependency/junit/junit",
@@ -14,8 +17,5 @@ scala_library(
         "//external:io_bazel_rules_scala/dependency/specs2/specs2",
         "//external:io_bazel_rules_scala/dependency/specs2/specs2_junit",
         "//src/java/io/bazel/rulesscala/test_discovery",
-    ],
-    unused_dependency_checker_ignored_targets = [
-        "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
     ],
 )

--- a/src/java/io/bazel/rulesscala/specs2/BUILD
+++ b/src/java/io/bazel/rulesscala/specs2/BUILD
@@ -15,4 +15,7 @@ scala_library(
         "//external:io_bazel_rules_scala/dependency/specs2/specs2_junit",
         "//src/java/io/bazel/rulesscala/test_discovery",
     ],
+    unused_dependency_checker_ignored_targets = [
+        "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
+    ],
 )

--- a/src/scala/scripts/BUILD
+++ b/src/scala/scripts/BUILD
@@ -45,6 +45,9 @@ scala_library(
         "//src/java/io/bazel/rulesscala/jar",
         "//src/java/io/bazel/rulesscala/worker",
     ],
+    unused_dependency_checker_ignored_targets = [
+        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
+    ],
 )
 
 scala_binary(

--- a/src/scala/scripts/BUILD
+++ b/src/scala/scripts/BUILD
@@ -31,6 +31,9 @@ scala_library(
 scala_library(
     name = "scalapb_generator_lib",
     srcs = ["ScalaPBGenerator.scala"],
+    unused_dependency_checker_ignored_targets = [
+        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
+    ],
     visibility = ["//visibility:public"],
     runtime_deps = [
         "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
@@ -44,9 +47,6 @@ scala_library(
         "//src/java/io/bazel/rulesscala/io_utils",
         "//src/java/io/bazel/rulesscala/jar",
         "//src/java/io/bazel/rulesscala/worker",
-    ],
-    unused_dependency_checker_ignored_targets = [
-        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
     ],
 )
 

--- a/test/shell/test_deps.sh
+++ b/test/shell/test_deps.sh
@@ -50,7 +50,7 @@ test_plus_one_ast_analyzer_strict_deps() {
   expected_message_error="error: Target '$dependenecy_target' is used but isn't explicitly declared, please add it to the deps"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_error}" ${test_target} "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error" "eq"
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_error}" ${test_target} "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_unused_deps_error" "eq"
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_error}" ${test_target} "--extra_toolchains=//scala:ast_plus_one_deps_strict_deps_unused_deps_error" "eq"
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_warn}" ${test_target} "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_warn" "ne"
 }
 

--- a/test/shell/test_deps.sh
+++ b/test/shell/test_deps.sh
@@ -50,7 +50,7 @@ test_plus_one_ast_analyzer_strict_deps() {
   expected_message_error="error: Target '$dependenecy_target' is used but isn't explicitly declared, please add it to the deps"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_error}" ${test_target} "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error" "eq"
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_error}" ${test_target} "--extra_toolchains=//scala:ast_plus_one_deps_strict_deps_unused_deps_error" "eq"
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_error}" ${test_target} "--extra_toolchains=//scala:minimal_direct_source_deps" "eq"
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message_warn}" ${test_target} "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_warn" "ne"
 }
 

--- a/test/shell/test_unused_dependency.sh
+++ b/test/shell/test_unused_dependency.sh
@@ -56,7 +56,7 @@ test_plus_one_ast_analyzer_unused_deps_error() {
 }
 
 test_plus_one_ast_analyzer_unused_deps_strict_deps_error() {
-  action_should_fail build --extra_toolchains="//scala:ast_plus_one_deps_strict_deps_unused_deps_error" //test_expect_failure/plus_one_deps/with_unused_deps:a
+  action_should_fail build --extra_toolchains="//scala:minimal_direct_source_deps" //test_expect_failure/plus_one_deps/with_unused_deps:a
 }
 
 test_plus_one_ast_analyzer_unused_deps_warn() {

--- a/test/shell/test_unused_dependency.sh
+++ b/test/shell/test_unused_dependency.sh
@@ -56,7 +56,7 @@ test_plus_one_ast_analyzer_unused_deps_error() {
 }
 
 test_plus_one_ast_analyzer_unused_deps_strict_deps_error() {
-  action_should_fail build --extra_toolchains="//test/toolchains:ast_plus_one_deps_strict_deps_unused_deps_error" //test_expect_failure/plus_one_deps/with_unused_deps:a
+  action_should_fail build --extra_toolchains="//scala:ast_plus_one_deps_strict_deps_unused_deps_error" //test_expect_failure/plus_one_deps/with_unused_deps:a
 }
 
 test_plus_one_ast_analyzer_unused_deps_warn() {

--- a/test/src/main/scala/scalarules/test/srcjars_with_java/BUILD
+++ b/test/src/main/scala/scalarules/test/srcjars_with_java/BUILD
@@ -10,8 +10,8 @@ scala_library(
 scala_library(
     name = "mixed_language_dependent",
     srcs = ["MixedLanguageDependent.scala"],
-    deps = [":mixed_language_source_jar"],
     unused_dependency_checker_ignored_targets = [":mixed_language_source_jar"],
+    deps = [":mixed_language_source_jar"],
 )
 
 scala_library(
@@ -24,6 +24,6 @@ scala_library(
 scala_library(
     name = "java_dependent",
     srcs = ["JavaDependent.scala"],
-    deps = [":java_source_jar"],
     unused_dependency_checker_ignored_targets = [":java_source_jar"],
+    deps = [":java_source_jar"],
 )

--- a/test/src/main/scala/scalarules/test/srcjars_with_java/BUILD
+++ b/test/src/main/scala/scalarules/test/srcjars_with_java/BUILD
@@ -11,6 +11,7 @@ scala_library(
     name = "mixed_language_dependent",
     srcs = ["MixedLanguageDependent.scala"],
     deps = [":mixed_language_source_jar"],
+    unused_dependency_checker_ignored_targets = [":mixed_language_source_jar"],
 )
 
 scala_library(
@@ -24,4 +25,5 @@ scala_library(
     name = "java_dependent",
     srcs = ["JavaDependent.scala"],
     deps = [":java_source_jar"],
+    unused_dependency_checker_ignored_targets = [":java_source_jar"],
 )

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -59,19 +59,3 @@ toolchain(
     toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
-
-scala_toolchain(
-    name = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
-    dependency_mode = "plus-one",
-    dependency_tracking_method = "ast",
-    strict_deps_mode = "error",
-    unused_dependency_checker_mode = "error",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "ast_plus_one_deps_strict_deps_unused_deps_error",
-    toolchain = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-    visibility = ["//visibility:public"],
-)

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -18,10 +18,10 @@ $runner bazel test test/...
 $runner bazel test third_party/...
 # UnusedDependencyChecker doesn't work with strict_java_deps
 $runner bazel build "--strict_java_deps=ERROR -- test/... -test:UnusedDependencyChecker"
-$runner bazel build "--extra_toolchains=//scala:ast_plus_one_deps_strict_deps_unused_deps_error -- test/... -test:UnusedDependencyChecker"
+$runner bazel build "--extra_toolchains=//scala:minimal_direct_source_deps -- test/... -test:UnusedDependencyChecker"
 #$runner bazel build "--strict_java_deps=ERROR --all_incompatible_changes -- test/... -test:UnusedDependencyChecker"
 $runner bazel test "--strict_java_deps=ERROR -- test/... -test:UnusedDependencyChecker"
-$runner bazel test "--extra_toolchains=//scala:ast_plus_one_deps_strict_deps_unused_deps_error -- test/... -test:UnusedDependencyChecker"
+$runner bazel test "--extra_toolchains=//scala:minimal_direct_source_deps -- test/... -test:UnusedDependencyChecker"
 $runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn"
 $runner bazel build //test_expect_failure/proto_source_root/... --strict_proto_deps=off
 $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -18,8 +18,10 @@ $runner bazel test test/...
 $runner bazel test third_party/...
 # UnusedDependencyChecker doesn't work with strict_java_deps
 $runner bazel build "--strict_java_deps=ERROR -- test/... -test:UnusedDependencyChecker"
+$runner bazel build "--extra_toolchains=//scala:ast_plus_one_deps_strict_deps_unused_deps_error -- test/... -test:UnusedDependencyChecker"
 #$runner bazel build "--strict_java_deps=ERROR --all_incompatible_changes -- test/... -test:UnusedDependencyChecker"
 $runner bazel test "--strict_java_deps=ERROR -- test/... -test:UnusedDependencyChecker"
+$runner bazel test "--extra_toolchains=//scala:ast_plus_one_deps_strict_deps_unused_deps_error -- test/... -test:UnusedDependencyChecker"
 $runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn"
 $runner bazel build //test_expect_failure/proto_source_root/... --strict_proto_deps=off
 $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"


### PR DESCRIPTION
### Description
`ast_plus_one_deps_strict_deps_unused_deps_error` toolchain has more coverage and first class


This PR moves `//scala:ast_plus_one_deps_strict_deps_unused_deps_error` toolchain to the prod section since we now promote it as the alternative but leave users up to stitching everything themselves. I also added reference to it in the readme.
Additionally it builds and tests `test/...` with this toolchain to surface issues like #1029.


### Motivation
Better coverage for AST and other combo and better alignment with our approach.

### Open issues
1. Should we choose a more concise name for the toolchain? Right now it's honest and complete but I'm not sure we should stick to it (wasn't sure what the abstraction is OTOH).
2. I needed to add quite a few `unused_dependency_checker_ignored_targets` exclusions to get the build passing. I'd really love for us to understand if they are working as intended, bugs we can fix or bugs we'll have to live with.
We might be able to merge this PR even with these exclusions but I'm willing to do that only if it's clear who's owning the rest of the inquiry.