### PR TITLE
Use ctx.actions.args() in compile_scala

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -77,9 +77,6 @@ def compile_scala(
         plugins = depset(transitive = [plugins, dep_plugin.files])
         internal_plugin_jars = ctx.files._dependency_analyzer_plugin
 
-        current_target = str(target_label)
-        args.add("--CurrentTarget", current_target)
-
     if dependency_info.need_indirect_info:
         args.add_joined("--IndirectJars", transitive_compile_jars, join_with = ",")
         args.add_joined("--IndirectTargets", [labels[j.path] for j in transitive_compile_jars.to_list()], join_with = ",")
@@ -98,6 +95,7 @@ def compile_scala(
     resource_paths = _resource_paths(resources, resource_strip_prefix)
     enable_diagnostics_report = toolchain.enable_diagnostics_report
 
+    args.add("--CurrentTarget", target_label)
     args.add_joined("--Classpath", compiler_classpath_jars, join_with = ctx.configuration.host_path_separator)
     args.add_joined("--ClasspathResourceSrcs", classpath_resources, join_with = ",")
     args.add_joined("--Files", sources, join_with = ",")

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -120,12 +120,9 @@ def compile_scala(
         transitive = [compiler_classpath_jars, all_srcjars, plugins]
     )
 
-    # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the
-    # toolchain
-    final_scalac_jvm_flags = first_non_empty(
-        scalac_jvm_flags,
-        ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags,
-    )
+    # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the toolchain
+    final_scalac_jvm_flags = first_non_empty(scalac_jvm_flags, toolchain.scalac_jvm_flags)
+
     if len(BAZEL_VERSION) == 0 and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
         ctx.actions.run(
             inputs = ins,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -71,9 +71,7 @@ def compile_scala(
     if dependency_info.dependency_mode != "direct":
         compiler_classpath_jars = transitive_compile_jars
     optional_scalac_args = ""
-    classpath_resources = []
-    if (hasattr(ctx.files, "classpath_resources")):
-        classpath_resources = ctx.files.classpath_resources
+    classpath_resources = getattr(ctx.files, "classpath_resources", [])
 
     if dependency_info.use_analyzer:
         dep_plugin = ctx.attr._dependency_analyzer_plugin

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -62,14 +62,12 @@ def compile_scala(
     # look for any plugins:
     input_plugins = plugins
     plugins = _collect_plugin_paths(plugins)
-    internal_plugin_jars = []
     compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars
     classpath_resources = getattr(ctx.files, "classpath_resources", [])
 
     if dependency_info.use_analyzer:
         dep_plugin = ctx.attr._dependency_analyzer_plugin
         plugins = depset(transitive = [plugins, dep_plugin.files])
-        internal_plugin_jars = ctx.files._dependency_analyzer_plugin
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
     scalacopts = [ctx.expand_location(v, input_plugins) for v in toolchain.scalacopts + in_scalacopts]
@@ -116,7 +114,7 @@ def compile_scala(
     outs = [output, statsfile, diagnosticsfile]
 
     ins = depset(
-        direct = [manifest] + sources + internal_plugin_jars + classpath_resources + resources + resource_jars + scalac_inputs,
+        direct = [manifest] + sources + classpath_resources + resources + resource_jars + scalac_inputs,
         transitive = [compiler_classpath_jars, all_srcjars, plugins]
     )
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -58,7 +58,6 @@ def compile_scala(
         scalac,
         dependency_info,
         unused_dependency_checker_ignored_targets):
-
     # look for any plugins:
     input_plugins = plugins
     plugins = _collect_plugin_paths(plugins)
@@ -113,7 +112,7 @@ def compile_scala(
 
     ins = depset(
         direct = [manifest] + sources + classpath_resources + resources + resource_jars + scalac_inputs,
-        transitive = [compiler_classpath_jars, all_srcjars, plugins]
+        transitive = [compiler_classpath_jars, all_srcjars, plugins],
     )
 
     # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the toolchain

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -67,9 +67,7 @@ def compile_scala(
     input_plugins = plugins
     plugins = _collect_plugin_paths(plugins)
     internal_plugin_jars = []
-    compiler_classpath_jars = cjars
-    if dependency_info.dependency_mode != "direct":
-        compiler_classpath_jars = transitive_compile_jars
+    compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars
     classpath_resources = getattr(ctx.files, "classpath_resources", [])
 
     if dependency_info.use_analyzer:

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -118,49 +118,26 @@ def compile_scala(
     # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the toolchain
     final_scalac_jvm_flags = first_non_empty(scalac_jvm_flags, toolchain.scalac_jvm_flags)
 
-    if len(BAZEL_VERSION) == 0 and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
-        ctx.actions.run(
-            inputs = ins,
-            outputs = outs,
-            executable = scalac,
-            mnemonic = "Scalac",
-            progress_message = "scala %s" % target_label,
-            execution_requirements = {"supports-workers": "1"},
-            #  when we run with a worker, the `@argfile.path` is removed and passed
-            #  line by line as arguments in the protobuf. In that case,
-            #  the rest of the arguments are passed to the process that
-            #  starts up and stays resident.
+    ctx.actions.run(
+        inputs = ins,
+        outputs = outs,
+        executable = scalac,
+        mnemonic = "Scalac",
+        progress_message = "scala %s" % target_label,
+        execution_requirements = {"supports-workers": "1"},
+        #  when we run with a worker, the `@argfile.path` is removed and passed
+        #  line by line as arguments in the protobuf. In that case,
+        #  the rest of the arguments are passed to the process that
+        #  starts up and stays resident.
 
-            # In either case (worker or not), they will be jvm flags which will
-            # be correctly handled since the executable is a jvm app that will
-            # consume the flags on startup.
-            arguments = [
-                "--jvm_flag=%s" % f
-                for f in expand_location(ctx, final_scalac_jvm_flags)
-            ] + [args],
-            diagnostics_file = diagnosticsfile,
-        )
-    else:
-        ctx.actions.run(
-            inputs = ins,
-            outputs = outs,
-            executable = scalac,
-            mnemonic = "Scalac",
-            progress_message = "scala %s" % target_label,
-            execution_requirements = {"supports-workers": "1"},
-            #  when we run with a worker, the `@argfile.path` is removed and passed
-            #  line by line as arguments in the protobuf. In that case,
-            #  the rest of the arguments are passed to the process that
-            #  starts up and stays resident.
-
-            # In either case (worker or not), they will be jvm flags which will
-            # be correctly handled since the executable is a jvm app that will
-            # consume the flags on startup.
-            arguments = [
-                "--jvm_flag=%s" % f
-                for f in expand_location(ctx, final_scalac_jvm_flags)
-            ] + [args],
-        )
+        # In either case (worker or not), they will be jvm flags which will
+        # be correctly handled since the executable is a jvm app that will
+        # consume the flags on startup.
+        arguments = [
+            "--jvm_flag=%s" % f
+            for f in expand_location(ctx, final_scalac_jvm_flags)
+        ] + [args],
+    )
 
 def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, providers_of_dependencies):
     return java_common.compile(

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -61,6 +61,11 @@ def compile_scala(
         scalac,
         dependency_info,
         unused_dependency_checker_ignored_targets):
+
+    args = ctx.actions.args()
+    args.set_param_file_format("multiline")
+    args.use_param_file(param_file_arg = "@%s", use_always = True)
+
     # look for any plugins:
     input_plugins = plugins
     plugins = _collect_plugin_paths(plugins)
@@ -73,114 +78,65 @@ def compile_scala(
     if (hasattr(ctx.files, "classpath_resources")):
         classpath_resources = ctx.files.classpath_resources
 
-    optional_scalac_args_map = {}
-
     if dependency_info.use_analyzer:
         dep_plugin = ctx.attr._dependency_analyzer_plugin
         plugins = depset(transitive = [plugins, dep_plugin.files])
         internal_plugin_jars = ctx.files._dependency_analyzer_plugin
+
+        current_target = str(target_label)
+        args.add("--CurrentTarget", current_target)
 
     if dependency_info.need_indirect_info:
         transitive_cjars_list = transitive_compile_jars.to_list()
         indirect_jars = _join_path(transitive_cjars_list)
         indirect_targets = ",".join([str(labels[j.path]) for j in transitive_cjars_list])
 
-        optional_scalac_args_map["IndirectJars"] = indirect_jars
-        optional_scalac_args_map["IndirectTargets"] = indirect_targets
+        args.add_joined("--IndirectJars", transitive_compile_jars, join_with = ",", omit_if_empty = False)
+        args.add("--IndirectTargets", indirect_targets)
 
     if dependency_info.unused_deps_mode != "off":
         ignored_targets = ",".join([str(d) for d in unused_dependency_checker_ignored_targets])
-        optional_scalac_args_map["UnusedDepsIgnoredTargets"] = ignored_targets
+        args.add("--UnusedDepsIgnoredTargets", ignored_targets)
 
     if dependency_info.need_direct_info:
         cjars_list = cjars.to_list()
         if dependency_info.need_direct_jars:
             direct_jars = _join_path(cjars_list)
-            optional_scalac_args_map["DirectJars"] = direct_jars
+            args.add_joined("--DirectJars", cjars_list, join_with = ",", omit_if_empty = False)
         if dependency_info.need_direct_targets:
             direct_targets = ",".join([str(labels[j.path]) for j in cjars_list])
-            optional_scalac_args_map["DirectTargets"] = direct_targets
-
-    optional_scalac_args = "\n".join([
-        "{k}: {v}".format(k = k, v = v)
-        # We sort the arguments for input stability and reproducibility
-        for (k, v) in sorted(optional_scalac_args_map.items())
-    ])
-
-    plugins_list = plugins.to_list()
-    plugin_arg = _join_path(plugins_list)
-
-    separator = ctx.configuration.host_path_separator
-    compiler_classpath = _join_path(compiler_classpath_jars.to_list(), separator)
+            args.add("--DirectTargets", direct_targets)
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
     scalacopts = [ctx.expand_location(v, input_plugins) for v in toolchain.scalacopts + in_scalacopts]
     resource_paths = _resource_paths(resources, resource_strip_prefix)
     enable_diagnostics_report = toolchain.enable_diagnostics_report
 
-    scalac_args = """
-CurrentTarget: {current_target}
-Classpath: {cp}
-ClasspathResourceSrcs: {classpath_resource_src}
-Files: {files}
-JarOutput: {out}
-Manifest: {manifest}
-Plugins: {plugin_arg}
-PrintCompileTime: {print_compile_time}
-ExpectJavaOutput: {expect_java_output}
-ResourceTargets: {resource_targets}
-ResourceSources: {resource_sources}
-ResourceJars: {resource_jars}
-ScalacOpts: {scala_opts}
-SourceJars: {srcjars}
-StrictDepsMode: {strict_deps_mode}
-UnusedDependencyCheckerMode: {unused_dependency_checker_mode}
-DependencyTrackingMethod: {dependency_tracking_method}
-StatsfileOutput: {statsfile_output}
-EnableDiagnosticsReport: {enable_diagnostics_report}
-DiagnosticsFile: {diagnostics_output}
-""".format(
-        current_target = str(target_label),
-        out = output.path,
-        manifest = manifest.path,
-        # Using ':::' as delimiter because ',' can collide with actual scalac options
-        # https://github.com/bazelbuild/rules_scala/issues/1049
-        scala_opts = ":::".join(scalacopts),
-        print_compile_time = print_compile_time,
-        expect_java_output = expect_java_output,
-        plugin_arg = plugin_arg,
-        cp = compiler_classpath,
-        classpath_resource_src = _join_path(classpath_resources),
-        files = _join_path(sources),
-        srcjars = _join_path(all_srcjars.to_list()),
-        # the resource paths need to be aligned in order
-        resource_targets = ",".join([p[0] for p in resource_paths]),
-        resource_sources = ",".join([p[1] for p in resource_paths]),
-        resource_jars = _join_path(resource_jars),
-        strict_deps_mode = dependency_info.strict_deps_mode,
-        unused_dependency_checker_mode = dependency_info.unused_deps_mode,
-        dependency_tracking_method = dependency_info.dependency_tracking_method,
-        statsfile_output = statsfile.path,
-        enable_diagnostics_report = enable_diagnostics_report,
-        diagnostics_output = diagnosticsfile.path,
-    )
-
-    argfile = ctx.actions.declare_file(
-        "%s_scalac_worker_input" % target_label.name,
-        sibling = output,
-    )
-
-    ctx.actions.write(
-        output = argfile,
-        content = scalac_args + optional_scalac_args,
-    )
+    args.add_joined("--Classpath", compiler_classpath_jars, join_with = ctx.configuration.host_path_separator, omit_if_empty = False)
+    args.add_joined("--ClasspathResourceSrcs", classpath_resources, join_with = ",", omit_if_empty = False)
+    args.add_joined("--Files", sources, join_with = ",", omit_if_empty = False)
+    args.add("--JarOutput", output)
+    args.add("--Manifest", manifest)
+    args.add_joined("--Plugins", plugins, join_with = ",", omit_if_empty = False)
+    args.add("--PrintCompileTime", print_compile_time)
+    args.add("--ExpectJavaOutput", expect_java_output)
+    args.add_joined("--ResourceTargets", [p[0] for p in resource_paths], join_with = ",", omit_if_empty = False)
+    args.add_joined("--ResourceSources", [p[1] for p in resource_paths], join_with = ",", omit_if_empty = False)
+    args.add_joined("--ResourceJars", resource_jars, join_with = ",", omit_if_empty = False)
+    args.add_joined("--ScalacOpts", scalacopts, join_with = ":::", omit_if_empty = False)
+    args.add_joined("--SourceJars", all_srcjars, join_with = ",", omit_if_empty = False)
+    args.add("--StrictDepsMode", dependency_info.strict_deps_mode)
+    args.add("--UnusedDependencyCheckerMode", dependency_info.unused_deps_mode)
+    args.add("--DependencyTrackingMethod", dependency_info.dependency_tracking_method)
+    args.add("--StatsfileOutput", statsfile)
+    args.add("--EnableDiagnosticsReport", enable_diagnostics_report)
+    args.add("--DiagnosticsFile", diagnosticsfile)
 
     outs = [output, statsfile, diagnosticsfile]
 
-    ins = (
-        compiler_classpath_jars.to_list() + all_srcjars.to_list() + list(sources) +
-        plugins_list + internal_plugin_jars + classpath_resources + resources +
-        resource_jars + [manifest, argfile]
+    ins = depset(
+        direct = [manifest] + sources + internal_plugin_jars + classpath_resources + resources + resource_jars + scalac_inputs,
+        transitive = [compiler_classpath_jars, all_srcjars, plugins]
     )
 
     # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the
@@ -189,28 +145,49 @@ DiagnosticsFile: {diagnostics_output}
         scalac_jvm_flags,
         ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags,
     )
+    if len(BAZEL_VERSION) == 0 and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
+        ctx.actions.run(
+            inputs = ins,
+            outputs = outs,
+            executable = scalac,
+            mnemonic = "Scalac",
+            progress_message = "scala %s" % target_label,
+            execution_requirements = {"supports-workers": "1"},
+            #  when we run with a worker, the `@argfile.path` is removed and passed
+            #  line by line as arguments in the protobuf. In that case,
+            #  the rest of the arguments are passed to the process that
+            #  starts up and stays resident.
 
-    ctx.actions.run(
-        inputs = ins,
-        outputs = outs,
-        executable = scalac,
-        mnemonic = "Scalac",
-        progress_message = "scala %s" % target_label,
-        execution_requirements = {"supports-workers": "1"},
-        #  when we run with a worker, the `@argfile.path` is removed and passed
-        #  line by line as arguments in the protobuf. In that case,
-        #  the rest of the arguments are passed to the process that
-        #  starts up and stays resident.
+            # In either case (worker or not), they will be jvm flags which will
+            # be correctly handled since the executable is a jvm app that will
+            # consume the flags on startup.
+            arguments = [
+                "--jvm_flag=%s" % f
+                for f in expand_location(ctx, final_scalac_jvm_flags)
+            ] + [args],
+            diagnostics_file = diagnosticsfile,
+        )
+    else:
+        ctx.actions.run(
+            inputs = ins,
+            outputs = outs,
+            executable = scalac,
+            mnemonic = "Scalac",
+            progress_message = "scala %s" % target_label,
+            execution_requirements = {"supports-workers": "1"},
+            #  when we run with a worker, the `@argfile.path` is removed and passed
+            #  line by line as arguments in the protobuf. In that case,
+            #  the rest of the arguments are passed to the process that
+            #  starts up and stays resident.
 
-        # In either case (worker or not), they will be jvm flags which will
-        # be correctly handled since the executable is a jvm app that will
-        # consume the flags on startup.
-        arguments = [
-            "--jvm_flag=%s" % f
-            for f in expand_location(ctx, final_scalac_jvm_flags)
-        ] + ["@" + argfile.path],
-        # diagnostics_file = diagnosticsfile TODO: add diagnostics_file argument whenever this argument is supported: https://github.com/bazelbuild/rules_scala/issues/1215
-    )
+            # In either case (worker or not), they will be jvm flags which will
+            # be correctly handled since the executable is a jvm app that will
+            # consume the flags on startup.
+            arguments = [
+                "--jvm_flag=%s" % f
+                for f in expand_location(ctx, final_scalac_jvm_flags)
+            ] + [args],
+        )
 
 def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, providers_of_dependencies):
     return java_common.compile(

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -70,7 +70,6 @@ def compile_scala(
     compiler_classpath_jars = cjars
     if dependency_info.dependency_mode != "direct":
         compiler_classpath_jars = transitive_compile_jars
-    optional_scalac_args = ""
     classpath_resources = getattr(ctx.files, "classpath_resources", [])
 
     if dependency_info.use_analyzer:

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -62,14 +62,12 @@ def compile_scala(
     # look for any plugins:
     input_plugins = plugins
     plugins = _collect_plugin_paths(plugins)
-    compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars
-    classpath_resources = getattr(ctx.files, "classpath_resources", [])
-
     if dependency_info.use_analyzer:
-        dep_plugin = ctx.attr._dependency_analyzer_plugin
-        plugins = depset(transitive = [plugins, dep_plugin.files])
+        plugins = depset(transitive = [plugins, ctx.attr._dependency_analyzer_plugin.files])
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
+    compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars
+    classpath_resources = getattr(ctx.files, "classpath_resources", [])
     scalacopts = [ctx.expand_location(v, input_plugins) for v in toolchain.scalacopts + in_scalacopts]
     resource_paths = _resource_paths(resources, resource_strip_prefix)
     enable_diagnostics_report = toolchain.enable_diagnostics_report

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -91,7 +91,7 @@ def compile_scala(
         indirect_jars = _join_path(transitive_cjars_list)
         indirect_targets = ",".join([str(labels[j.path]) for j in transitive_cjars_list])
 
-        args.add_joined("--IndirectJars", transitive_compile_jars, join_with = ",", omit_if_empty = False)
+        args.add_joined("--IndirectJars", transitive_compile_jars, join_with = ",")
         args.add("--IndirectTargets", indirect_targets)
 
     if dependency_info.unused_deps_mode != "off":
@@ -102,7 +102,7 @@ def compile_scala(
         cjars_list = cjars.to_list()
         if dependency_info.need_direct_jars:
             direct_jars = _join_path(cjars_list)
-            args.add_joined("--DirectJars", cjars_list, join_with = ",", omit_if_empty = False)
+            args.add_joined("--DirectJars", cjars_list, join_with = ",")
         if dependency_info.need_direct_targets:
             direct_targets = ",".join([str(labels[j.path]) for j in cjars_list])
             args.add("--DirectTargets", direct_targets)
@@ -112,19 +112,19 @@ def compile_scala(
     resource_paths = _resource_paths(resources, resource_strip_prefix)
     enable_diagnostics_report = toolchain.enable_diagnostics_report
 
-    args.add_joined("--Classpath", compiler_classpath_jars, join_with = ctx.configuration.host_path_separator, omit_if_empty = False)
-    args.add_joined("--ClasspathResourceSrcs", classpath_resources, join_with = ",", omit_if_empty = False)
-    args.add_joined("--Files", sources, join_with = ",", omit_if_empty = False)
+    args.add_joined("--Classpath", compiler_classpath_jars, join_with = ctx.configuration.host_path_separator)
+    args.add_joined("--ClasspathResourceSrcs", classpath_resources, join_with = ",")
+    args.add_joined("--Files", sources, join_with = ",")
     args.add("--JarOutput", output)
     args.add("--Manifest", manifest)
-    args.add_joined("--Plugins", plugins, join_with = ",", omit_if_empty = False)
+    args.add_joined("--Plugins", plugins, join_with = ",")
     args.add("--PrintCompileTime", print_compile_time)
     args.add("--ExpectJavaOutput", expect_java_output)
-    args.add_joined("--ResourceTargets", [p[0] for p in resource_paths], join_with = ",", omit_if_empty = False)
-    args.add_joined("--ResourceSources", [p[1] for p in resource_paths], join_with = ",", omit_if_empty = False)
-    args.add_joined("--ResourceJars", resource_jars, join_with = ",", omit_if_empty = False)
-    args.add_joined("--ScalacOpts", scalacopts, join_with = ":::", omit_if_empty = False)
-    args.add_joined("--SourceJars", all_srcjars, join_with = ",", omit_if_empty = False)
+    args.add_joined("--ResourceTargets", [p[0] for p in resource_paths], join_with = ",")
+    args.add_joined("--ResourceSources", [p[1] for p in resource_paths], join_with = ",")
+    args.add_joined("--ResourceJars", resource_jars, join_with = ",")
+    args.add_joined("--ScalacOpts", scalacopts, join_with = ":::")
+    args.add_joined("--SourceJars", all_srcjars, join_with = ",")
     args.add("--StrictDepsMode", dependency_info.strict_deps_mode)
     args.add("--UnusedDependencyCheckerMode", dependency_info.unused_deps_mode)
     args.add("--DependencyTrackingMethod", dependency_info.dependency_tracking_method)

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -111,7 +111,7 @@ def compile_scala(
     outs = [output, statsfile, diagnosticsfile]
 
     ins = depset(
-        direct = [manifest] + sources + classpath_resources + resources + resource_jars + scalac_inputs,
+        direct = [manifest] + sources + classpath_resources + resources + resource_jars,
         transitive = [compiler_classpath_jars, all_srcjars, plugins],
     )
 

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -90,14 +90,12 @@ public class CompileOptions {
   }
 
   private static HashMap<String, String> buildArgMap(List<String> lines) {
-    HashMap hm = new HashMap();
-    for (String line : lines) {
-      String[] lSplit = line.split(": ");
-      if (lSplit.length > 2) {
-        throw new RuntimeException("Bad arg, should have at most 1 space/2 spans. arg: " + line);
-      }
-      if (lSplit.length > 1) {
-        hm.put(lSplit[0], lSplit[1]);
+    HashMap<String, String> hm = new HashMap<>();
+    for (int i = 0; i < lines.size() - 1; i += 2) {
+      String key = lines.get(i).substring(2);
+      String value = lines.get(i + 1);
+      if(!value.isEmpty()) {
+        hm.put(key, value);
       }
     }
     return hm;

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -91,12 +91,8 @@ public class CompileOptions {
 
   private static HashMap<String, String> buildArgMap(List<String> lines) {
     HashMap<String, String> hm = new HashMap<>();
-    for (int i = 0; i < lines.size() - 1; i += 2) {
-      String key = lines.get(i).substring(2);
-      String value = lines.get(i + 1);
-      if(!value.isEmpty()) {
-        hm.put(key, value);
-      }
+    for (int i = 0; i < lines.size(); i += 2) {
+      hm.put(lines.get(i).substring(2), lines.get(i + 1));
     }
     return hm;
   }

--- a/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
+++ b/src/java/io/bazel/rulesscala/scalac/CompileOptions.java
@@ -89,12 +89,12 @@ public class CompileOptions {
     return resources;
   }
 
-  private static HashMap<String, String> buildArgMap(List<String> lines) {
-    HashMap<String, String> hm = new HashMap<>();
+  private static Map<String, String> buildArgMap(List<String> lines) {
+    Map<String, String> args = new HashMap<>();
     for (int i = 0; i < lines.size(); i += 2) {
-      hm.put(lines.get(i).substring(2), lines.get(i + 1));
+      args.put(lines.get(i).substring(2), lines.get(i + 1));
     }
-    return hm;
+    return args;
   }
 
   protected static String[] getTripleColonList(Map<String, String> m, String k) {


### PR DESCRIPTION
### Description

Use ctx.actions.args() to pass parameters to persistent worker.

### Motivation

As per recommendations in https://docs.bazel.build/versions/master/skylark/performance.html#use-ctxactionsargs-for-command-lines this should reduce memory consumption at analysis phase by:
- deferring expansion of depsets
- avoiding concatenation of list
- avoiding construction of large strings for args file
