### PR TITLE
Testing toolchain and Junit deps

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,45 @@
+## Testing toolchain configuration
+
+Toolchain type `testing_toolchain_type` is used to set up test dependencies. 
+
+### Example to set up JUnit dependencies
+
+`BUILD` file content in your prefered package:
+```starlark
+load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
+load("@io_bazel_rules_scala//testing/toolchain:toolchain.bzl", "scala_testing_toolchain")
+
+scala_testing_toolchain(
+    name = "testing_toolchains_with_junit",
+    dep_providers = [
+        ":junit_classpath_provider",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "testing_toolchain",
+    toolchain = ":testing_toolchains_with_junit",
+    toolchain_type = "@io_bazel_rules_scala//testing/toolchain:testing_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+declare_deps_provider(
+    name = "junit_classpath_provider",
+    deps_id = "junit_classpath",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@my_hamcrest_core",
+        "@my_junit",
+    ],
+)
+```
+
+`junit_classpath_provider` (deps_id `junit_classpath`) is where classpath required for junit tests
+is defined.
+
+Toolchain must be registerd in your `WORKSPACE` file: 
+```starlark
+register_toolchains('//my/package:testing_toolchain')
+```
+

--- a/junit/junit.bzl
+++ b/junit/junit.bzl
@@ -31,3 +31,5 @@ def junit_repositories(maven_servers = _default_maven_server_urls()):
         name = "io_bazel_rules_scala/dependency/hamcrest/hamcrest_core",
         actual = "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//jar",
     )
+
+    native.register_toolchains("@io_bazel_rules_scala//testing:testing_toolchain")

