### PR TITLE
ScalaPB deps toolchain

### DIFF
--- a/docs/scala_proto_library.md
+++ b/docs/scala_proto_library.md
@@ -34,6 +34,7 @@ To configure ScalaPB options, configure a different `scala_proto_toolchain` and 
 
 ```python
 load("@io_bazel_rules_scala//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
+load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
 
 scala_proto_toolchain(
     name = "scala_proto_toolchain_configuration",
@@ -41,12 +42,27 @@ scala_proto_toolchain(
     with_flat_package = False,
     with_single_line_to_string = False,
     visibility = ["//visibility:public"],
+    dep_providers = [":my_grpc_deps", ":my_compile_deps"],
 )
 
 toolchain(
     name = "scalapb_toolchain",
     toolchain = ":scala_proto_toolchain_configuration",
     toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+declare_deps_provider(
+    name = "my_compile_deps",
+    deps_id = "scalapb_compile_deps",
+    deps = ["@dep1", "@dep2"],
+    visibility = ["//visibility:public"],
+)
+
+declare_deps_provider(
+    name = "my_grpc_deps",
+    deps_id = "scalapb_grpc_deps",
+    deps = ["@dep3", "@dep4"],
     visibility = ["//visibility:public"],
 )
 ```
@@ -63,6 +79,5 @@ toolchain(
 | code_generator                | `Label, optional (has default)` <br> Which code generator to use. A sensible default is provided.
 | named_generators              | `String dict, optional` <br>
 | extra_generator_dependencies  | `List of labels, optional` <br>
-| grpc_deps                     | `List of labels, optional (has default)` <br> gRPC dependencies. A sensible default is provided.
-| implicit_compile_deps         | `List of labels, optional (has default)` <br> ScalaPB dependencies. A sensible default is provided.
 | scalac                        | `Label, optional (has default)` <br> Target for scalac. A sensible default is provided.
+| dep_providers                 | `List of labels, optional (has default)` <br> allows inject gRPC (deps_id - `scalapb_grpc_deps`) and ScalaPB (deps_id `scalapb_compile_deps`) dependencies

--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -42,13 +42,13 @@ toolchain(
 declare_deps_provider(
     name = "scalapb_compile_deps",
     deps_id = "scalapb_compile_deps",
-    deps = DEFAULT_SCALAPB_COMPILE_DEPS,
     visibility = ["//visibility:public"],
+    deps = DEFAULT_SCALAPB_COMPILE_DEPS,
 )
 
 declare_deps_provider(
     name = "scalapb_grpc_deps",
     deps_id = "scalapb_grpc_deps",
-    deps = DEFAULT_SCALAPB_GRPC_DEPS,
     visibility = ["//visibility:public"],
+    deps = DEFAULT_SCALAPB_GRPC_DEPS,
 )

--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -1,6 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_library")
 load("//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
 load("//scala_proto:default_dep_sets.bzl", "DEFAULT_SCALAPB_COMPILE_DEPS", "DEFAULT_SCALAPB_GRPC_DEPS")
+load("//scala:providers.bzl", "declare_deps_provider")
 
 toolchain_type(
     name = "toolchain_type",
@@ -38,14 +39,16 @@ toolchain(
     visibility = ["//visibility:public"],
 )
 
-java_library(
-    name = "default_scalapb_compile_dependencies",
+declare_deps_provider(
+    name = "scalapb_compile_deps",
+    deps_id = "scalapb_compile_deps",
+    deps = DEFAULT_SCALAPB_COMPILE_DEPS,
     visibility = ["//visibility:public"],
-    exports = DEFAULT_SCALAPB_COMPILE_DEPS,
 )
 
-java_library(
-    name = "default_scalapb_grpc_dependencies",
+declare_deps_provider(
+    name = "scalapb_grpc_deps",
+    deps_id = "scalapb_grpc_deps",
+    deps = DEFAULT_SCALAPB_GRPC_DEPS,
     visibility = ["//visibility:public"],
-    exports = DEFAULT_SCALAPB_GRPC_DEPS,
 )

--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -1,10 +1,29 @@
 load("@rules_java//java:defs.bzl", "java_library")
-load("//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
-load("//scala_proto:default_dep_sets.bzl", "DEFAULT_SCALAPB_COMPILE_DEPS", "DEFAULT_SCALAPB_GRPC_DEPS")
+load(
+    "//scala_proto:scala_proto_toolchain.bzl",
+    "export_scalapb_toolchain_deps",
+    "scala_proto_deps_toolchain",
+    "scala_proto_toolchain",
+)
+load(
+    "//scala_proto:default_dep_sets.bzl",
+    "DEFAULT_SCALAPB_COMPILE_DEPS",
+    "DEFAULT_SCALAPB_GRPC_DEPS",
+)
 load("//scala:providers.bzl", "declare_deps_provider")
 
 toolchain_type(
     name = "toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+toolchain_type(
+    name = "deps_toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+scala_proto_deps_toolchain(
+    name = "default_deps_toolchain_impl",
     visibility = ["//visibility:public"],
 )
 
@@ -21,6 +40,12 @@ toolchain(
     toolchain = ":default_toolchain_impl",
     toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
     visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "default_deps_toolchain",
+    toolchain = ":default_deps_toolchain_impl",
+    toolchain_type = ":deps_toolchain_type",
 )
 
 scala_proto_toolchain(
@@ -40,15 +65,32 @@ toolchain(
 )
 
 declare_deps_provider(
-    name = "scalapb_compile_deps",
+    name = "scalapb_compile_deps_provider",
     deps_id = "scalapb_compile_deps",
     visibility = ["//visibility:public"],
     deps = DEFAULT_SCALAPB_COMPILE_DEPS,
 )
 
 declare_deps_provider(
-    name = "scalapb_grpc_deps",
+    name = "scalapb_grpc_deps_provider",
     deps_id = "scalapb_grpc_deps",
     visibility = ["//visibility:public"],
     deps = DEFAULT_SCALAPB_GRPC_DEPS,
+)
+
+declare_deps_provider(
+    name = "scalapb_worker_deps_provider",
+    deps_id = "scalapb_worker_deps",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
+        "//external:io_bazel_rules_scala/dependency/proto/protoc_bridge",
+        "//external:io_bazel_rules_scala/dependency/proto/scalapb_plugin",
+    ],
+)
+
+export_scalapb_toolchain_deps(
+    name = "scalapb_worker_deps",
+    deps_id = "scalapb_worker_deps",
+    visibility = ["//visibility:public"],
 )

--- a/scala_proto/private/scala_proto_default_repositories.bzl
+++ b/scala_proto/private/scala_proto_default_repositories.bzl
@@ -198,3 +198,5 @@ def scala_proto_default_repositories(
         name = "io_bazel_rules_scala/dependency/proto/opencensus_contrib_grpc_metrics",
         actual = "@scala_proto_rules_opencensus_contrib_grpc_metrics//jar",
     )
+
+    native.register_toolchains("@io_bazel_rules_scala//scala_proto:default_deps_toolchain")

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -246,10 +246,11 @@ scalapb_aspect = aspect(
     attrs = {
         "_protoc": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = "@com_google_protobuf//:protoc",
         ),
     },
+    incompatible_use_toolchain_transition = True,
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",
         "@io_bazel_rules_scala//scala_proto:toolchain_type",

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -140,16 +140,21 @@ def _scalapb_aspect_impl(target, ctx):
         compile_protos = sorted(target_ti.direct_sources)
         transitive_protos = sorted(target_ti.transitive_sources.to_list())
 
+        deps_toolchain_type_label = "@io_bazel_rules_scala//scala_proto:deps_toolchain_type"
         toolchain_type_label = "@io_bazel_rules_scala//scala_proto:toolchain_type"
         toolchain = ctx.toolchains[toolchain_type_label]
         flags = []
 
-        compile_deps = find_deps_info_on(ctx, toolchain_type_label, "scalapb_compile_deps").deps
+        compile_deps = find_deps_info_on(
+            ctx,
+            deps_toolchain_type_label,
+            "scalapb_compile_deps",
+        ).deps
 
         imps = [dep[JavaInfo] for dep in compile_deps]
 
         if toolchain.with_grpc:
-            grpc_deps = find_deps_info_on(ctx, toolchain_type_label, "scalapb_grpc_deps").deps
+            grpc_deps = find_deps_info_on(ctx, deps_toolchain_type_label, "scalapb_grpc_deps").deps
             flags.append("grpc")
             imps.extend([dep[JavaInfo] for dep in grpc_deps])
 
@@ -248,5 +253,6 @@ scalapb_aspect = aspect(
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",
         "@io_bazel_rules_scala//scala_proto:toolchain_type",
+        "@io_bazel_rules_scala//scala_proto:deps_toolchain_type",
     ],
 )

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -1,4 +1,5 @@
 load("//scala_proto:default_dep_sets.bzl", "DEFAULT_SCALAPB_COMPILE_DEPS", "DEFAULT_SCALAPB_GRPC_DEPS")
+load("@io_bazel_rules_scala//scala:providers.bzl", "DepsInfo")
 
 def _scala_proto_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
@@ -10,6 +11,7 @@ def _scala_proto_toolchain_impl(ctx):
         extra_generator_dependencies = ctx.attr.extra_generator_dependencies,
         scalac = ctx.attr.scalac,
         named_generators = ctx.attr.named_generators,
+        dep_providers = ctx.attr.dep_providers,
     )
     return [toolchain]
 
@@ -40,6 +42,13 @@ scala_proto_toolchain = rule(
             default = Label(
                 "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac",
             ),
+        ),
+        "dep_providers": attr.label_list(
+            default = [
+                "//scala_proto:scalapb_compile_deps",
+                "//scala_proto:scalapb_grpc_deps",
+            ],
+            providers = [DepsInfo],
         ),
     },
 )

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -30,7 +30,7 @@ scala_proto_toolchain = rule(
         "blacklisted_protos": attr.label_list(default = []),
         "code_generator": attr.label(
             executable = True,
-            cfg = "host",
+            cfg = "exec",
             default = Label("@io_bazel_rules_scala//src/scala/scripts:scalapb_worker"),
             allow_files = True,
         ),
@@ -61,6 +61,7 @@ scala_proto_deps_toolchain = rule(
                 "@io_bazel_rules_scala//scala_proto:scalapb_grpc_deps_provider",
                 "@io_bazel_rules_scala//scala_proto:scalapb_worker_deps_provider",
             ],
+            cfg = "target",
             providers = [DepsInfo],
         ),
     },

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -45,8 +45,8 @@ scala_proto_toolchain = rule(
         ),
         "dep_providers": attr.label_list(
             default = [
-                "//scala_proto:scalapb_compile_deps",
-                "//scala_proto:scalapb_grpc_deps",
+                "@io_bazel_rules_scala//scala_proto:scalapb_compile_deps",
+                "@io_bazel_rules_scala//scala_proto:scalapb_grpc_deps",
             ],
             providers = [DepsInfo],
         ),

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -77,5 +77,6 @@ export_scalapb_toolchain_deps = rule(
             mandatory = True,
         ),
     },
+    incompatible_use_toolchain_transition = True,
     toolchains = ["@io_bazel_rules_scala//scala_proto:deps_toolchain_type"],
 )

