### PR TITLE
WIP - Create rule for a `scala_service_provider`

### DIFF
--- a/docs/scala_service_provider.md
+++ b/docs/scala_service_provider.md
@@ -1,0 +1,50 @@
+# scala_service_provider
+TODO: this is copy/pasted from scala_doc so far
+```python
+scala_service_provider(
+    name,
+    srcs,
+    deps,
+    runtime_deps,
+    exports,
+    data,
+    main_class,
+    resources,
+    resource_strip_prefix,
+    scalacopts,
+    jvm_flags,
+    scalac_jvm_flags,
+    javac_jvm_flags,
+    unused_dependency_checker_mode,
+    services
+)
+```
+
+A scala service provider is a thin wrapper around a [`scala_library`](scala_library.md), which
+expects one additional argument: `services`.
+`services` is a dictionary where the keys are strings representing one service API and the values
+are a list of implementations for that service.
+If the `services` attribute is provided, the services matching this attribute will be added to the
+output jar under the `META-INF/services` directory, as prescribed by the [Service Provider
+Interface protocol](https://docs.oracle.com/javase/tutorial/ext/basics/spi.html)
+
+## Example
+
+```python
+scala_service_provider(
+    name = "a_scala_service_provider",
+    srcs = ["TestServer.scala"],
+    deps = ["//test/proto:test_proto"],
+    services = {"com.scala.test.service": ["com.scala.test.Service1","com.scala.test.Service2",],}
+)
+
+
+```
+
+## Attributes
+
+Please refer to `scala_library` for all the attributes but the `services` attribute.
+
+| Attribute name        | Description                                           |
+| --------------------- | ----------------------------------------------------- |
+| services              | `Dict of strings to list of strings`<br>Mapping between services and their implementations`

--- a/scala/private/BUILD
+++ b/scala/private/BUILD
@@ -1,0 +1,9 @@
+load(
+    "//scala/private:rules/scala_service_provider.bzl",
+    "scala_service_provider_singleton",
+)
+
+scala_service_provider_singleton(
+    name = "phase_write_services_files",
+    visibility = ["//visibility:public"],
+)

--- a/scala/private/rules/scala_service_provider.bzl
+++ b/scala/private/rules/scala_service_provider.bzl
@@ -1,0 +1,45 @@
+"""Rule for declaring a Service Provider in scala.
+A service provider is like a scala library, except it also accepts
+a `services` attribute which is used to load configurable services
+using the `Service Provider Interface` as described here:
+https://docs.oracle.com/javase/tutorial/ext/basics/spi.html
+"""
+load("@io_bazel_rules_scala//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("@io_bazel_rules_scala//scala:advanced_usage/scala.bzl", "make_scala_library")
+
+
+def _phase_write_services_files(ctx, p):
+    resources = [resource for resource in ctx.files.resources]
+    for service, impls in ctx.attr.services.items():
+        service_file_path = ctx.actions.declare_file("META-INF/services/" + service)
+        ctx.actions.write(
+            output = service_file_path,
+            content = "\n".join(impls)+ "\n"
+        )
+        resources.append(service_file_path)
+    return resources
+
+service_provider_custom_phase = {
+    "attrs": {
+        "services": attr.string_list_dict(),
+    },
+    "phase_providers": [
+        "phase_write_services_files",
+    ],
+}
+
+scala_service_provider = make_scala_library(service_provider_custom_phase)
+
+
+def _scala_service_provider_singleton_implementation(ctx):
+    return [
+        ScalaRulePhase(
+            custom_phases = [
+                ("$", "", "phase_write_services_file", _phase_write_services_files),
+            ],
+        ),
+    ]
+
+scala_service_provider_singleton = rule(
+    implementation = _scala_service_provider_singleton_implementation,
+)

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -30,6 +30,10 @@ load(
     _scala_repl = "scala_repl",
 )
 load(
+    "@io_bazel_rules_scala//scala/private:rules/scala_service_provider.bzl",
+    _scala_service_provider = "scala_service_provider",
+)
+load(
     "@io_bazel_rules_scala//scala/private:rules/scala_test.bzl",
     _scala_test = "scala_test",
     _scala_test_suite = "scala_test_suite",
@@ -58,5 +62,6 @@ scala_library_suite = _scala_library_suite
 scala_macro_library = _scala_macro_library
 scala_repl = _scala_repl
 scala_repositories = _scala_repositories
+scala_service_provider = _scala_service_provider
 scala_test = _scala_test
 scala_test_suite = _scala_test_suite

--- a/test/BUILD
+++ b/test/BUILD
@@ -12,6 +12,7 @@ load(
     "scala_library_suite",
     "scala_macro_library",
     "scala_repl",
+    "scala_service_provider",
     "scala_specs2_junit_test",
     "scala_test",
     "scala_test_suite",
@@ -637,6 +638,13 @@ scala_library(
     name = "lib_with_scala_proto_dep",
     srcs = ["TestServer.scala"],
     deps = ["//test/proto:test_proto"],
+)
+
+scala_service_provider(
+    name = "a_scala_service_provider",
+    srcs = ["TestServer.scala"],
+    deps = ["//test/proto:test_proto"],
+    services = {"com.scala.test.service": ["com.scala.test.Service1","com.scala.test.Service2",],}
 )
 
 scala_binary(

--- a/test/example_jars/expected_services.txt
+++ b/test/example_jars/expected_services.txt
@@ -1,0 +1,2 @@
+com.scala.test.Service1
+com.scala.test.Service2

--- a/test/shell/test_scala_service_provider.sh
+++ b/test/shell/test_scala_service_provider.sh
@@ -1,0 +1,18 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_scala_service_provider_should_produce_expected_files() {
+  services_jar='lib_with_scala_services.jar'
+  services_file='META-INF/services/com.scala.test.service'
+  services_target="//test:lib_with_scala_services"
+  bazel build $services_target
+  unzip -p bazel-bin/test/$services_jar $services_file > services.txt
+  diff services.txt test/example_jars/expected_services.txt
+  RESPONSE_CODE=$?
+  rm services.txt
+  exit $RESPONSE_CODE
+}
+
+$runner test_scala_service_provider_should_produce_expected_files

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -39,6 +39,7 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 . "${test_dir}"/test_scala_jvm_flags.sh
 . "${test_dir}"/test_scala_library_jar.sh
 . "${test_dir}"/test_scala_library.sh
+. "${test_dir}"/test_scala_service_provider.sh
 . "${test_dir}"/test_scala_specs2.sh
 . "${test_dir}"/test_toolchain.sh
 . "${test_dir}"/test_unused_dependency.sh


### PR DESCRIPTION
### Description

A `scala_service_provider` is like a `scala_library`, excepts it exports
a list of implementations for a number of services in its output jar.

Use the phases mechanism to wrap around the `scala_library` rule with
minimal boilerplate.

This is a work-in-progress and I would like to ask a few questions
before this PR is considered for merging:

* Does it make sense to create a new target for a
`scala_service_provider`?
* If so, would it be a welcome addition to `rules_scala` or should we
simply keep this implementation inside our own code base?
* Is it right to use the phases mechanism as I did to add a phase for
writing services to the output jar? Is there a more idiomatic way to
achieve low duplication between this new rule and `scala_library`?
* Does the name: `scala_service_provider` sound good? It is in line with
the "SPI" terminology but may conflict with other concepts in the Bazel
world. Would `scala_spi_plugin` be more explicit/suitable?
* Is there a better way to implement the test than a shell script under
shell? Maybe using the `test_sh` target and doing it in a build file?

### Motivation

Addresses https://github.com/bazelbuild/rules_scala/issues/696 by developing on the ideas from https://github.com/bazelbuild/rules_scala/pull/697 and addressing the comment on separating concerns by creating a new rule rather than extending scala_library.