--- a/scala/private/phases/phase_collect_jars.bzl
+++ b/scala/private/phases/phase_collect_jars.bzl
@@ -33,8 +33,7 @@ def phase_collect_jars_macro_library(ctx, p):
 def phase_collect_jars_junit_test(ctx, p):
     args = struct(
         extra_deps = [
-            ctx.attr._junit,
-            ctx.attr._hamcrest,
+            ctx.attr._junit_classpath,
             ctx.attr.suite_label,
             ctx.attr._bazel_test_runner,
         ],

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -62,16 +62,14 @@ def phase_compile_junit_test(ctx, p):
     args = struct(
         buildijar = False,
         implicit_junit_deps_needed_for_java_compilation = [
-            ctx.attr._junit,
-            ctx.attr._hamcrest,
+            ctx.attr._junit_classpath,
         ],
         unused_dependency_checker_ignored_targets = [
             target.label
             for target in p.scalac_provider.default_classpath +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ] + [
-            ctx.attr._junit.label,
-            ctx.attr._hamcrest.label,
+            ctx.attr._junit_classpath.label,
             ctx.attr.suite_label.label,
             ctx.attr._bazel_test_runner.label,
         ],

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -69,15 +69,8 @@ _scala_junit_test_attrs = {
         mandatory = False,
     ),
     "jvm_flags": attr.string_list(),
-    "_junit": attr.label(
-        default = Label(
-            "//external:io_bazel_rules_scala/dependency/junit/junit",
-        ),
-    ),
-    "_hamcrest": attr.label(
-        default = Label(
-            "//external:io_bazel_rules_scala/dependency/hamcrest/hamcrest_core",
-        ),
+    "_junit_classpath": attr.label(
+        default = Label("@io_bazel_rules_scala//testing/toolchain:junit_classpath"),
     ),
     "_bazel_test_runner": attr.label(
         default = Label(
@@ -93,10 +86,7 @@ _junit_resolve_deps = {
             Label(
                 "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
             ),
-            Label("//external:io_bazel_rules_scala/dependency/junit/junit"),
-            Label(
-                "//external:io_bazel_rules_scala/dependency/hamcrest/hamcrest_core",
-            ),
+            Label("@io_bazel_rules_scala//testing/toolchain:junit_classpath"),
         ],
         allow_files = False,
     ),

--- a/src/java/io/bazel/rulesscala/test_discovery/BUILD
+++ b/src/java/io/bazel/rulesscala/test_discovery/BUILD
@@ -7,5 +7,5 @@ scala_library(
         "FilteredRunnerBuilder.scala",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//external:io_bazel_rules_scala/dependency/junit/junit"],
+    deps = ["@io_bazel_rules_scala//testing/toolchain:junit_classpath"],
 )

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -33,14 +33,12 @@ def _rule_impl(ctx):
         "scala_junit_test": [
             "//test/aspect:scala_junit_test",
             "//scala/private/toolchain_deps:scala_library_classpath",
-            "@io_bazel_rules_scala_junit_junit//:io_bazel_rules_scala_junit_junit",
-            "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//:io_bazel_rules_scala_org_hamcrest_hamcrest_core",
+            "//testing/toolchain:junit_classpath",
         ],
         "scala_specs2_junit_test": [
             "//scala/private/toolchain_deps:scala_library_classpath",
             "//test/aspect:scala_specs2_junit_test",
-            "@io_bazel_rules_scala_junit_junit//:io_bazel_rules_scala_junit_junit",
-            "@io_bazel_rules_scala_org_hamcrest_hamcrest_core//:io_bazel_rules_scala_org_hamcrest_hamcrest_core",
+            "//testing/toolchain:junit_classpath",
             # From specs2/specs2.bzl:specs2_dependencies()
             "@io_bazel_rules_scala//specs2:specs2",
             "@io_bazel_rules_scala_org_specs2_specs2_common//:io_bazel_rules_scala_org_specs2_specs2_common",

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,0 +1,27 @@
+load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
+load("@io_bazel_rules_scala//testing/toolchain:toolchain.bzl", "scala_testing_toolchain")
+
+scala_testing_toolchain(
+    name = "testing_toolchains_with_all_deps_impl",
+    dep_providers = [
+        ":junit_classpath_provider",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "testing_toolchain",
+    toolchain = ":testing_toolchains_with_all_deps_impl",
+    toolchain_type = "@io_bazel_rules_scala//testing/toolchain:testing_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+declare_deps_provider(
+    name = "junit_classpath_provider",
+    deps_id = "junit_classpath",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:io_bazel_rules_scala/dependency/hamcrest/hamcrest_core",
+        "//external:io_bazel_rules_scala/dependency/junit/junit",
+    ],
+)

--- a/testing/toolchain/BUILD
+++ b/testing/toolchain/BUILD
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_scala//testing/toolchain:toolchain_deps.bzl", "testing_toolchain_deps")
+
+toolchain_type(
+    name = "testing_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+testing_toolchain_deps(
+    name = "junit_classpath",
+    deps_id = "junit_classpath",
+    visibility = ["//visibility:public"],
+)

--- a/testing/toolchain/toolchain.bzl
+++ b/testing/toolchain/toolchain.bzl
@@ -1,0 +1,18 @@
+load("//scala:providers.bzl", _DepsInfo = "DepsInfo")
+
+def _scala_toolchain_impl(ctx):
+    toolchain = platform_common.ToolchainInfo(
+        dep_providers = ctx.attr.dep_providers,
+    )
+    return [toolchain]
+
+scala_testing_toolchain = rule(
+    _scala_toolchain_impl,
+    attrs = {
+        "dep_providers": attr.label_list(
+            default = [
+            ],
+            providers = [_DepsInfo],
+        ),
+    },
+)

--- a/testing/toolchain/toolchain_deps.bzl
+++ b/testing/toolchain/toolchain_deps.bzl
@@ -1,0 +1,18 @@
+load(
+    "//scala/private/toolchain_deps:toolchain_deps.bzl",
+    "expose_toolchain_deps",
+    "java_info_for_deps",
+)
+
+_toolchain_type = "@io_bazel_rules_scala//testing/toolchain:testing_toolchain_type"
+
+def _testing_toolchain_deps(ctx):
+    return expose_toolchain_deps(ctx, _toolchain_type)
+
+testing_toolchain_deps = rule(
+    implementation = _testing_toolchain_deps,
+    attrs = {
+        "deps_id": attr.string(mandatory = True),
+    },
+    toolchains = [_toolchain_type],
+)


### PR DESCRIPTION
This PR is part of refactoring towards toolchains #940

This is a proposal for a generic testing toolchain, which can be used to configure multiple testing libraries. Some users may want to use multiple testing libraries or implementations that depend on Junit. Instead of setting up multiple toolchains (which look very similar), I think it it is more practical to have a single toolchain type, which allows to provide dependencies for mutiple testing libraries.

This PR covers toolchain itself and configuration for JUnit.

Support for ScalaTest and Specs2 will be developed as separate PRs.