### PR TITLE
Revert "Disable non-functional version check in rule_impl.bsl"

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -195,7 +195,7 @@ DiagnosticsFile: {diagnostics_output}
         scalac_jvm_flags,
         ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags,
     )
-    if False and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
+    if len(BAZEL_VERSION) == 0 and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
         ctx.actions.run(
             inputs = ins,
             outputs = outs,


### PR DESCRIPTION
This reverts commit 9a50e1b22d986d4c4fa292659c923960f48e1f6f.

### Description
This change was not needed. Even with previous commit rules_scala builds on downstream tests (with latest unreleased bazel version): https://buildkite.com/bazel/rules-scala-scala/builds/2265
