### PR TITLE
Extended proto rule

### DIFF
--- a/scala_proto/private/compile_proto.bzl
+++ b/scala_proto/private/compile_proto.bzl
@@ -1,0 +1,82 @@
+load("//scala/private:rule_impls.bzl", "compile_scala")
+load("//scala/private:common.bzl", "write_manifest_file")
+load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_protobuf_scrooge")
+
+def _concat_lists(list1, list2):
+    all_providers = []
+    all_providers.extend(list1)
+    all_providers.extend(list2)
+    return all_providers
+
+def compiled_jar_file(actions, scalapb_jar):
+    scalapb_jar_name = scalapb_jar.basename
+
+    # ends with .srcjar, so remove last 6 characters
+    without_suffix = scalapb_jar_name[0:len(scalapb_jar_name) - 6]
+
+    # this already ends with _scalapb because that is how scalapb_jar is named
+    compiled_jar = without_suffix + "jar"
+    return actions.declare_file(compiled_jar, sibling = scalapb_jar)
+
+def compile_proto(
+        ctx,
+        scalac,
+        label,
+        output,
+        scalapb_jar,
+        deps_java_info,
+        implicit_deps,
+        resources,
+        resource_strip_prefix):
+    manifest = ctx.actions.declare_file(
+        label.name + "_MANIFEST.MF",
+        sibling = scalapb_jar,
+    )
+    write_manifest_file(ctx.actions, manifest, None)
+    statsfile = ctx.actions.declare_file(
+        label.name + "_scalac.statsfile",
+        sibling = scalapb_jar,
+    )
+    diagnosticsfile = ctx.actions.declare_file(
+        label.name + "_scalac.diagnosticsproto",
+        sibling = scalapb_jar,
+    )
+    merged_deps = java_common.merge(_concat_lists(deps_java_info, implicit_deps))
+
+    # this only compiles scala, not the ijar, but we don't
+    # want the ijar for generated code anyway: any change
+    # in the proto generally will change the interface and
+    # method bodies
+    compile_scala(
+        ctx,
+        Label("%s-fast" % (label)),
+        output,
+        manifest,
+        statsfile,
+        diagnosticsfile,
+        sources = [],
+        cjars = merged_deps.compile_jars,
+        all_srcjars = depset([scalapb_jar]),
+        transitive_compile_jars = merged_deps.transitive_compile_time_jars,
+        plugins = [],
+        resource_strip_prefix = resource_strip_prefix,
+        resources = resources,
+        resource_jars = [],
+        labels = {},
+        in_scalacopts = [],
+        print_compile_time = False,
+        expect_java_output = False,
+        scalac_jvm_flags = [],
+        scalac = scalac,
+        dependency_info = legacy_unclear_dependency_info_for_protobuf_scrooge(ctx),
+        unused_dependency_checker_ignored_targets = [],
+    )
+
+    return JavaInfo(
+        source_jar = scalapb_jar,
+        deps = deps_java_info + implicit_deps,
+        runtime_deps = deps_java_info + implicit_deps,
+        exports = deps_java_info + implicit_deps,
+        output_jar = output,
+        compile_jar = output,
+    )

--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -1,8 +1,6 @@
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
-load("//scala/private:common.bzl", "write_manifest_file")
-load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_protobuf_scrooge")
-load("//scala/private:rule_impls.bzl", "compile_scala")
 load("//scala_proto/private:proto_to_scala_src.bzl", "proto_to_scala_src")
