### PR TITLE
Use toolchain for providing jacocorunner

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -61,7 +61,7 @@ register_toolchains('//my/package:testing_toolchains_with_junit')
 `junit_classpath_provider` (deps_id `junit_classpath`) is where classpath required for junit tests
 is defined.
 
-### ScalaTest dependencies can be configured by decalring a provider with an id `scalatest_classpath`:
+### ScalaTest dependencies can be configured by declaring a provider with an id `scalatest_classpath`:
 
 ```starlark
 # my/package/BUILD

--- a/manual_test/scala_test_jacocorunner/BUILD
+++ b/manual_test/scala_test_jacocorunner/BUILD
@@ -1,0 +1,20 @@
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("//scala:scala.bzl", "scala_test")
+
+scala_toolchain(
+    name = "passing_toolchain_impl",
+    jacocorunner = "@bazel_tools//tools/jdk:JacocoCoverage",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "passing_scala_toolchain",
+    toolchain = "passing_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+scala_test(
+    name = "empty_test",
+    srcs = ["EmptyTest.scala"],
+)

--- a/manual_test/scala_test_jacocorunner/EmptyTest.scala
+++ b/manual_test/scala_test_jacocorunner/EmptyTest.scala
@@ -1,0 +1,9 @@
+package test_expect_failure.scala_test_jacocorunner
+
+import org.scalatest.funsuite._
+
+class EmptyTest extends AnyFunSuite {
+  test("empty test") {
+    assert(true)
+  }
+}

--- a/scala/private/phases/phase_coverage_runfiles.bzl
+++ b/scala/private/phases/phase_coverage_runfiles.bzl
@@ -21,7 +21,8 @@ def phase_coverage_runfiles(ctx, p):
             coverage_replacements[jar] if jar in coverage_replacements else jar
             for jar in rjars.to_list()
         ])
-        coverage_runfiles = ctx.files._jacocorunner + ctx.files._lcov_merger + coverage_replacements.values()
+        jacocorunner = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].jacocorunner
+        coverage_runfiles = jacocorunner.files.to_list() + ctx.files._lcov_merger + coverage_replacements.values()
     return struct(
         coverage_runfiles = coverage_runfiles,
         runfiles = depset(coverage_runfiles),

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -110,8 +110,9 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
     )
 
     if use_jacoco and ctx.configuration.coverage_enabled:
+        jacocorunner = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].jacocorunner
         classpath = ctx.configuration.host_path_separator.join(
-            ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list() + ctx.files._jacocorunner],
+            ["${RUNPATH}%s" % (j.short_path) for j in rjars.to_list() + jacocorunner.files.to_list()],
         )
         jacoco_metadata_file = ctx.actions.declare_file(
             "%s.jacoco_metadata.txt" % ctx.attr.name,

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -72,9 +72,6 @@ _scala_test_attrs = {
     "_scalatest_reporter": attr.label(
         default = Label("//scala/support:test_reporter"),
     ),
-    "_jacocorunner": attr.label(
-        default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
-    ),
     "_lcov_merger": attr.label(
         default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
     ),

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -58,6 +58,7 @@ def _scala_toolchain_impl(ctx):
         scalac_jvm_flags = ctx.attr.scalac_jvm_flags,
         scala_test_jvm_flags = ctx.attr.scala_test_jvm_flags,
         enable_diagnostics_report = enable_diagnostics_report,
+        jacocorunner = ctx.attr.jacocorunner,
     )
     return [toolchain]
 
@@ -95,6 +96,9 @@ scala_toolchain = rule(
         "scala_test_jvm_flags": attr.string_list(),
         "enable_diagnostics_report": attr.bool(
             doc = "Enable the output of structured diagnostics through the BEP",
+        ),
+        "jacocorunner": attr.label(
+            default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
         ),
     },
     fragments = ["java"],

--- a/test/shell/test_scala_jacocorunner.sh
+++ b/test/shell/test_scala_jacocorunner.sh
@@ -1,0 +1,16 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_scala_jacocorunner_from_scala_toolchain_passes() {
+  bazel coverage --extra_toolchains="//manual_test/scala_test_jacocorunner:passing_scala_toolchain" //manual_test/scala_test_jacocorunner:empty_test
+}
+
+test_scala_jacocorunner_from_scala_toolchain_fails() {
+  action_should_fail coverage --extra_toolchains="//test_expect_failure/scala_test_jacocorunner:failing_scala_toolchain" //test_expect_failure/scala_test_jacocorunner:empty_test
+}
+
+$runner test_scala_jacocorunner_from_scala_toolchain_passes
+$runner test_scala_jacocorunner_from_scala_toolchain_fails

--- a/test_expect_failure/scala_test_jacocorunner/BUILD
+++ b/test_expect_failure/scala_test_jacocorunner/BUILD
@@ -1,0 +1,26 @@
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("//scala:scala.bzl", "scala_test")
+
+scala_toolchain(
+    name = "failing_toolchain_impl",
+    # This will fail because :failing_jacocorunner is not a valid JacocoRunner.
+    jacocorunner = ":failing_jacocorunner",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "failing_scala_toolchain",
+    toolchain = "failing_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+scala_test(
+    name = "empty_test",
+    srcs = ["EmptyTest.scala"],
+)
+
+filegroup(
+    name = "failing_jacocorunner",
+    srcs = ["EmptyTest.scala"],
+)

--- a/test_expect_failure/scala_test_jacocorunner/EmptyTest.scala
+++ b/test_expect_failure/scala_test_jacocorunner/EmptyTest.scala
@@ -1,0 +1,9 @@
+package test_expect_failure.scala_test_jacocorunner
+
+import org.scalatest.FunSuite
+
+class EmptyTest extends FunSuite {
+    test("empty test") {
+        assert(true)
+    }
+}

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -40,6 +40,7 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 . "${test_dir}"/test_scala_classpath.sh
 . "${test_dir}"/test_scala_import_source_jar.sh
 . "${test_dir}"/test_scala_jvm_flags.sh
+. "${test_dir}"/test_scala_jacocorunner.sh
 . "${test_dir}"/test_scala_library_jar.sh
 . "${test_dir}"/test_scala_proto_library.sh
 . "${test_dir}"/test_scala_library.sh


### PR DESCRIPTION
### Description
Use toolchains to provide jacocorunner for scala_test.
This is to enable overriding jacocorunner.

### Motivation
Following the discussion in #1166 and #1163, this is the latest proposal to solve #1056.
