### PR TITLE
Fix slow specs2 filtering

### DIFF
--- a/test/shell/test_scala_specs2.sh
+++ b/test/shell/test_scala_specs2.sh
@@ -13,7 +13,8 @@ scala_specs2_junit_test_test_filter_everything(){
   local expected=(
     "[info] JunitSpec2RegexTest"
     "[info] JunitSpecs2AnotherTest"
-    "[info] JunitSpecs2Test")
+    "[info] JunitSpecs2Test"
+    "[info] JunitSpecs2ManyFragmentsTest")
   local unexpected=(
       "[info] UnrelatedTest")
   for method in "${expected[@]}"; do

--- a/test/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
+++ b/test/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
@@ -50,3 +50,10 @@ class JunitSpec2RegexTest extends SpecWithJUnit {
   }
 }
 
+class JunitSpecs2ManyFragmentsTest extends SpecWithJUnit {
+
+  (1 to 200) foreach { i =>
+    s"fragment no $i" in success
+  }
+
+}


### PR DESCRIPTION
### Description
Filtering of specs2 test classes with many examples is slow because of inefficient construction of list of examples that needs to be run. For each included example all examples are scanned in test class.

### Motivation
Fixes https://github.com/bazelbuild/rules_scala/issues/1014