### PR TITLE
Add Gemini as rules_scala user

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,6 +369,7 @@ Here's a (non-exhaustive) list of companies that use `rules_scala` in production
 * [Ascend](https://ascend.io/)
 * [Canva](https://www.canva.com/)
 * [Etsy](https://www.etsy.com/)
+* [Gemini](https://gemini.com/)
 * [Grand Rounds](http://grandrounds.com/)
 * [Kitty Hawk](https://kittyhawk.aero/)
 * [Meetup](https://meetup.com/)


### PR DESCRIPTION
### Description

Updates README to add Gemini as a user of rules_scala.

### Motivation

Just trying to be transparent about our usage in hopes it can help others make the choice to also use `rules_scala`