### PR TITLE
Change dependency tracking method default in some cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,9 +290,9 @@ The strict dependency tracker and unused dependency tracker need to track the us
 - `dependency_tracking_method = "high-level"` - This is the existing tracking method which has false positives and negatives but generally works reasonably well for `direct` dependency mode.
 - `dependency_tracking_method = "ast"` - This is a new tracking method which is being developed for `plus-one` and `transitive` dependency modes. It is still being developed and may have issues which need fixing. If you discover an issue, please submit a small repro of the problem.
 
-Note we intend to eventually remove this flag and use `high-level` as the method for `direct` dependency mode, and `ast` as the method for `plus-one` and `transitive` dependency modes.
+By default, `plus-one` and `transitive` dependency modes will use the `ast` dependency tracking method, while `direct` mode will use the `high-level` dependency tracking method.
 
-In the meantime, if you are using `plus-one` or `transitive` dependency modes, you can use `ast` dependency tracking mode and see how well it works for you.
+Note we intend to eventually remove this flag and make the defaults non-configurable.
 
 ### [Experimental] Turning on strict_deps_mode/unused_dependency_checker_mode
 

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -13,9 +13,14 @@ def _compute_strict_deps_mode(input_strict_deps_mode, dependency_mode):
             return "off"
     return input_strict_deps_mode
 
-def _compute_dependency_tracking_method(input_dependency_tracking_method):
+def _compute_dependency_tracking_method(
+        dependency_mode,
+        input_dependency_tracking_method):
     if input_dependency_tracking_method == "default":
-        return "high-level"
+        if dependency_mode == "direct":
+            return "high-level"
+        else:
+            return "ast"
     return input_dependency_tracking_method
 
 def _scala_toolchain_impl(ctx):
@@ -26,7 +31,10 @@ def _scala_toolchain_impl(ctx):
     )
 
     unused_dependency_checker_mode = ctx.attr.unused_dependency_checker_mode
-    dependency_tracking_method = _compute_dependency_tracking_method(ctx.attr.dependency_tracking_method)
+    dependency_tracking_method = _compute_dependency_tracking_method(
+        dependency_mode,
+        ctx.attr.dependency_tracking_method,
+    )
 
     # Final quality checks to possibly detect buggy code above
     if dependency_mode not in ("direct", "plus-one", "transitive"):


### PR DESCRIPTION
### Description
We change the default dependency tracking method to ast mode when the dependency mode is either transitive or plus-one.

### Motivation
We do this as a step in making the dependency tracking method non-configurable. This will hopefully help us find more errors in ast mode.