### PR TITLE
Support --instrument_test_targets flag in coverage

### DIFF
--- a/scala/private/phases/phase_coverage_runfiles.bzl
+++ b/scala/private/phases/phase_coverage_runfiles.bzl
@@ -14,7 +14,7 @@ def phase_coverage_runfiles(ctx, p):
     if ctx.configuration.coverage_enabled and _coverage_replacements_provider.is_enabled(ctx):
         coverage_replacements = _coverage_replacements_provider.from_ctx(
             ctx,
-            base = p.coverage.replacements,
+            #            base = p.coverage.replacements,
         ).replacements
 
         rjars = depset([

--- a/scala/private/phases/phase_coverage_runfiles.bzl
+++ b/scala/private/phases/phase_coverage_runfiles.bzl
@@ -14,7 +14,7 @@ def phase_coverage_runfiles(ctx, p):
     if ctx.configuration.coverage_enabled and _coverage_replacements_provider.is_enabled(ctx):
         coverage_replacements = _coverage_replacements_provider.from_ctx(
             ctx,
-            #            base = p.coverage.replacements,
+            base = p.coverage.replacements if ctx.coverage_instrumented() else {},
         ).replacements
 
         rjars = depset([

--- a/test/coverage/expected-coverage.dat
+++ b/test/coverage/expected-coverage.dat
@@ -104,21 +104,3 @@ DA:46,4
 LH:4
 LF:4
 end_of_record
-SF:test/coverage/TestAll.scala
-FN:4,coverage/TestAll::<init> ()V
-FNDA:1,coverage/TestAll::<init> ()V
-FNF:1
-FNH:1
-BA:7,2
-BRF:1
-BRH:1
-DA:4,3
-DA:6,22
-DA:7,1
-DA:10,22
-DA:11,1
-DA:14,22
-DA:15,1
-LH:7
-LF:7
-end_of_record

--- a/test/shell/test_coverage.sh
+++ b/test/shell/test_coverage.sh
@@ -19,9 +19,5 @@ test_coverage_includes_test_targets() {
     grep -q "SF:test/coverage/TestAll.scala" $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
 }
 
-xmllint_test() {
-  find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null
-}
-
 $runner test_coverage_on
 $runner test_coverage_includes_test_targets

--- a/test/shell/test_coverage.sh
+++ b/test/shell/test_coverage.sh
@@ -1,0 +1,27 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_coverage_on() {
+    bazel coverage \
+          --extra_toolchains="//scala:code_coverage_toolchain" \
+          //test/coverage/...
+    diff test/coverage/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
+}
+
+test_coverage_includes_test_targets() {
+    bazel coverage \
+          --extra_toolchains="//scala:code_coverage_toolchain" \
+          --instrument_test_targets=True \
+          //test/coverage/...
+    grep -q "SF:test/coverage/TestAll.scala" $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
+}
+
+xmllint_test() {
+  find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null
+}
+
+$runner test_coverage_on
+$runner test_coverage_includes_test_targets

--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -129,6 +129,14 @@ test_coverage_on() {
     diff test/coverage/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
 }
 
+test_coverage_includes_test_targets() {
+    bazel coverage \
+          --extra_toolchains="//scala:code_coverage_toolchain" \
+          --instrument_test_targets=True \
+          //test/coverage/...
+    grep -q "SF:test/coverage/TestAll.scala" $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
+}
+
 xmllint_test() {
   find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null
 }
@@ -142,4 +150,5 @@ $runner scala_test_test_filters
 $runner test_multi_service_manifest
 $runner test_override_javabin
 $runner test_coverage_on
+$runner test_coverage_includes_test_targets
 $runner xmllint_test

--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -122,21 +122,6 @@ test_override_javabin() {
   JAVABIN=/etc/basdf action_should_fail run test:ScalaBinary
 }
 
-test_coverage_on() {
-    bazel coverage \
-          --extra_toolchains="//scala:code_coverage_toolchain" \
-          //test/coverage/...
-    diff test/coverage/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
-}
-
-test_coverage_includes_test_targets() {
-    bazel coverage \
-          --extra_toolchains="//scala:code_coverage_toolchain" \
-          --instrument_test_targets=True \
-          //test/coverage/...
-    grep -q "SF:test/coverage/TestAll.scala" $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
-}
-
 xmllint_test() {
   find -L ./bazel-testlogs -iname "*.xml" | xargs -n1 xmllint > /dev/null
 }
@@ -149,6 +134,4 @@ $runner test_benchmark_jmh_failure
 $runner scala_test_test_filters
 $runner test_multi_service_manifest
 $runner test_override_javabin
-$runner test_coverage_on
-$runner test_coverage_includes_test_targets
 $runner xmllint_test

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -32,6 +32,7 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 . "${test_dir}"/test_custom_reporter_class.sh
 . "${test_dir}"/test_junit.sh
 . "${test_dir}"/test_misc.sh
+. "${test_dir}"/test_coverage.sh
 . "${test_dir}"/test_phase.sh
 . "${test_dir}"/test_scalafmt.sh
 . "${test_dir}"/test_scala_binary.sh


### PR DESCRIPTION
Support `--instrument_test_targets` (default value is False) flag. Solves #1042 and partially addresses instability with rules_scala coverage testing when test libraries change (by excluding test target coverage).