### PR TITLE
Add protobuf deps to "Getting Started"

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,11 @@ http_archive(
     strip_prefix = "protobuf-%s" % protobuf_version,
     sha256 = protobuf_version_sha256,
 )
+
+# Dependencies needed for google_protobuf.
+# You may need to modify this if your project uses google_protobuf for other purposes.
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()
 ```
 
 This will load the `rules_scala` repository at the commit sha

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -64,3 +64,6 @@ http_archive(
     strip_prefix = "protobuf-%s" % protobuf_version,
     sha256 = protobuf_version_sha256,
 )
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+protobuf_deps()


### PR DESCRIPTION
### Description
As described in #1083, there's no official guideline yet on how to set up transitive repository deps.
In the interim, this PR modifies the "Getting Started" section of the `Readme.md` (and the example `WORKSPACE.template`) to add the necessary dependencies.

### Motivation
We would like the "Getting Started" workflow to be as close to "copy, paste and go" as possible. This means that we need to include those dependencies in the Readme, even if some users end up having to modify it afterwards to fit their project needs.

Fixes #1083 