### PR TITLE
Remove usage of scala_export_to_java

### DIFF
--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -32,9 +32,10 @@ test_transitive_deps() {
     exit 1
   fi
 
-  bazel build test_expect_failure/transitive/java_to_scala:d
-  if [ $? -eq 0 ]; then
-    echo "'bazel build test_expect_failure/transitive/java_to_scala:d' should have failed."
+  expected_message="error: [strict] Using type example.A from an indirect dependency"
+  output=$(bazel build test_expect_failure/transitive/java_to_scala:d 2>&1)
+  if [ $? -eq 0 ] || [[ "$output" != *"$expected_message"* ]]; then
+    echo "'bazel build test_expect_failure/transitive/java_to_scala:d' should have failed with message '$expected_message'."
     exit 1
   fi
 

--- a/test_expect_failure/transitive/java_to_scala/BUILD
+++ b/test_expect_failure/transitive/java_to_scala/BUILD
@@ -1,21 +1,15 @@
 load("@rules_java//java:defs.bzl", "java_library")
-load("//scala:scala.bzl", "scala_export_to_java", "scala_library")
+load("//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "a",
     srcs = ["A.scala"],
 )
 
-scala_export_to_java(
-    name = "b",
-    exports = [":a"],
-    runtime_deps = [],
-)
-
 java_library(
     name = "c",
     srcs = ["C.java"],
-    deps = [":b"],
+    deps = [":a"],
 )
 
 java_library(


### PR DESCRIPTION
### Description
`scala_export_to_java` was removed in https://github.com/bazelbuild/rules_scala/pull/227/files#diff-9957b181001dad28e385437a86e99126L788 but is still used in `rules_scala/test_expect_failure/transitive/java_to_scala/BUILD`

`bazel build test_expect_failure/transitive/java_to_scala:d` was indeed failing but for different reason than expected. However current `test_transitive_deps` was passing because it checks only exit code and not exact reason. I tried to tighten assertion but not really sure about proposed bash changes.

### Motivation
I tried to open repository with vscode which queried bazel build targets with `bazel query ...:* --output=package` and that failed with `file '//scala:scala.bzl' does not contain symbol 'scala_export_to_java'`