### PR TITLE
[travisci] dry check latest bazel version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -61,6 +61,12 @@ jobs:
     - name: "[osx] Test scala version"
       <<: *osx
       env: TEST_SCRIPT=test_version XDG_CACHE_HOME=~/xdg_cache
+    - name: "[linux] Dry test rules_scala + latest bazel version"
+      <<: *linux
+      env: TEST_SCRIPT=test_rules_scala XDG_CACHE_HOME=~/xdg_cache USE_BAZEL_VERSION=latest
+
+  allow_failures:
+    env: TEST_SCRIPT=test_rules_scala XDG_CACHE_HOME=~/xdg_cache USE_BAZEL_VERSION=latest
 
 before_install:
   - |


### PR DESCRIPTION
### Description
Adding another automatic test (that doesn't fail the build) that will always check the repo against latest release of bazel.
This can help us identify breaking changes as early as possible and prepare mitigations and adjust the code.