### PR TITLE
Remove call to obsolete function asserts.set_equals

### DIFF
--- a/test/src/main/scala/scalarules/test/twitter_scrooge/twitter_scrooge_test.bzl
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/twitter_scrooge_test.bzl
@@ -1,14 +1,15 @@
-load("@bazel_skylib//:lib.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:unittest.bzl", "asserts", "unittest")
+load("@bazel_skylib//lib:collections.bzl", "collections")
 load("//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
 load("//thrift:thrift.bzl", "thrift_library")
 
 def _scrooge_transitive_outputs(ctx):
     env = unittest.begin(ctx)
 
-    asserts.set_equals(
+    asserts.equals(
         env,
-        depset(ctx.attr.expected_jars),
-        depset([out.class_jar.basename for out in ctx.attr.dep[JavaInfo].outputs.jars]),
+        sorted(ctx.attr.expected_jars),
+        sorted(collections.uniq([out.class_jar.basename for out in ctx.attr.dep[JavaInfo].outputs.jars])),
     )
 
     return unittest.end(env)


### PR DESCRIPTION
### Description

The behavior of the sets module changed in Skylib (internal
representation moved from depset to dict), which changed the API.

With this change, we stop using the sets module and we make the test
more explicit.

### Motivation

This fixes compatibility with the Bazel flag
--incompatible_disable_depset_items (planned in Bazel 4.0) as well as
the next release of Skylib.