### PR TITLE
revive test_lint fix ability

### DIFF
--- a/test_lint.sh
+++ b/test_lint.sh
@@ -1,5 +1,9 @@
 #!/usr/bin/env bash
 
 set -eou pipefail
+lint_command="${1:-check}"
+if [[ "$lint_command" == "ci" ]]; then
+    lint_command="check"
+fi
 
-./tools/bazel run //tools:buildifier@check
+./tools/bazel run //tools:buildifier@$lint_command


### PR DESCRIPTION
### Description
take lint command as an input to test_lint.sh

#826 inadvertently broke the ability to run `./test_lint.sh fix` locally by hardocding `check` as the only option. This change returns this ability to also align with the instructions in the readme.

### Motivation
Easier way to run lint fix and one that is aligned with the docs