### PR TITLE
Fix deduplication error on FocusedZipImporter

### DIFF
--- a/src/scala/io/bazel/rules_scala/scrooge_support/FocusedZipImporter.scala
+++ b/src/scala/io/bazel/rules_scala/scrooge_support/FocusedZipImporter.scala
@@ -60,6 +60,12 @@ case class FocusedZipImporter(focus: Option[File], zips: List[File], zipFiles: L
       FileContents(importer, Source.fromInputStream(zipFile.getInputStream(entry), "UTF-8").mkString, Some(entry.getName))
     }
 
+  // Instances of this class are supposed to be mergeable into MultiImporters
+  // However, MultiImporters use `toString` to deduplicate importers
+  // (reference: https://github.com/twitter/scrooge/blob/2c8db36fa38bc4450d7ce0264407c40b37a9aff6/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/Importer.scala#L213)
+  // We create a unique string representation of this instance, that takes the focus into account.
+  override def toString(): String = s"focusedZipImporter(focus=$focus,zips=${zips.mkString(":")},zipfiles=${zipFiles.mkString(":")})"
+
   private[this] def canResolve(filename: String): Boolean = resolve(filename).isDefined
 
   override def getResolvedPath(filename: String): Option[String] =

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_a/src/thrift/com/project/a/A.thrift
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_a/src/thrift/com/project/a/A.thrift
@@ -1,0 +1,5 @@
+namespace java com.project.b
+
+struct StructA {
+  1: string field
+}

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_a/src/thrift/com/project/a/BUILD
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_a/src/thrift/com/project/a/BUILD
@@ -1,0 +1,16 @@
+load("//thrift:thrift.bzl", "thrift_library")
+load("//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+
+thrift_library(
+    name = "a_thrift",
+    srcs = ["A.thrift"],
+    visibility = ["//visibility:public"],
+)
+
+scrooge_scala_library(
+    name = "d",
+    visibility = ["//visibility:public"],
+    deps = [
+        ":a_thrift",
+    ],
+)

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_b/src/thrift/com/project/b/B.thrift
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_b/src/thrift/com/project/b/B.thrift
@@ -1,0 +1,7 @@
+namespace java com.project.b
+
+include "com/project/a/A.thrift"
+
+struct StructB {
+  1: A.StructA field
+}

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_b/src/thrift/com/project/b/BUILD
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_b/src/thrift/com/project/b/BUILD
@@ -1,0 +1,20 @@
+load("//thrift:thrift.bzl", "thrift_library")
+load("//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+
+thrift_library(
+    name = "b_thrift_no_prefixes",
+    srcs = ["B.thrift"],
+    visibility = ["//visibility:public"],
+    deps = ["//test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_a/src/thrift/com/project/a:a_thrift"],
+)
+
+scrooge_scala_library(
+    name = "d",
+    visibility = ["//visibility:public"],
+    exports = [
+        "//test/src/main/scala/scalarules/test/twitter_scrooge/interproject_test/project_a/src/thrift/com/project/a:d",
+    ],
+    deps = [
+        ":b_thrift_no_prefixes",
+    ],
+)


### PR DESCRIPTION
### Description
Add a `toString` method to `FocusedZipImporter` that creates a unique representation of the instance, in order to allow `MultiImporter` to handle deduplication correctly.

When compiling thrift files with dependencies, `FocusedZipImporter`s get created and merged into a `MultiImporter` ([coderef](https://github.com/bazelbuild/rules_scala/blob/44438c6205f5c4a9bf5b9b762715b88530356ea9/src/scala/io/bazel/rules_scala/scrooge_support/Compiler.scala#L125)). However, `MultiImporter` uses `toString` to decide whether it should deduplicate importers when merging them ([coderef](https://github.com/twitter/scrooge/blob/2c8db36fa38bc4450d7ce0264407c40b37a9aff6/scrooge-generator/src/main/scala/com/twitter/scrooge/frontend/Importer.scala#L213)). Therefore, the merging of importers mentioned above had no effect.

### Motivation
I have added a folder with a reproduction of the case that doesn't work without the changes, but works with them.

Note that the test case is not using `absolute_prefixes`. It's possible that those would solve the issue, but I think this change is relevant regardless, as currently [this `+:` operation](https://github.com/bazelbuild/rules_scala/blob/44438c6205f5c4a9bf5b9b762715b88530356ea9/src/scala/io/bazel/rules_scala/scrooge_support/Compiler.scala#L125) has no effect.