+load("//scala_proto/private:compile_proto.bzl", "compile_proto", "compiled_jar_file")
 
 ScalaPBAspectInfo = provider(fields = [
     "proto_info",
@@ -31,79 +29,6 @@ def merge_scalapb_aspect_info(scalapbs):
         output_files = depset(transitive = [s.output_files for s in scalapbs]),
         proto_info = merge_proto_infos([s.proto_info for s in scalapbs]),
         java_info = java_common.merge([s.java_info for s in scalapbs]),
-    )
-
-def _compiled_jar_file(actions, scalapb_jar):
-    scalapb_jar_name = scalapb_jar.basename
-
-    # ends with .srcjar, so remove last 6 characters
-    without_suffix = scalapb_jar_name[0:len(scalapb_jar_name) - 6]
-
-    # this already ends with _scalapb because that is how scalapb_jar is named
-    compiled_jar = without_suffix + "jar"
-    return actions.declare_file(compiled_jar, sibling = scalapb_jar)
-
-def _compile_scala(
-        ctx,
-        scalac,
-        label,
-        output,
-        scalapb_jar,
-        deps_java_info,
-        implicit_deps,
-        resources,
-        resource_strip_prefix):
-    manifest = ctx.actions.declare_file(
-        label.name + "_MANIFEST.MF",
-        sibling = scalapb_jar,
-    )
-    write_manifest_file(ctx.actions, manifest, None)
-    statsfile = ctx.actions.declare_file(
-        label.name + "_scalac.statsfile",
-        sibling = scalapb_jar,
-    )
-    diagnosticsfile = ctx.actions.declare_file(
-        label.name + "_scalac.diagnosticsproto",
-        sibling = scalapb_jar,
-    )
-    merged_deps = java_common.merge(_concat_lists(deps_java_info, implicit_deps))
-
-    # this only compiles scala, not the ijar, but we don't
-    # want the ijar for generated code anyway: any change
-    # in the proto generally will change the interface and
-    # method bodies
-    compile_scala(
-        ctx,
-        Label("%s-fast" % (label)),
-        output,
-        manifest,
-        statsfile,
-        diagnosticsfile,
-        sources = [],
-        cjars = merged_deps.compile_jars,
-        all_srcjars = depset([scalapb_jar]),
-        transitive_compile_jars = merged_deps.transitive_compile_time_jars,
-        plugins = [],
-        resource_strip_prefix = resource_strip_prefix,
-        resources = resources,
-        resource_jars = [],
-        labels = {},
-        in_scalacopts = [],
-        print_compile_time = False,
-        expect_java_output = False,
-        scalac_jvm_flags = [],
-        scalac = scalac,
-        dependency_info = legacy_unclear_dependency_info_for_protobuf_scrooge(ctx),
-        unused_dependency_checker_ignored_targets = [],
-    )
-
-    return JavaInfo(
-        source_jar = scalapb_jar,
-        deps = deps_java_info + implicit_deps,
-        runtime_deps = deps_java_info + implicit_deps,
-        exports = deps_java_info + implicit_deps,
-        output_jar = output,
-        compile_jar = output,
     )
 
 ####
@@ -191,9 +116,9 @@ def _scalapb_aspect_impl(target, ctx):
             )
 
             src_jars = depset([scalapb_file])
-            output = _compiled_jar_file(ctx.actions, scalapb_file)
+            output = compiled_jar_file(ctx.actions, scalapb_file)
             outs = depset([output])
