### PR TITLE
Reintroduce implicit_compile_deps

### DIFF
--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -1,6 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
 load("//scala_proto:scala_proto_toolchain.bzl", "scala_proto_toolchain")
-load("//scala_proto:default_dep_sets.bzl", "DEFAULT_SCALAPB_COMPILE_DEPS", "DEFAULT_SCALAPB_GRPC_DEPS")
 
 toolchain_type(
     name = "toolchain_type",
@@ -36,16 +35,4 @@ toolchain(
     toolchain = ":enable_all_options_toolchain_impl",
     toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
     visibility = ["//visibility:public"],
-)
-
-java_library(
-    name = "default_scalapb_compile_dependencies",
-    visibility = ["//visibility:public"],
-    exports = DEFAULT_SCALAPB_COMPILE_DEPS,
-)
-
-java_library(
-    name = "default_scalapb_grpc_dependencies",
-    visibility = ["//visibility:public"],
-    exports = DEFAULT_SCALAPB_GRPC_DEPS,
 )

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -141,11 +141,11 @@ def _scalapb_aspect_impl(target, ctx):
 
         toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
         flags = []
-        imps = [j[JavaInfo] for j in ctx.attr._implicit_compile_deps]
+        imps = [j[JavaInfo] for j in toolchain.implicit_compile_deps]
 
         if toolchain.with_grpc:
             flags.append("grpc")
-            imps.extend([j[JavaInfo] for j in ctx.attr._grpc_deps])
+            imps.extend([j[JavaInfo] for j in toolchain.grpc_deps])
 
         if toolchain.with_flat_package:
             flags.append("flat_package")
@@ -234,12 +234,6 @@ scalapb_aspect = aspect(
     ],
     attrs = {
         "_protoc": attr.label(executable = True, cfg = "host", default = "@com_google_protobuf//:protoc"),
-        "_implicit_compile_deps": attr.label_list(cfg = "target", default = [
-            "//external:io_bazel_rules_scala/dependency/proto/implicit_compile_deps",
-        ]),
-        "_grpc_deps": attr.label_list(cfg = "target", default = [
-            "//external:io_bazel_rules_scala/dependency/proto/grpc_deps",
-        ]),
     },
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -19,24 +19,10 @@ load(
     "scalapb_aspect",
 )
 
-def register_default_proto_dependencies():
-    if native.existing_rule("io_bazel_rules_scala/dependency/proto/grpc_deps") == None:
-        native.bind(
-            name = "io_bazel_rules_scala/dependency/proto/grpc_deps",
-            actual = "@io_bazel_rules_scala//scala_proto:default_scalapb_grpc_dependencies",
-        )
-
-    if native.existing_rule("io_bazel_rules_scala/dependency/proto/implicit_compile_deps") == None:
-        native.bind(
-            name = "io_bazel_rules_scala/dependency/proto/implicit_compile_deps",
-            actual = "@io_bazel_rules_scala//scala_proto:default_scalapb_compile_dependencies",
-        )
-
 def scala_proto_repositories(
         scala_version = _default_scala_version(),
         maven_servers = _default_maven_server_urls()):
     ret = scala_proto_default_repositories(scala_version, maven_servers)
-    register_default_proto_dependencies()
     return ret
 
 def _scala_proto_library_impl(ctx):

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -8,6 +8,8 @@ def _scala_proto_toolchain_impl(ctx):
         blacklisted_protos = ctx.attr.blacklisted_protos,
         code_generator = ctx.attr.code_generator,
         extra_generator_dependencies = ctx.attr.extra_generator_dependencies,
+        grpc_deps=ctx.attr.grpc_deps,
+        implicit_compile_deps=ctx.attr.implicit_compile_deps,
         scalac = ctx.attr.scalac,
         named_generators = ctx.attr.named_generators,
     )
@@ -35,6 +37,16 @@ scala_proto_toolchain = rule(
         "named_generators": attr.string_dict(),
         "extra_generator_dependencies": attr.label_list(
             providers = [JavaInfo],
+        ),
+        "grpc_deps": attr.label_list(
+            providers = [JavaInfo],
+            default = DEFAULT_SCALAPB_GRPC_DEPS,
+            cfg = "target"
+        ),
+        "implicit_compile_deps": attr.label_list(
+            providers = [JavaInfo],
+            default = DEFAULT_SCALAPB_COMPILE_DEPS,
+            cfg = "target"
         ),
         "scalac": attr.label(
             default = Label(


### PR DESCRIPTION
## Why
Reverts #801

## Why
ScalaPB features like extra imports and type mappers don't work with the current implementation of scala_proto_library.
This adds back `implicit_compile_deps` tha allows the user to add extra implicit dependencies added to all scala_proto_library targets.

## How
Reverted some of the changes in #801. This should work with the latest versions of Bazel since toolchain transitions have been introduced.

This is not the ideal solution since changes to theses dependencies will trigger a rebuild of all the proto targets.

But it can be an escape hatch for people already using these features and are looking to migrate to Bazel.
