### PR TITLE
Fix reference to //scala/private/toolchain_deps:scala_library_classpath

### DIFF
--- a/tut_rule/tut.bzl
+++ b/tut_rule/tut.bzl
@@ -50,7 +50,7 @@ def scala_tut_doc(**kw):
         main_class = "io.bazel.rules_scala.tut_support.TutCompiler",
         deps = deps + [
             "@io_bazel_rules_scala//src/scala/io/bazel/rules_scala/tut_support:tut_compiler_lib",
-            "//scala/private/toolchain_deps:scala_library_classpath",
+            "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
         ],
     )
     native.genrule(


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
After bumping to the latest version, one of our internal stripe repos was throwing the following error:

```
ERROR: /src/src/scala/com/stripe/[redacted]/BUILD:54:14: no such package 'scala/private/toolchain_deps': 
BUILD file not found in any of the following directories. 
Add a BUILD file to a directory to mark it as a package.
 - /src/scala/private/toolchain_deps and referenced by '//src/scala/com/stripe/[redacted]'
```

I think this is because a recent PR (https://github.com/bazelbuild/rules_scala/commit/eabb1d28fb288fb5b15857260f87818dda5a97c8#diff-b7d365641ae2b252b2c88a798dec35dd) changed this from a `//external` reference to a local reference. Changing this to a a fully qualified reference (ie, including the workspace name) fixes the build issue.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
