### PR TITLE
Add javax annotations-api so it works with jdk 11

### DIFF
--- a/test/shell/test_twitter_scrooge.sh
+++ b/test/shell/test_twitter_scrooge.sh
@@ -1,0 +1,11 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+scrooge_compile_with_jdk_11() {
+    bazel build --javacopt='--release 11' test/src/main/scala/scalarules/test/twitter_scrooge/...
+}
+
+$runner scrooge_compile_with_jdk_11

--- a/test/shell/test_twitter_scrooge.sh
+++ b/test/shell/test_twitter_scrooge.sh
@@ -5,7 +5,12 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 scrooge_compile_with_jdk_11() {
-    bazel build --javacopt='--release 11' test/src/main/scala/scalarules/test/twitter_scrooge/...
+    bazel build --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
+        --host_javabase=@bazel_tools//tools/jdk:remote_jdk11 \
+        --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
+        --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
+        --javacopt='--release 11' \
+        test/src/main/scala/scalarules/test/twitter_scrooge/...
 }
 
 $runner scrooge_compile_with_jdk_11

--- a/test/src/main/scala/scalarules/test/twitter_scrooge/thrift/Thrift1.thrift
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/thrift/Thrift1.thrift
@@ -9,3 +9,11 @@ struct Struct1 {
   2: Thrift2_B.Struct2B msg_b
   3: Thrift3.Struct3 msg
 }
+
+# A union causes scrooge to generate a `@javax.annotation.Generated` annotation,
+# which was moved between jdk8 and jdk11. So having this union is important for
+# testing jdk11, which requires the shims in javax.annotation:javax.annotation-api:1.3.2
+# to compile.
+union Union {
+  1: Struct1 struct1
+}

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -42,3 +42,4 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 . "${test_dir}"/test_scala_specs2.sh
 . "${test_dir}"/test_toolchain.sh
 . "${test_dir}"/test_unused_dependency.sh
+. "${test_dir}"/test_twitter_scrooge.sh

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -161,6 +161,21 @@ def twitter_scrooge(
         actual = util_logging,
     )
 
+    # This is a shim needed to import `@javax.annotation.Generated` when compiled with jdk11.
+    if not native.existing_rule("io_bazel_rules_scala/dependency/thrift/javax_annotation_api"):
+        _scala_maven_import_external(
+            name = "io_bazel_rules_scala_javax_annotation_api",
+            artifact = "javax.annotation:javax.annotation-api:1.3.2",
+            artifact_sha256 = "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+            licenses = ["notice"],
+            server_urls = maven_servers,
+        )
+
+        native.bind(
+            name = "io_bazel_rules_scala/dependency/thrift/javax_annotation_api",
+            actual = "@io_bazel_rules_scala_javax_annotation_api",
+        )
+
 def _colon_paths(data):
     return ":".join([f.path for f in sorted(data)])
 
@@ -453,6 +468,9 @@ common_attrs = {
             ),
             Label(
                 "//external:io_bazel_rules_scala/dependency/thrift/util_core",
+            ),
+            Label(
+                "//external:io_bazel_rules_scala/dependency/thrift/javax_annotation_api",
             ),
         ],
     ),


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
This adds support for compiling twitter scrooge files with jdk11.

scrooge makes use of the `@javax.annotation.Generated` annotation when code gen'ing `union`s. The location of this annotation moved between jdk8 and jdk11. The `javax.annotation-api` dep I added shims this definition in.

You can see the scrooge project making the same change here: https://github.com/twitter/scrooge/commit/78b06e92b9a5268f1c684eb186f7bff1dd429886
Related issue: https://github.com/twitter/scrooge/issues/299
