### PR TITLE
[dummy] checking test_disappearing_class

### DIFF
--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -4,6 +4,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+
 test_disappearing_class() {
   git checkout test_expect_failure/disappearing_class/ClassProvider.scala
   bazel build test_expect_failure/disappearing_class:uses_class


### PR DESCRIPTION
https://github.com/bazelbuild/rules_scala/pull/1071 is failing on `test_disappearing_class` and we have a hunch that it's not related to the change but to travis cache or something.

I ran the same test on my fork and [it didn't fail](https://travis-ci.org/github/or-shachar/rules_scala/jobs/710459641).

FYI @simuons @ittaiz 