-            java_info = _compile_scala(
+            java_info = compile_proto(
                 ctx,
                 toolchain.scalac,
                 target.label,

--- a/scala_proto/scala_proto_extended.bzl
+++ b/scala_proto/scala_proto_extended.bzl
@@ -1,0 +1,98 @@
+load(
+    "@rules_proto//proto:defs.bzl",
+    "ProtoInfo",
+)
+load(
+    "//scala_proto/private:proto_to_scala_src.bzl",
+    "proto_to_scala_src",
+)
+load("//scala_proto/private:compile_proto.bzl", "compile_proto", "compiled_jar_file")
+
+def _scala_proto_library_extended_impl(ctx):
+    deps = [d[JavaInfo] for d in ctx.attr.deps]
+
+    # we sort so the inputs are always the same for caching
+    compile_protos = sorted(ctx.attr.proto[ProtoInfo].direct_sources)
+    transitive_protos = sorted(ctx.attr.proto[ProtoInfo].transitive_sources.to_list())
+
+    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
+    flags = []
+    imps = [j[JavaInfo] for j in ctx.attr._implicit_compile_deps]
+
+    if toolchain.with_grpc:
+        flags.append("grpc")
+        imps.extend([j[JavaInfo] for j in ctx.attr._grpc_deps])
+
+    if toolchain.with_flat_package:
+        flags.append("flat_package")
+
+    if toolchain.with_single_line_to_string:
+        flags.append("single_line_to_proto_string")
+
+    extra_generator_jars = []
+    for generator_dep in toolchain.extra_generator_dependencies:
+        jinfo = generator_dep[JavaInfo]
+        extra_generator_jars.extend(jinfo.transitive_runtime_jars.to_list())
+
+    code_generator = toolchain.code_generator
+
+    scalapb_file = ctx.actions.declare_file(
+        ctx.attr.proto.label.name + "_scalapb.srcjar",
+    )
+
+    proto_to_scala_src(
+        ctx,
+        ctx.attr.proto.label,
+        code_generator,
+        compile_protos,
+        transitive_protos,
+        ctx.attr.proto[ProtoInfo].transitive_proto_path.to_list(),
+        flags,
+        scalapb_file,
+        toolchain.named_generators,
+        sorted(extra_generator_jars),
+    )
+
+    src_jars = depset([scalapb_file])
+    output = compiled_jar_file(ctx.actions, scalapb_file)
+    outs = depset([output])
+    java_info = compile_proto(
+        ctx,
+        toolchain.scalac,
+        ctx.attr.proto.label,
+        output,
+        scalapb_file,
+        deps,
+        imps,
+        compile_protos,
+        "" if ctx.attr.proto[ProtoInfo].proto_source_root == "." else ctx.attr.proto[ProtoInfo].proto_source_root,
+    )
+    return [
+        java_info,
+        DefaultInfo(files = outs),
+    ]
+
+scala_proto_library_extended = rule(
+    implementation = _scala_proto_library_extended_impl,
+    attrs = {
+        "proto": attr.label(providers = [ProtoInfo]),
+        "deps": attr.label_list(
+            providers = [JavaInfo],
+        ),
+        "_protoc": attr.label(executable = True, cfg = "host", default = "@com_google_protobuf//:protoc"),
+        "_implicit_compile_deps": attr.label_list(cfg = "target", default = [
+            "//external:io_bazel_rules_scala/dependency/proto/implicit_compile_deps",
+        ]),
+        "_grpc_deps": attr.label_list(cfg = "target", default = [
+            "//external:io_bazel_rules_scala/dependency/proto/grpc_deps",
+        ]),
+    },
+    toolchains = [
+        "@io_bazel_rules_scala//scala:toolchain_type",
+        "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    ],
+    provides = [DefaultInfo, JavaInfo],
+)
+
+def scalapb_proto_library_extended(**kwargs):
+    scala_proto_library_extended(**kwargs)

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -5,6 +5,10 @@ load(
     "scala_proto_library",
 )
 load(
+    "//scala_proto:scala_proto_extended.bzl",
+    "scala_proto_library_extended",
+)
+load(
     "//scala:scala.bzl",
     "scala_binary",
     "scala_library",
@@ -80,6 +84,20 @@ scala_proto_library(
     name = "test_external_dep",
     visibility = ["//visibility:public"],
     deps = [":test_external_dep_proto"],
+)
+
+proto_library(
+    name = "test_external_dep_proto_extended",
+    srcs = ["test_external_dep.proto"],
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_google_protobuf//:wrappers_proto",
+    ],
+)
+
+scala_proto_library_extended(
+    name = "test_extended",
+    proto = ":test_external_dep_proto_extended",
 )
 
 # Test that the `proto_source_root` attribute is handled properly

--- a/test/proto_extended/BUILD
+++ b/test/proto_extended/BUILD
@@ -1,0 +1,53 @@
+load("@rules_proto//proto:defs.bzl", "proto_library")
+load(
+    "//scala_proto:scala_proto_extended.bzl",
+    "scala_proto_library_extended",
+)
+load(
+    "//scala:scala.bzl",
+    "scala_binary",
+    "scala_library",
+    "scala_test",
+)
+
+proto_library(
+    name = "scalapb",
+    srcs = ["scalapb.proto"],
+    deps = ["@com_google_protobuf//:descriptor_proto"],
+)
+
+proto_library(
+    name = "proto1",
+    srcs = ["proto1.proto"],
+    deps = [":scalapb"],
+)
+
+proto_library(
+    name = "proto2",
+    srcs = ["proto2.proto"],
+    deps = [
+        ":proto1",
+        ":scalapb",
+    ],
+)
+
+scala_library(
+    name = "custom_import_lib",
+    srcs = ["CustomImport.scala"],
+)
+
+scala_proto_library_extended(
+    name = "proto1_test",
+    proto = ":proto1",
+    deps = [
+        ":custom_import_lib",
+    ],
+)
+
+scala_proto_library_extended(
+    name = "proto2_test",
+    proto = ":proto2",
+    deps = [
+        ":proto1_test"
+    ],
+)

--- a/test/proto_extended/CustomImport.scala
+++ b/test/proto_extended/CustomImport.scala
@@ -1,0 +1,5 @@
+package some.thing
+
+object TheObject {
+  implicit val theValue: String = "flu"
+}

--- a/test/proto_extended/proto1.proto
+++ b/test/proto_extended/proto1.proto
@@ -1,0 +1,11 @@
+syntax = "proto2";
+
+import "test/proto_extended/scalapb.proto";
+
+option (scalapb.options) = {
+  import: "some.thing.TheObject.theValue"
+};
+
+message TestMessage1 {
+    required string message = 1;
+}

--- a/test/proto_extended/proto2.proto
+++ b/test/proto_extended/proto2.proto
@@ -1,0 +1,12 @@
+syntax = "proto2";
+
+import "test/proto_extended/scalapb.proto";
+import "test/proto_extended/proto1.proto";
+
+option (scalapb.options) = {
+  import: "some.thing.TheObject.theValue"
+};
+
+message TestMessage2 {
+    required TestMessage1 message = 1;
+}

--- a/test/proto_extended/scalapb.proto
+++ b/test/proto_extended/scalapb.proto
@@ -1,0 +1,265 @@
+syntax = "proto2";
+
+package scalapb;
+
+option java_package = "scalapb.options";
+
+option (options) = {
+  package_name: "scalapb.options"
+  flat_package: true
+};
+
+import "google/protobuf/descriptor.proto";
+
+message ScalaPbOptions {
+  // If set then it overrides the java_package and package.
+  optional string package_name = 1;
+
+  // If true, the compiler does not append the proto base file name
+  // into the generated package name. If false (the default), the
+  // generated scala package name is the package_name.basename where
+  // basename is the proto file name without the .proto extension.
+  optional bool flat_package = 2;
+
+  // Adds the following imports at the top of the file (this is meant
+  // to provide implicit TypeMappers)
+  repeated string import = 3;
+
+  // Text to add to the generated scala file.  This can be used only
+  // when single_file is true.
+  repeated string preamble = 4;
+
+  // If true, all messages and enums (but not services) will be written
+  // to a single Scala file.
+  optional bool single_file = 5;
+
+  // By default, wrappers defined at
+  // https://github.com/google/protobuf/blob/master/src/google/protobuf/wrappers.proto,
+  // are mapped to an Option[T] where T is a primitive type. When this field
+  // is set to true, we do not perform this transformation.
+  optional bool no_primitive_wrappers = 7;
+
+  // DEPRECATED. In ScalaPB <= 0.5.47, it was necessary to explicitly enable
+  // primitive_wrappers. This field remains here for backwards compatibility,
+  // but it has no effect on generated code. It is an error to set both
+  // `primitive_wrappers` and `no_primitive_wrappers`.
+  optional bool primitive_wrappers = 6;
+
+  // Scala type to be used for repeated fields. If unspecified,
+  // `scala.collection.Seq` will be used.
+  optional string collection_type = 8;
+
+  // If set to true, all generated messages in this file will preserve unknown
+  // fields.
+  optional bool preserve_unknown_fields = 9 [default=true];
+
+  // If defined, sets the name of the file-level object that would be generated. This
+  // object extends `GeneratedFileObject` and contains descriptors, and list of message
+  // and enum companions.
+  optional string object_name = 10;
+
+  // Whether to apply the options only to this file, or for the entire package (and its subpackages)
+  enum OptionsScope {
+    // Apply the options for this file only (default)
+    FILE = 0;
+
+    // Apply the options for the entire package and its subpackages.
+    PACKAGE = 1;
+  }
+  // Experimental: scope to apply the given options.
+  optional OptionsScope scope = 11;
+
+  // If true, lenses will be generated.
+  optional bool lenses = 12 [default=true];
+
+  // If true, then source-code info information will be included in the
+  // generated code - normally the source code info is cleared out to reduce
+  // code size.  The source code info is useful for extracting source code
+  // location from the descriptors as well as comments.
+  optional bool retain_source_code_info = 13;
+
+  // Scala type to be used for maps. If unspecified,
+  // `scala.collection.immutable.Map` will be used.
+  optional string map_type = 14;
+
+  // If true, no default values will be generated in message constructors.
+  optional bool no_default_values_in_constructor = 15;
+
+  /* Naming convention for generated enum values */
+  enum EnumValueNaming {
+    AS_IN_PROTO = 0;  // Enum value names in Scala use the same name as in the proto
+    CAMEL_CASE = 1;   // Convert enum values to CamelCase in Scala.
+  }
+  optional EnumValueNaming enum_value_naming = 16;
+
+  // Indicate if prefix (enum name + optional underscore) should be removed in scala code
+  // Strip is applied before enum value naming changes.
+  optional bool enum_strip_prefix = 17 [default=false];
+
+  // AuxMessageOptions enables you to set message-level options through package-scoped options.
+  // This is useful when you can't add a dependency on scalapb.proto from the proto file that
+  // defines the message.
+  message AuxMessageOptions {
+    // The fully-qualified name of the message in the proto name space.
+    optional string target = 1;
+
+    // Options to apply to the message. If there are any options defined on the target message
+    // they take precedence over the options.
+    optional MessageOptions options = 2;
+  }
+
+  // AuxFieldOptions enables you to set field-level options through package-scoped options.
+  // This is useful when you can't add a dependency on scalapb.proto from the proto file that
+  // defines the field.
+  message AuxFieldOptions {
+    // The fully-qualified name of the field in the proto name space.
+    optional string target = 1;
+
+    // Options to apply to the field. If there are any options defined on the target message
+    // they take precedence over the options.
+    optional FieldOptions options = 2;
+  }
+
+  // AuxEnumOptions enables you to set enum-level options through package-scoped options.
+  // This is useful when you can't add a dependency on scalapb.proto from the proto file that
+  // defines the enum.
+  message AuxEnumOptions {
+    // The fully-qualified name of the enum in the proto name space.
+    optional string target = 1;
+
+    // Options to apply to the enum. If there are any options defined on the target message
+    // they take precedence over the options.
+    optional EnumOptions options = 2;
+  }
+
+  // List of message options to apply to some messages.
+  repeated AuxMessageOptions aux_message_options = 18;
+
+  // List of message options to apply to some fields.
+  repeated AuxFieldOptions aux_field_options = 19;
+
+  // List of message options to apply to some enums.
+  repeated AuxEnumOptions aux_enum_options = 20;
+
+  // Scala type to use for bytes fields.
+  optional string bytes_type = 21;
+
+  // For use in tests only. Inhibit Java conversions even when when generator parameters
+  // request for it.
+  optional bool test_only_no_java_conversions = 100001;
+}
+
+extend google.protobuf.FileOptions {
+  // File-level optionals for ScalaPB.
+  // Extension number officially assigned by protobuf-global-extension-registry@google.com
+  optional ScalaPbOptions options = 1020;
+}
+
+message MessageOptions {
+  // Additional classes and traits to mix in to the case class.
+  repeated string extends = 1;
+
+  // Additional classes and traits to mix in to the companion object.
+  repeated string companion_extends = 2;
+
+  // Custom annotations to add to the generated case class.
+  repeated string annotations = 3;
+
+  // All instances of this message will be converted to this type. An implicit TypeMapper
+  // must be present.
+  optional string type = 4;
+
+  // Custom annotations to add to the companion object of the generated class.
+  repeated string companion_annotations = 5;
+
+  // Additional classes and traits to mix in to generated sealed_oneof base trait.
+  repeated string sealed_oneof_extends = 6;
+
+  // If true, when this message is used as an optional field, do not wrap it in an `Option`.
+  // This is equivalent of setting `(field).no_box` to true on each field with the message type.
+  optional bool no_box = 7;
+}
+
+extend google.protobuf.MessageOptions {
+  // Message-level optionals for ScalaPB.
+  // Extension number officially assigned by protobuf-global-extension-registry@google.com
+  optional MessageOptions message = 1020;
+}
+
+message FieldOptions {
+  optional string type = 1;
+
+  optional string scala_name = 2;
+
+  // Can be specified only if this field is repeated. If unspecified,
+  // it falls back to the file option named `collection_type`, which defaults
+  // to `scala.collection.Seq`.
+  optional string collection_type = 3;
+
+  // If the field is a map, you can specify custom Scala types for the key
+  // or value.
+  optional string key_type = 4;
+  optional string value_type = 5;
+
+  // Custom annotations to add to the field.
+  repeated string annotations = 6;
+
+  // Can be specified only if this field is a map. If unspecified,
+  // it falls back to the file option named `map_type` which defaults to
+  // `scala.collection.immutable.Map`
+  optional string map_type = 7;
+
+  // Do not box this value in Option[T]. If set, this overrides MessageOptions.no_box
+  optional bool no_box = 30;
+}
+
+extend google.protobuf.FieldOptions {
+  // Field-level optionals for ScalaPB.
+  // Extension number officially assigned by protobuf-global-extension-registry@google.com
+  optional FieldOptions field = 1020;
+}
+
+message EnumOptions {
+  // Additional classes and traits to mix in to the base trait
+  repeated string extends = 1;
+
+  // Additional classes and traits to mix in to the companion object.
+  repeated string companion_extends = 2;
+
+  // All instances of this enum will be converted to this type. An implicit TypeMapper
+  // must be present.
+  optional string type = 3;
+}
+
+extend google.protobuf.EnumOptions {
+  // Enum-level optionals for ScalaPB.
+  // Extension number officially assigned by protobuf-global-extension-registry@google.com
+  //
+  // The field is called enum_options and not enum since enum is not allowed in Java.
+  optional EnumOptions enum_options = 1020;
+}
+
+message EnumValueOptions {
+  // Additional classes and traits to mix in to an individual enum value.
+  repeated string extends = 1;
+
+  // Name in Scala to use for this enum value.
+  optional string scala_name = 2;
+}
+
+extend google.protobuf.EnumValueOptions {
+  // Enum-level optionals for ScalaPB.
+  // Extension number officially assigned by protobuf-global-extension-registry@google.com
+  optional EnumValueOptions enum_value = 1020;
+}
+
+message OneofOptions {
+  // Additional traits to mix in to a oneof.
+  repeated string extends = 1;
+}
+
+extend google.protobuf.OneofOptions {
+  // Enum-level optionals for ScalaPB.
+  // Extension number officially assigned by protobuf-global-extension-registry@google.com
+  optional OneofOptions oneof = 1020;
+}


### PR DESCRIPTION
## What?
Adds a new rule for compiling protobuf to scala. This rule is not aspect based and that allows the user to add extra dependencies to the compilation.

## Why?
The current proto rule does not support adding extra dependencies becaue it's aspect based.

## How?
Extracted some of the functionality of the aspect based rule and reused it in the new rule.
