### PR TITLE
Add Scala 2.13 to docs as supported version

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,18 +125,18 @@ Please check [coverage.md](docs/coverage.md) for more details on coverage suppor
 
 ## Selecting Scala version
 
-Rules scala supports the last two released minor versions for each of Scala 2.11 and 2.12.
+Rules scala supports the last two released minor versions for each of Scala 2.11, 2.12, 2.13.
 Previous minor versions may work but are supported only on a best effort basis.
 
 To configure Scala version you must call `scala_config(scala_version = "2.xx.xx")` and configure 
 dependencies by declaring [scala_toolchain](https://github.com/bazelbuild/rules_scala/blob/master/docs/scala_toolchain.md). 
 For a quick start you can use `scala_repositories()` and `scala_register_toolchains()`, which have 
-dependency providers configured for `2.11.12` and `2.12.11` versions.
+dependency providers configured for `2.11.12`, `2.12.11` and `2.13.3` versions.
 
 ```starlark
 # WORKSPACE
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
-scala_config(scala_version = "2.11.12")
+scala_config(scala_version = "2.13.3")
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()


### PR DESCRIPTION
Mentions 2.13 as supported in README