### PR TITLE
Move test_disappearing_class to dedicated output base and disk cache dir

### DIFF
--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -5,13 +5,17 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 test_disappearing_class() {
+  tmp=$(mktemp -d -t test_disappearing_class-XXXXXXXXXX)
+  out=$tmp/out
+  cache=$tmp/cache
   git checkout test_expect_failure/disappearing_class/ClassProvider.scala
-  bazel build test_expect_failure/disappearing_class:uses_class
+  bazel --output_base=$out build --disk_cache=$cache test_expect_failure/disappearing_class:uses_class
   echo -e "package scalarules.test\n\nobject BackgroundNoise{}" > test_expect_failure/disappearing_class/ClassProvider.scala
   set +e
-  bazel build test_expect_failure/disappearing_class:uses_class
+  bazel --output_base=$out build --disk_cache=$cache test_expect_failure/disappearing_class:uses_class
   RET=$?
   git checkout test_expect_failure/disappearing_class/ClassProvider.scala
+  rm -rf $tmp
   if [ $RET -eq 0 ]; then
     echo "Class caching at play. This should fail"
     exit 1


### PR DESCRIPTION

### Description
Since `test_disappearing_class` checks bazel/scala caching I believe it is important to isolate builds from other tasks. Although I don't have a 100% proof but I think test is failing for some PRs because multiple tasks build same targets and write to same output/cache directories. This change fixed build for https://github.com/bazelbuild/rules_scala/pull/1071

### Motivation
`test_disappearing_class` is failing for seemingly unrelated changes.
See PRs https://github.com/bazelbuild/rules_scala/pull/1071 and https://github.com/bazelbuild/rules_scala/pull/1080 as an example. Later one doesn't even touch any scala/starlark code.
