### PR TITLE
Fixes to make test_version.sh work

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,14 @@ jobs:
       env: TEST_SCRIPT=test_rules_scala BAZEL_VERSION=2.0.0
     - <<: *linux
       env: TEST_SCRIPT=test_reproducibility BAZEL_VERSION=2.0.0
+    - <<: *linux
+      env: TEST_SCRIPT=test_version BAZEL_VERSION=2.0.0
     - <<: *osx
       env: TEST_SCRIPT=test_rules_scala BAZEL_VERSION=2.0.0
     - <<: *osx
       env: TEST_SCRIPT=test_reproducibility BAZEL_VERSION=2.0.0
+    - <<: *osx
+      env: TEST_SCRIPT=test_version BAZEL_VERSION=2.0.0
 
 before_install:
   - |

--- a/test_version.sh
+++ b/test_version.sh
@@ -37,7 +37,7 @@ test_scala_version() {
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # shellcheck source=./test_runner.sh
-. "${dir}"/test_runner.sh
+. "${dir}"/test/shell/test_runner.sh
 runner=$(get_test_runner "${1:-local}")
 
 $runner test_scala_version "2.11.12" \

--- a/test_version.sh
+++ b/test_version.sh
@@ -35,6 +35,11 @@ test_scala_version() {
 
 }
 
+if ! bazel_loc="$(type -p 'bazel')" || [[ -z "$bazel_loc" ]]; then
+  export PATH="$(cd "$(dirname "$0")"; pwd)"/tools:$PATH
+  echo 'Using ./tools/bazel directly for bazel calls'
+fi
+
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 # shellcheck source=./test_runner.sh
 . "${dir}"/test/shell/test_runner.sh

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -1,5 +1,16 @@
 workspace(name = "io_bazel_rules_scala_test")
 
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+# bazel-skylib 0.8.0 released 2019.03.20 (https://github.com/bazelbuild/bazel-skylib/releases/tag/0.8.0)
+skylib_version = "0.8.0"
+http_archive(
+    name = "bazel_skylib",
+    type = "tar.gz",
+    url = "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib.{}.tar.gz".format (skylib_version, skylib_version),
+    sha256 = "2ef429f5d7ce7111263289644d233707dba35e39696377ebab8b0bc701f7818e",
+)
+
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../../"

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -41,6 +41,10 @@ load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_reposito
 
 scala_proto_repositories(scala_version)
 
+load("@io_bazel_rules_scala//scala_proto:toolchains.bzl", "scala_proto_register_toolchains")
+
+scala_proto_register_toolchains()
+
 load("@io_bazel_rules_scala//specs2:specs2_junit.bzl", "specs2_junit_repositories")
 
 specs2_junit_repositories(scala_version)
@@ -49,9 +53,12 @@ load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_
 
 scala_register_unused_deps_toolchains()
 
+protobuf_version="3.11.3"
+protobuf_version_sha256="cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852"
+
 http_archive(
     name = "com_google_protobuf",
-    sha256 = "9510dd2afc29e7245e9e884336f848c8a6600a14ae726adb6befdb4f786f0be2",
-    urls = ["https://github.com/protocolbuffers/protobuf/archive/v3.6.1.3.zip"],
-    strip_prefix = "protobuf-3.6.1.3",
+    url = "https://github.com/protocolbuffers/protobuf/archive/v%s.tar.gz" % protobuf_version,
+    strip_prefix = "protobuf-%s" % protobuf_version,
+    sha256 = protobuf_version_sha256,
 )

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -107,7 +107,7 @@ scala_library(
     srcs = glob(["src/main/scala/scalarules/test/mix_java_scala/*.scala"]) + glob([
         "src/main/scala/scalarules/test/mix_java_scala/*.java",
     ]),
-    jvm_flags = [
+    scalac_jvm_flags = [
         "-Xms1G",
         "-Xmx4G",
     ],


### PR DESCRIPTION
### Description
Update the `test_version.sh` machinery to work with recent versions of the repo.

Changes:
- There were some missing dependencies and setup steps in `WORKSPACE.template`.
- The path to `test/shell/test_runner.sh` from `test_version.sh` was wrong.
- One target used the invalid `jvm_flags` attribute. Changed it to `scalac_jvm_flags`. **Question:** Should these flags be added as `javac_jvm_flags` as well?

Result:
`./test_version.sh` now passes.

Questions:
- Would it be possible to add `./test_version.sh` to travis somewhere, so that it doesn't regress again?

### Motivation
It would be useful to extend this machinery to test In #1050.