### PR TITLE
Customizable jacocorunner for scala_test

### DIFF
--- a/scala/private/phases/phase_coverage_runfiles.bzl
+++ b/scala/private/phases/phase_coverage_runfiles.bzl
@@ -21,7 +21,7 @@ def phase_coverage_runfiles(ctx, p):
             coverage_replacements[jar] if jar in coverage_replacements else jar
             for jar in rjars.to_list()
         ])
-        coverage_runfiles = ctx.files._jacocorunner + ctx.files._lcov_merger + coverage_replacements.values()
+        coverage_runfiles = ctx.files.jacocorunner + ctx.files._lcov_merger + coverage_replacements.values()
     return struct(
         coverage_runfiles = coverage_runfiles,
         runfiles = depset(coverage_runfiles),

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -111,7 +111,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
 
     if use_jacoco and ctx.configuration.coverage_enabled:
         classpath = ctx.configuration.host_path_separator.join(
-            ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list() + ctx.files._jacocorunner],
+            ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list() + ctx.files.jacocorunner],
         )
         jacoco_metadata_file = ctx.actions.declare_file(
             "%s.jacoco_metadata.txt" % ctx.attr.name,

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -60,6 +60,9 @@ _scala_test_attrs = {
     "reporter_class": attr.string(
         default = "io.bazel.rules.scala.JUnitXmlReporter",
     ),
+    "jacocorunner": attr.label(
+        default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
+    ),
     "_scalatest": attr.label(
         default = Label(
             "@io_bazel_rules_scala//testing/toolchain:scalatest_classpath",
@@ -71,9 +74,6 @@ _scala_test_attrs = {
     ),
     "_scalatest_reporter": attr.label(
         default = Label("//scala/support:test_reporter"),
-    ),
-    "_jacocorunner": attr.label(
-        default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
     ),
     "_lcov_merger": attr.label(
         default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),

--- a/test/coverage/BUILD
+++ b/test/coverage/BUILD
@@ -7,6 +7,8 @@ scala_test(
     srcs = [
         "TestAll.scala",
     ],
+    # Test providing the default value.
+    jacocorunner = "@bazel_tools//tools/jdk:JacocoCoverage",
     deps = [
         ":a1",
         ":a2",


### PR DESCRIPTION
### Description

Enable overriding the hard-coded jacocorunner.

### Motivation

To be able to work around https://github.com/bazelbuild/bazel/issues/11674 and https://github.com/bazelbuild/rules_scala/issues/1056 rules_scala would need to enable using a custom jacocorunner (that enables upgrading Jacoco without a Bazel-wide upgrade, to solve Scala code coverage issues).