### PR TITLE
Add executable as a direct dependency

### DIFF
--- a/scala/private/phases/phase_default_info.bzl
+++ b/scala/private/phases/phase_default_info.bzl
@@ -7,6 +7,7 @@
 def phase_default_info(ctx, p):
     executable = None
     files = []
+    direct = None
     runfiles = []
 
     phase_names = dir(p)
@@ -18,6 +19,7 @@ def phase_default_info(ctx, p):
         if hasattr(phase, "executable"):
             if executable == None:
                 executable = phase.executable
+                direct = [executable]
             else:
                 fail("only one executable may be provided")
 
@@ -31,11 +33,11 @@ def phase_default_info(ctx, p):
         external_providers = {
             "DefaultInfo": DefaultInfo(
                 executable = executable,
-                files = depset(transitive = files),
+                files = depset(direct = direct, transitive = files),
                 # TODO:
                 # Per Bazel documentation, we should avoid using collect_data. The core phases need to be updated
                 # before we can make the adjustment.
-                runfiles = ctx.runfiles(transitive_files = depset(transitive = runfiles), collect_data = True),
+                runfiles = ctx.runfiles(transitive_files = depset(direct = direct, transitive = runfiles), collect_data = True),
             ),
         },
     )

--- a/test/BUILD
+++ b/test/BUILD
@@ -478,6 +478,26 @@ scala_specs2_junit_test(
     "//test:test_scala_proto_server",
 ]]
 
+# Generate a file containing the rootpaths of a Scala binary.
+genrule(
+    name = "rootpath-script",
+    srcs = [":ScalaBinary"],
+    outs = ["rootpath-script.out"],
+    cmd = """
+       rootpaths=($(rootpaths {}))
+       (IFS='\n'; echo "$${{rootpaths[*]}}") | sort > $@
+   """.format(":ScalaBinary"),
+)
+
+# Validate that the rootpaths point to both the binary
+# and the JAR.
+sh_test(
+    name = "ScalaBinaryRootpaths",
+    srcs = ["rootpaths_binary.sh"],
+    args = ["$(location :rootpath-script.out)"],
+    data = [":rootpath-script.out"],
+)
+
 sh_test(
     name = "test_binary_run_with_large_classpath",
     srcs = ["test_binary_run_with_large_classpath.sh"],

--- a/test/rootpaths_binary.sh
+++ b/test/rootpaths_binary.sh
@@ -1,0 +1,11 @@
+#!/usr/bin/env bash
+
+set -eou pipefail
+
+content="$(cat $1)"
+expected=$'test/ScalaBinary\ntest/ScalaBinary.jar'
+if [ "$content" != "$expected" ]; then
+    echo "Unexpected rootpaths: $content"
+    echo "$expected"
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes a bug where `rootpath` on a `scala_binary` resolved to the JAR instead of the wrapper binary.

This fixes a bug introduced by
https://github.com/bazelbuild/rules_scala/pull/958. Before #958,
`rootpath` on a Scala binary resolved to the wrapper binary so other
rules could treat it as an opaque executable. After that PR `rootpath`
now resolves to the JAR instead of the wrapper binary.

Adding the executable back as a direct dependency fixes that.

Happy to try and add a test for this but I need some guidance how and where to test this.

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
