### PR TITLE
Add diagnostics toolchain flag to compilation action call

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ http_archive(
     sha256 = "8c48283aeb70e7165af48191b0e39b7434b0368718709d1bced5c3781787d8e7",
 )
 
+load("@io_bazel_rules_scala//:version.bzl", "bazel_version")
+bazel_version(name = "bazel_version")
+
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 scala_register_toolchains()
 
@@ -70,9 +73,6 @@ http_archive(
 # You may need to modify this if your project uses google_protobuf for other purposes.
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 protobuf_deps()
-
-load("@io_bazel_rules_scala//:version.bzl", "bazel_version")
-bazel_version(name = "bazel_version")
 ```
 
 This will load the `rules_scala` repository at the commit sha

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -120,6 +120,7 @@ def compile_scala(
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
     scalacopts = [ctx.expand_location(v, input_plugins) for v in toolchain.scalacopts + in_scalacopts]
     resource_paths = _resource_paths(resources, resource_strip_prefix)
+    enable_diagnostics_report = toolchain.enable_diagnostics_report
 
     scalac_args = """
 Classpath: {cp}
@@ -162,7 +163,7 @@ DiagnosticsFile: {diagnostics_output}
         unused_dependency_checker_mode = dependency_info.unused_deps_mode,
         dependency_tracking_method = dependency_info.dependency_tracking_method,
         statsfile_output = statsfile.path,
-        enable_diagnostics_report = toolchain.enable_diagnostics_report,
+        enable_diagnostics_report = enable_diagnostics_report,
         diagnostics_output = diagnosticsfile.path,
     )
 
@@ -181,6 +182,7 @@ DiagnosticsFile: {diagnostics_output}
     )
 
     outs = [output, statsfile, diagnosticsfile]
+
     ins = (
         compiler_classpath_jars.to_list() + all_srcjars.to_list() + list(sources) +
         plugins_list + internal_plugin_jars + classpath_resources + resources +
@@ -193,7 +195,7 @@ DiagnosticsFile: {diagnostics_output}
         scalac_jvm_flags,
         ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags,
     )
-    if len(BAZEL_VERSION) == 0:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
+    if len(BAZEL_VERSION) == 0 and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
         ctx.actions.run(
             inputs = ins,
             outputs = outs,

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -27,9 +27,7 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 . "${test_dir}"/test_build_event_protocol.sh
 . "${test_dir}"/test_compilation.sh
 . "${test_dir}"/test_deps.sh
-if [ "$(bazel --version)" = "bazel no_version" ]; then
-  . "${test_dir}"/test_diagnostics_reporter.sh
-fi
+# . "${test_dir}"/test_diagnostics_reporter.sh TODO: Uncomment after changes to bazel are merged
 . "${test_dir}"/test_javac_jvm_flags.sh
 . "${test_dir}"/test_junit.sh
 . "${test_dir}"/test_misc.sh


### PR DESCRIPTION
### Description
Compilation call now only passes the diagnostics file to the action if using a development build of bazel and diagnostics are enabled. 

This way, diagnostics can still be built for older versions of bazel and it gates other development builds of bazel from going down this path.
In order to fix the buildkit build, the test for the diagnostics file was also commented (since it was found that uses a development build of bazel).


### Motivation
Closes #1093 . At first it was thought gating the action with a single check for a development build was enough, but this proved out to be wrong.
