### PR TITLE
[buildkite] Using new presubmit format

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,6 +1,7 @@
 ---
-platforms:
+tasks:
   ubuntu1604:
+    platform: ubuntu1604
     shell_commands:
     # Disable local disk caching on CI.
     - mv tools/bazel.rc.buildkite tools/bazel.rc
@@ -10,6 +11,7 @@ platforms:
     test_targets:
     - "//test/..."
   ubuntu1804:
+    platform: ubuntu1804
     shell_commands:
     # Disable local disk caching on CI.
     - mv tools/bazel.rc.buildkite tools/bazel.rc
@@ -19,6 +21,7 @@ platforms:
     test_targets:
     - "//test/..."
   macos:
+    platform: macos
     shell_commands:
     # Disable local disk caching on CI.
     - mv tools/bazel.rc.buildkite tools/bazel.rc
@@ -28,6 +31,7 @@ platforms:
     test_targets:
     - "//test/..."
   rbe_ubuntu1604:
+    platform: rbe_ubuntu1604
     build_targets:
     - "//test/..."
     test_targets:


### PR DESCRIPTION
### Description
Seems like we're using Google's buildkite config [legacy format](https://github.com/bazelbuild/continuous-integration/tree/master/buildkite#legacy-format). 

This is my attempt to move to the new format (also to learn this config so maybe I can tackle #1157 in the future)
