### PR TITLE
[CI-shell-tests] Support granular test timeout

### DIFF
--- a/test/shell/test_runner.sh
+++ b/test/shell/test_runner.sh
@@ -5,7 +5,6 @@
 NC='\033[0m'
 GREEN='\033[0;32m'
 RED='\033[0;31m'
-TIMOUT=60
 
 run_test_ci() {
   # spawns the test to new process
@@ -15,6 +14,7 @@ run_test_ci() {
   eval $TEST_ARG &>$log_file &
   local test_pid=$!
   SECONDS=0
+  TIMOUT=${TEST_TIMEOUT-60}
   test_pulse_printer $! $TIMOUT $TEST_ARG &
   local pulse_printer_pid=$!
   local result

--- a/test_version.sh
+++ b/test_version.sh
@@ -120,8 +120,9 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test/shell/test_runner.sh
 runner=$(get_test_runner "${1:-local}")
 export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat $dir/.bazelversion)}
-$runner test_scala_version "${scala_2_11_version}"
-$runner test_scala_version "${scala_2_12_version}"
 
-$runner test_twitter_scrooge_versions "18.6.0"
-$runner test_twitter_scrooge_versions "20.5.0"
+TEST_TIMEOUT=3 $runner test_scala_version "${scala_2_11_version}"
+TEST_TIMEOUT=5 $runner test_scala_version "${scala_2_12_version}"
+
+TEST_TIMEOUT=1 $runner test_twitter_scrooge_versions "18.6.0"
+TEST_TIMEOUT=1 $runner test_twitter_scrooge_versions "20.5.0"

--- a/test_version.sh
+++ b/test_version.sh
@@ -121,8 +121,8 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat $dir/.bazelversion)}
 
-TEST_TIMEOUT=3 $runner test_scala_version "${scala_2_11_version}"
-TEST_TIMEOUT=5 $runner test_scala_version "${scala_2_12_version}"
+TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_11_version}"
+TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_12_version}"
 
-TEST_TIMEOUT=1 $runner test_twitter_scrooge_versions "18.6.0"
-TEST_TIMEOUT=1 $runner test_twitter_scrooge_versions "20.5.0"
+TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "18.6.0"
+TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "20.5.0"


### PR DESCRIPTION
### Description

I wanna add a way for specifying specific timeout per test. Currently there's a global timeout of 60 minutes **per test** while in travis the timeout it for each test **suite** is 50 minutes. 

When travis terminates the run in the middle of test run, we can't even see the logs of the timing out test. Using this mechanism we can terminate the test ourselves and see the output.


### Motivation
I looked at [travis job](https://travis-ci.org/github/bazelbuild/rules_scala/jobs/737970813) from [this PR](https://github.com/bazelbuild/rules_scala/pull/1118)

## draft notice
~I'm checking it now with super low timeout in purpose - I wanna see how it looks like.~ - see first commit travis to see example for failure on timeout..

PR is ready to merge AFAIC.
FYI: @liucijus 