### PR TITLE
[bazel-buildtools] Use latest released version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -4,11 +4,13 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:git.bzl", "git_repository")
 load("@bazel_tools//tools/build_defs/repo:jvm.bzl", "jvm_maven_import_external")
 
+_build_tools_release = "3.3.0"
+
 http_archive(
     name = "com_github_bazelbuild_buildtools",
-    sha256 = "cdaac537b56375f658179ee2f27813cac19542443f4722b6730d84e4125355e6",
-    strip_prefix = "buildtools-f27d1753c8b3210d9e87cdc9c45bc2739ae2c2db",
-    url = "https://github.com/bazelbuild/buildtools/archive/f27d1753c8b3210d9e87cdc9c45bc2739ae2c2db.zip",
+    sha256 = "f11fc80da0681a6d64632a850346ed2d4e5cbb0908306d9a2a2915f707048a10",
+    strip_prefix = "buildtools-%s" % _build_tools_release,
+    url = "https://github.com/bazelbuild/buildtools/archive/%s.tar.gz" % _build_tools_release,
 )
 
 load("@com_github_bazelbuild_buildtools//buildifier:deps.bzl", "buildifier_dependencies")


### PR DESCRIPTION
### Description
Suggesting a very straightforward change.
1. Making sure we are using the a **release** version of bazeltools so we can keep track of how far behind are we
2. Updating to the latest release `3.3.0`

### Motivation
In general - we do want to make sure that our code is well linted.

I wanted to check out what we already have and I noticed that the current `lint.sh` only calls `bazel run //tools:buildifier@fix` which depends on the version of buildifier we bring from the WORKSPACE.

Without getting into the details I wanted to make sure we use the latest version and that it's easy to understand which version we depend on.