### PR TITLE
Use incompatible_use_toolchain_transition in all rules

### DIFF
--- a/docs/toolchain_development.md
+++ b/docs/toolchain_development.md
@@ -99,6 +99,7 @@ my_toolchain_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//my_rules/toolchain:my_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )
 ```
 
@@ -159,5 +160,6 @@ my_toolchain_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//my_rules/toolchain:my_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )
 ```

--- a/jmh/toolchain/toolchain.bzl
+++ b/jmh/toolchain/toolchain.bzl
@@ -33,4 +33,5 @@ export_toolchain_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//jmh/toolchain:jmh_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )

--- a/scala/plusone.bzl
+++ b/scala/plusone.bzl
@@ -24,4 +24,5 @@ collect_plus_one_deps_aspect = aspect(
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
 )

--- a/scala/private/coverage_replacements_provider.bzl
+++ b/scala/private/coverage_replacements_provider.bzl
@@ -68,6 +68,7 @@ _aspect = aspect(
     attr_aspects = _dependency_attributes,
     implementation = _aspect_impl,
     toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )
 
 def _is_enabled(ctx):

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -76,6 +76,7 @@ def make_scala_binary(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_binary_impl,
     )
 

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -118,6 +118,7 @@ def make_scala_junit_test(*extras):
         ),
         test = True,
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_junit_test_impl,
     )
 

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -97,6 +97,7 @@ def make_scala_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_library_impl,
     )
 
@@ -181,6 +182,7 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_library_for_plugin_bootstrapping_impl,
     )
 
@@ -247,6 +249,7 @@ def make_scala_macro_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_macro_library_impl,
     )
 

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -75,6 +75,7 @@ def make_scala_repl(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_repl_impl,
     )
 

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -117,6 +117,7 @@ def make_scala_test(*extras):
         ),
         test = True,
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        incompatible_use_toolchain_transition = True,
         implementation = _scala_test_impl,
     )
 

--- a/scala/private/toolchain_deps/toolchain_dep_rules.bzl
+++ b/scala/private/toolchain_deps/toolchain_dep_rules.bzl
@@ -15,4 +15,5 @@ common_toolchain_deps = rule(
         "deps_id": attr.string(mandatory = True),
     },
     toolchains = [_toolchain_type],
+    incompatible_use_toolchain_transition = True,
 )

--- a/scala/scalafmt/toolchain/toolchain.bzl
+++ b/scala/scalafmt/toolchain/toolchain.bzl
@@ -33,4 +33,5 @@ export_scalafmt_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//scala/scalafmt/toolchain:scalafmt_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )

--- a/testing/toolchain/toolchain_deps.bzl
+++ b/testing/toolchain/toolchain_deps.bzl
@@ -15,4 +15,5 @@ testing_toolchain_deps = rule(
         "deps_id": attr.string(mandatory = True),
     },
     toolchains = [_toolchain_type],
+    incompatible_use_toolchain_transition = True,
 )

--- a/tut_rule/toolchain/toolchain.bzl
+++ b/tut_rule/toolchain/toolchain.bzl
@@ -34,4 +34,5 @@ export_tut_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//tut_rule/toolchain:tut_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -39,4 +39,5 @@ export_scrooge_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -451,6 +451,7 @@ scrooge_scala_aspect = aspect(
         "@io_bazel_rules_scala//scala:toolchain_type",
         "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
 )
 
 scrooge_java_aspect = aspect(
@@ -471,6 +472,7 @@ scrooge_java_aspect = aspect(
         "@io_bazel_rules_scala//scala:toolchain_type",
         "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
     ],
+    incompatible_use_toolchain_transition = True,
     fragments = ["java"],
 )
 
@@ -547,4 +549,5 @@ scrooge_scala_import = rule(
     },
     provides = [ThriftInfo, JavaInfo, ScroogeImport],
     toolchains = ["@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type"],
+    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
Required to prevent host and target dependecies mixing for deps that come from toolchains. Example when it becomes a problem #1160 