### PR TITLE
make_scala_test: attrs keyword argument to enable default arguments for custom scala_test rules

### DIFF
--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -102,10 +102,11 @@ _scala_test_attrs.update(common_attrs)
 
 _scala_test_attrs.update(_test_resolve_deps)
 
-def make_scala_test(*extras):
+def make_scala_test(*extras, **kwargs):
     return rule(
         attrs = _dicts.add(
             _scala_test_attrs,
+            kwargs.get("attrs") if "attrs" in kwargs else {},
             extras_phases(extras),
             *[extra["attrs"] for extra in extras if "attrs" in extra]
         ),

--- a/test/scala_test/BUILD
+++ b/test/scala_test/BUILD
@@ -1,4 +1,8 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load(
+    "//test/scala_test:custom_scala_test.bzl",
+    "custom_default_attrs_scala_test",
+)
 
 scala_test(
     name = "a",
@@ -18,4 +22,12 @@ scala_test(
         "CustomReporter.scala",
     ],
     reporter_class = "test.scala_test.CustomReporter",
+)
+
+custom_default_attrs_scala_test(
+    name = "custom_reporter_with_default_attrs",
+    srcs = [
+        "A.scala",
+        "CustomReporter.scala",
+    ],
 )

--- a/test/scala_test/custom_scala_test.bzl
+++ b/test/scala_test/custom_scala_test.bzl
@@ -1,0 +1,17 @@
+"""
+This test makes sure custom default attributes can be defined for rules created with make_scala_test
+"""
+
+load(
+    "//scala:advanced_usage/scala.bzl",
+    _make_scala_test = "make_scala_test",
+)
+
+# Inputs for customizable default attributes of make_scala_test
+custom_default_attrs = {
+    "reporter_class": attr.string(
+        default = "test.scala_test.CustomReporter",
+    ),
+}
+
+custom_default_attrs_scala_test = _make_scala_test(attrs = custom_default_attrs)


### PR DESCRIPTION
### Description
Custom default attributes for make_scala_test to override rules_scala defaults.

extras already enables custom arguments but it's strongly coupled with phases.
Sometimes you may want to override some default arguments for your custom
scala_test rule created by make_scala_test.

Enabled keyword arguments on make_scala_test.
Use `attrs` to provide your own default attrs.

### Motivation
For certain attributes of your custom scala_test rules you may want to provide other defaults then foreseen by rules_scala. #1163 could be even more useful with this PR, as you could provide `jacocorunner` just once in your make_scala_test definition.