### PR TITLE
Fix JOpt Simple version

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -56,8 +56,8 @@ def jmh_repositories(maven_servers = _default_maven_server_urls()):
     )
     _scala_maven_import_external(
         name = "io_bazel_rules_scala_net_sf_jopt_simple_jopt_simple",
-        artifact = "net.sf.jopt-simple:jopt-simple:5.0.3",
-        artifact_sha256 = "6f45c00908265947c39221035250024f2caec9a15c1c8cf553ebeecee289f342",
+        artifact = "net.sf.jopt-simple:jopt-simple:4.6",
+        artifact_sha256 = "3fcfbe3203c2ea521bf7640484fd35d6303186ea2e08e72f032d640ca067ffda",
         licenses = ["notice"],
         server_urls = maven_servers,
     )

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
-load("//scala:scala.bzl", "scala_library")
+load("//scala:scala.bzl", "scala_library", "scala_test")
 load("//jmh:jmh.bzl", "scala_benchmark_jmh")
 
 java_library(
@@ -33,4 +33,11 @@ scala_benchmark_jmh(
     srcs = ["TestBenchmark.scala"],
     data = ["data.txt"],
     deps = [":add_numbers"],
+)
+
+scala_test(
+    name = "jmh_command_line_parsing_test",
+    args = ["-h"],
+    main_class = "org.openjdk.jmh.Main",
+    deps = [":test_benchmark"],
 )


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

The PR switches the version of `JOpt Simple` from `5.0.3` to `4.6`.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

The `JMH` support introduces a dependency to the version `5.0.3` of `JOpt Simple`. However the `JMH` library is built against the version `4.6` of `JOpt Simple`. In current state the command line parsing functionality of JMH is partially broken (see test `//test/jmh:jmh_command_line_parsing_test`).
