### PR TITLE
Add neverlink support

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -40,6 +40,10 @@ common_attrs_for_plugin_bootstrapping = {
         default = False,
         mandatory = False,
     ),
+    "neverlink": attr.bool(
+        default = False,
+        mandatory = False,
+    ),
 }
 
 common_attrs = {}

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -300,6 +300,7 @@ def _create_scala_compilation_provider(ctx, ijar, source_jar, deps_providers):
         deps = deps_providers,
         exports = exports,
         runtime_deps = runtime_deps,
+        neverlink = ctx.attr.neverlink,
     )
 
 def _pack_source_jar(ctx, scala_srcs, in_srcjars):

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -259,6 +259,7 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
         #needs to be empty since we want the provider.compile_jars to only contain the sources ijar
         #workaround until https://github.com/bazelbuild/bazel/issues/3528 is resolved
         exports = [],
+        neverlink = getattr(ctx.attr, "neverlink", False),
         java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
         host_javabase = find_java_runtime_toolchain(ctx, ctx.attr._host_javabase),
         strict_deps = ctx.fragments.java.strict_java_deps,

--- a/test/src/main/scala/scalarules/test/neverlink/A.scala
+++ b/test/src/main/scala/scalarules/test/neverlink/A.scala
@@ -1,0 +1,3 @@
+package neverlink
+
+class A

--- a/test/src/main/scala/scalarules/test/neverlink/B.scala
+++ b/test/src/main/scala/scalarules/test/neverlink/B.scala
@@ -1,0 +1,3 @@
+package neverlink
+
+class B

--- a/test/src/main/scala/scalarules/test/neverlink/BUILD
+++ b/test/src/main/scala/scalarules/test/neverlink/BUILD
@@ -1,0 +1,26 @@
+load("//scala:scala.bzl", "scala_library", "scala_test")
+
+scala_library(
+    name = "LinkableA",
+    srcs = ["A.scala"],
+)
+
+scala_library(
+    name = "NonLinkableB",
+    srcs = ["B.scala"],
+    neverlink = True,
+)
+
+scala_library(
+    name = "intermediate_export",
+    exports = [
+        ":LinkableA",
+        ":NonLinkableB",
+    ],
+)
+
+scala_test(
+    name = "NeverlinkTest",
+    srcs = ["NeverlinkTest.scala"],
+    runtime_deps = [":intermediate_export"],
+)

--- a/test/src/main/scala/scalarules/test/neverlink/NeverlinkTest.scala
+++ b/test/src/main/scala/scalarules/test/neverlink/NeverlinkTest.scala
@@ -3,11 +3,11 @@ package neverlink
 import org.scalatest._
 
 class NeverlinkTest extends FlatSpec {
-  "neverlink=True" should "exclude jar from classpath" in {
+  "neverlink=False" should "include jar into classpath" in {
     getClass.getClassLoader.loadClass("neverlink.A")
   }
 
-  "neverlink=False" should "not include jar in classpath" in {
+  "neverlink=True" should "exclude jar from classpath" in {
     assertThrows[ClassNotFoundException]{
       getClass.getClassLoader.loadClass("neverlink.B")
     }

--- a/test/src/main/scala/scalarules/test/neverlink/NeverlinkTest.scala
+++ b/test/src/main/scala/scalarules/test/neverlink/NeverlinkTest.scala
@@ -1,0 +1,15 @@
+package neverlink
+
+import org.scalatest._
+
+class NeverlinkTest extends FlatSpec {
+  "neverlink=True" should "exclude jar from classpath" in {
+    getClass.getClassLoader.loadClass("neverlink.A")
+  }
+
+  "neverlink=False" should "not include jar in classpath" in {
+    assertThrows[ClassNotFoundException]{
+      getClass.getClassLoader.loadClass("neverlink.B")
+    }
+  }
+}


### PR DESCRIPTION
Passes neverlink attribute to JavaInfo via compile phase. Can be extracted into a separate phase after https://github.com/bazelbuild/bazel/issues/11928 is fixed.
Solves #213