### PR TITLE
Move transitive dependency mode tests to use ast dependency method

### DIFF
--- a/src/java/io/bazel/rulesscala/specs2/BUILD
+++ b/src/java/io/bazel/rulesscala/specs2/BUILD
@@ -7,13 +7,9 @@ scala_library(
         "Specs2RunnerBuilder.scala",
         "package.scala",
     ],
-    unused_dependency_checker_ignored_targets = [
-        "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
-    ],
     visibility = ["//visibility:public"],
     deps = [
         "//external:io_bazel_rules_scala/dependency/junit/junit",
-        "//external:io_bazel_rules_scala/dependency/scala/scala_xml",
         "//external:io_bazel_rules_scala/dependency/specs2/specs2",
         "//external:io_bazel_rules_scala/dependency/specs2/specs2_junit",
         "//src/java/io/bazel/rulesscala/test_discovery",

--- a/test/shell/test_deps.sh
+++ b/test/shell/test_deps.sh
@@ -39,7 +39,7 @@ test_scala_import_expect_failure_on_missing_direct_deps_warn_mode() {
   local expected_message1="buildozer 'add deps $dependency_target1' //$test_target"
   local expected_message2="buildozer 'add deps $dependency_target2' //$test_target"
 
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message1}" ${test_target} "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn" "ne" "${expected_message2}"
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message1}" ${test_target} "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_warn" "ne" "${expected_message2}"
 }
 
 test_plus_one_ast_analyzer_strict_deps() {

--- a/test/shell/test_helper.sh
+++ b/test/shell/test_helper.sh
@@ -108,5 +108,5 @@ test_scala_library_expect_failure_on_missing_direct_deps() {
 
   local expected_message="buildozer 'add deps $dependenecy_target' //$test_target"
 
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_error"
 }

--- a/test/shell/test_scala_library.sh
+++ b/test/shell/test_scala_library.sh
@@ -85,7 +85,7 @@ test_scala_library_expect_failure_on_missing_direct_deps_warn_mode() {
 
   expected_message="warning: Target '$dependenecy_target' is used but isn't explicitly declared, please add it to the deps"
 
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn" "ne"
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" ${test_target} "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_warn" "ne"
 }
 
 test_scala_library_expect_failure_on_missing_direct_deps_warn_mode_java() {
@@ -107,7 +107,7 @@ test_scala_library_expect_failure_on_missing_direct_deps_off_mode() {
 test_scala_library_expect_no_recompilation_on_internal_change_of_transitive_dependency() {
   set +e
   no_recompilation_path="test/src/main/scala/scalarules/test/strict_deps/no_recompilation"
-  build_command="bazel build //$no_recompilation_path/... --subcommands --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
+  build_command="bazel build //$no_recompilation_path/... --subcommands --extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_error"
 
   echo "running initial build"
   $build_command
@@ -166,7 +166,7 @@ test_scala_library_expect_better_failure_message_on_missing_transitive_dependenc
 
   expected_message="Unknown label of file $transitive_target which came from $direct_target"
 
-  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_error"
 }
 
 $runner test_scala_library_suite

--- a/test/shell/test_unused_dependency.sh
+++ b/test/shell/test_unused_dependency.sh
@@ -39,7 +39,7 @@ test_succeeds_with_warning() {
 test_unused_dependency_checker_mode_warn() {
   # this is a hack to invalidate the cache, so that the target actually gets built and outputs warnings.
   bazel build \
-    --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn \
+    --extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_warn \
     //test:UnusedDependencyCheckerWarn
 
   test_succeeds_with_warning \

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -61,31 +61,31 @@ toolchain(
 )
 
 scala_toolchain(
-    name = "high_level_transitive_deps_strict_deps_warn_impl",
+    name = "ast_transitive_deps_strict_deps_warn_impl",
     dependency_mode = "transitive",
-    dependency_tracking_method = "high-level",
+    dependency_tracking_method = "ast",
     strict_deps_mode = "warn",
     visibility = ["//visibility:public"],
 )
 
 toolchain(
-    name = "high_level_transitive_deps_strict_deps_warn",
-    toolchain = "high_level_transitive_deps_strict_deps_warn_impl",
+    name = "ast_transitive_deps_strict_deps_warn",
+    toolchain = "ast_transitive_deps_strict_deps_warn_impl",
     toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
 scala_toolchain(
-    name = "high_level_transitive_deps_strict_deps_error_impl",
+    name = "ast_transitive_deps_strict_deps_error_impl",
     dependency_mode = "transitive",
-    dependency_tracking_method = "high-level",
+    dependency_tracking_method = "ast",
     strict_deps_mode = "error",
     visibility = ["//visibility:public"],
 )
 
 toolchain(
-    name = "high_level_transitive_deps_strict_deps_error",
-    toolchain = "high_level_transitive_deps_strict_deps_error_impl",
+    name = "ast_transitive_deps_strict_deps_error",
+    toolchain = "ast_transitive_deps_strict_deps_error_impl",
     toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -16,12 +16,12 @@ $runner bazel build test/...
 #$runner bazel build "test/... --all_incompatible_changes"
 $runner bazel test test/...
 $runner bazel test third_party/...
-$runner bazel build "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/..."
+$runner bazel build "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_error -- test/..."
 $runner bazel build "--extra_toolchains=//scala:minimal_direct_source_deps -- test/..."
-#$runner bazel build "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error --all_incompatible_changes -- test/..."
-$runner bazel test "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error -- test/..."
+#$runner bazel build "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_error --all_incompatible_changes -- test/..."
+$runner bazel test "--extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_error -- test/..."
 $runner bazel test "--extra_toolchains=//scala:minimal_direct_source_deps -- test/..."
-$runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn"
+$runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:ast_transitive_deps_strict_deps_warn"
 $runner bazel build //test_expect_failure/proto_source_root/... --strict_proto_deps=off
 $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
 . "${test_dir}"/test_build_event_protocol.sh


### PR DESCRIPTION
### Description
We change the transitive dependency mode tests to use the ast dependency method.

This allows us to use an instance of unused_dependency_checker_ignored_targets which was needed to a deficiency in the high-level analyzer.

### Motivation
As we are moving towards using the ast dependency method for transitive dependency mode, we wish to make the tests align with that. We also wish to not use `unused_dependency_checker_ignored_targets` when not necessary.