--- a/src/scala/scripts/BUILD
+++ b/src/scala/scripts/BUILD
@@ -31,18 +31,10 @@ scala_library(
 scala_library(
     name = "scalapb_worker_lib",
     srcs = ["ScalaPBWorker.scala"],
-    unused_dependency_checker_ignored_targets = [
-        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
-    ],
     visibility = ["//visibility:public"],
-    runtime_deps = [
-        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
-    ],
     deps = [
         ":scala_proto_request_extractor",
-        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
-        "//external:io_bazel_rules_scala/dependency/proto/protoc_bridge",
-        "//external:io_bazel_rules_scala/dependency/proto/scalapb_plugin",
+        "//scala_proto:scalapb_worker_deps",
         "//src/java/io/bazel/rulesscala/io_utils",
         "//src/java/io/bazel/rulesscala/jar",
         "//src/java/io/bazel/rulesscala/worker",

--- a/test/src/main/scala/scalarules/test/extra_protobuf_generator/BUILD
+++ b/test/src/main/scala/scalarules/test/extra_protobuf_generator/BUILD
@@ -5,8 +5,6 @@ scala_library(
     srcs = ["ExtraProtobufGenerator.scala"],
     visibility = ["//visibility:public"],
     deps = [
-        "//external:io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
-        "//external:io_bazel_rules_scala/dependency/proto/protoc_bridge",
-        "//external:io_bazel_rules_scala/dependency/proto/scalapb_plugin",
+        "//scala_proto:scalapb_worker_deps",
     ],
 )


### PR DESCRIPTION
Refactors scalapb toolchain to use DepsInfo providers to pass required dependencies. Part of #940