### PR TITLE
fixes after scalapb upgrade

### DIFF
--- a/scala_proto/private/scala_proto_default_repositories.bzl
+++ b/scala_proto/private/scala_proto_default_repositories.bzl
@@ -133,7 +133,7 @@ def scala_proto_default_repositories(
     _scala_maven_import_external(
         name = "scala_proto_rules_scalapb_fastparse",
         artifact = _scala_mvn_artifact(
-            "com.lihaoyi:fastparse:" + "2.1.2" if int(scala_version.split(".")[1]) < 12 else "2.1.3",
+            "com.lihaoyi:fastparse:" + ("2.1.2" if int(scala_version.split(".")[1]) < 12 else "2.1.3"),
             major_version,
         ),
         artifact_sha256 = scala_version_jar_shas["scalapb_fastparse"],


### PR DESCRIPTION
### Description
Reopened #1029 with only single change.

Failure happens with scala 2.12:
```
ERROR: /private/var/tmp/_bazel_darl/e51d20ff8cabb9ee5d304a36295c1184/external/io_bazel_rules_scala/scala/scala_cross_version.bzl:60:18: Traceback (most recent call last):
        File "/Users/darl/projects/backend/WORKSPACE", line 67
                scala_proto_repositories(<1 more arguments>)
        File "/private/var/tmp/_bazel_darl/e51d20ff8cabb9ee5d304a36295c1184/external/io_bazel_rules_scala/scala_proto/scala_proto.bzl", line 38, in scala_proto_repositories
                scala_proto_default_repositories(<2 more arguments>)
        File "/private/var/tmp/_bazel_darl/e51d20ff8cabb9ee5d304a36295c1184/external/io_bazel_rules_scala/scala_proto/private/scala_proto_default_repositories.bzl", line 133, in scala_proto_default_repositories
                _scala_maven_import_external(<5 more arguments>)
        File "/private/var/tmp/_bazel_darl/e51d20ff8cabb9ee5d304a36295c1184/external/io_bazel_rules_scala/scala_proto/private/scala_proto_default_repositories.bzl", line 135, in _scala_maven_import_external
                _scala_mvn_artifact(<2 more arguments>)
        File "/private/var/tmp/_bazel_darl/e51d20ff8cabb9ee5d304a36295c1184/external/io_bazel_rules_scala/scala/scala_cross_version.bzl", line 60, in _scala_mvn_artifact
                gav[1]
index out of range (index is 1, but sequence has 1 elements)
```

After "print-debugging" at appears that only `"2.1.3"` string got passed to `_scala_maven_import_external` function.
This change adds parenthesis to preserve intended precedence.
