### PR TITLE
Script to generate custom jacocorunner

### DIFF
--- a/docs/coverage.md
+++ b/docs/coverage.md
@@ -58,3 +58,46 @@ echo "coverage report at file://${destdir}/index.html"
 ### Support for testing frameworks
 
 Coverage support has been only tested with [ScalaTest](http://www.scalatest.org/).
+
+### Working around missing lambda coverage with Scala 2.12+
+
+The current Jacoco version in Bazel (0.8.3) has missing coverage for lambdas
+(including for comprehensions; see issue https://github.com/bazelbuild/rules_scala/issues/1056).
+This can be worked around by building a fixed version of Jacoco yourselves (including backported fixes from 0.8.5) and reconfiguring your
+build to use that one instead of the default `jacocorunner`.
+
+You can build jacocorunner with a script in `scripts/build_jacocorunner/build_jacocorunner.sh` (see comments there for more explanation and options).
+
+Then, you can use the `jacocorunner` property of `scala_toolchain` to provide the jacocorunner you have built:
+
+```
+# Example contents of coverage_local_jacocorunner/BUILD
+scala_toolchain(
+    name = "local_jacocorunner_toolchain_impl",
+    jacocorunner = ":local_jacocorunner",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "local_jacocorunner_scala_toolchain",
+    toolchain = "local_jacocorunner_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "local_jacocorunner",
+    srcs = ["JacocoCoverage_jarjar_deploy.jar"],
+)
+```
+
+In this example `jacocorunner` is provided as a local file, but you could also upload your version to an artifactory and then use `http_file` (to avoid
+keeping binaries in your repository).
+
+Finally provide the `scala_toolchain` in your `.bazelrc` or as an option to `bazel coverage`:
+
+```
+coverage --extra_toolchains="//coverage_local_jacocorunner:local_jacocorunner_scala_toolchain"
+```
+
+You can verify that the locally built `jacocorunner` works with `manual_test/coverage_local_jacocorunner/test.sh`.

--- a/manual_test/coverage_local_jacocorunner/BUILD
+++ b/manual_test/coverage_local_jacocorunner/BUILD
@@ -1,0 +1,20 @@
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("//scala:scala.bzl", "scala_test")
+
+scala_toolchain(
+    name = "local_jacocorunner_toolchain_impl",
+    jacocorunner = ":local_jacocorunner",
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "local_jacocorunner_scala_toolchain",
+    toolchain = "local_jacocorunner_toolchain_impl",
+    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "local_jacocorunner",
+    srcs = ["JacocoCoverage_jarjar_deploy.jar"],
+)

--- a/manual_test/coverage_local_jacocorunner/expected-coverage.dat
+++ b/manual_test/coverage_local_jacocorunner/expected-coverage.dat
@@ -1,0 +1,192 @@
+SF:test/coverage/A1.scala
+FN:-1,coverage/A1$::<clinit> ()V
+FN:3,coverage/A1$::<init> ()V
+FN:5,coverage/A1$::a1 (Z)Lcoverage/B1$;
+FN:-1,coverage/A1::a1 (Z)Lcoverage/B1$;
+FNDA:1,coverage/A1$::<clinit> ()V
+FNDA:1,coverage/A1$::<init> ()V
+FNDA:1,coverage/A1$::a1 (Z)Lcoverage/B1$;
+FNDA:0,coverage/A1::a1 (Z)Lcoverage/B1$;
+FNF:4
+FNH:3
+BRDA:5,0,0,-
+BRF:1
+BRH:0
+DA:3,1
+DA:5,1
+DA:6,1
+DA:7,1
+LH:4
+LF:4
+end_of_record
+SF:test/coverage/A2.scala
+FN:-1,coverage/A2$::<clinit> ()V
+FN:3,coverage/A2$::<init> ()V
+FN:5,coverage/A2$::a2 ()V
+FN:-1,coverage/A2::a2 ()V
+FNDA:1,coverage/A2$::<clinit> ()V
+FNDA:1,coverage/A2$::<init> ()V
+FNDA:1,coverage/A2$::a2 ()V
+FNDA:0,coverage/A2::a2 ()V
+FNF:4
+FNH:3
+DA:3,1
+DA:5,1
+DA:8,1
+LH:3
+LF:3
+end_of_record
+SF:test/coverage/B1.scala
+FN:-1,coverage/B1$::<clinit> ()V
+FN:3,coverage/B1$::<init> ()V
+FN:6,coverage/B1$::not_called ()V
+FN:-1,coverage/B1::not_called ()V
+FNDA:1,coverage/B1$::<clinit> ()V
+FNDA:1,coverage/B1$::<init> ()V
+FNDA:0,coverage/B1$::not_called ()V
+FNDA:0,coverage/B1::not_called ()V
+FNF:4
+FNH:2
+DA:3,1
+DA:6,0
+DA:9,1
+LH:2
+LF:3
+end_of_record
+SF:test/coverage/B2.java
+FN:3,coverage/B2::<init> ()V
+FN:5,coverage/B2::b2_a ()Ljava/lang/String;
+FN:9,coverage/B2::b2_b ()V
+FNDA:0,coverage/B2::<init> ()V
+FNDA:1,coverage/B2::b2_a ()Ljava/lang/String;
+FNDA:0,coverage/B2::b2_b ()V
+FNF:3
+FNH:1
+DA:3,0
+DA:5,1
+DA:9,0
+DA:10,0
+LH:1
+LF:4
+end_of_record
+SF:test/coverage/C2.scala
+FN:-1,coverage/C2$::<clinit> ()V
+FN:3,coverage/C2$::<init> ()V
+FN:5,coverage/C2$::c2 (Ljava/lang/String;)Ljava/lang/String;
+FN:-1,coverage/C2::c2 (Ljava/lang/String;)Ljava/lang/String;
+FNDA:1,coverage/C2$::<clinit> ()V
+FNDA:1,coverage/C2$::<init> ()V
+FNDA:1,coverage/C2$::c2 (Ljava/lang/String;)Ljava/lang/String;
+FNDA:1,coverage/C2::c2 (Ljava/lang/String;)Ljava/lang/String;
+FNF:4
+FNH:4
+DA:3,1
+DA:5,1
+DA:7,1
+LH:3
+LF:3
+end_of_record
+SF:test/coverage/D1.scala
+FN:10,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$1 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:19,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$10 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:20,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$11 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:21,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$12 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:22,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$13 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:23,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$14 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:24,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$15 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:25,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$16 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:26,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$17 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:27,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$18 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:28,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$19 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:11,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$2 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:29,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$20 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:30,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$21 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:31,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$22 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:32,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$23 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:33,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$24 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:34,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$25 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:35,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$26 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:36,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$27 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:38,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$28 (Ljava/lang/String;)V
+FN:36,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$28$adapted (Ljava/lang/String;)Ljava/lang/Object;
+FN:12,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$3 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:13,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$4 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:14,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$5 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:15,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$6 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:16,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$7 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:17,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$8 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:18,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$9 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FN:-1,coverage/D1$::<clinit> ()V
+FN:3,coverage/D1$::<init> ()V
+FN:5,coverage/D1$::veryLongFunctionNameIsHereAaaaaaaaa ()V
+FN:-1,coverage/D1::veryLongFunctionNameIsHereAaaaaaaaa ()V
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$1 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$10 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$11 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$12 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$13 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$14 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$15 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$16 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$17 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$18 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$19 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$2 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$20 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$21 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$22 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$23 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$24 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$25 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$26 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$27 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$28 (Ljava/lang/String;)V
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$28$adapted (Ljava/lang/String;)Ljava/lang/Object;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$3 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$4 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$5 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$6 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$7 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$8 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::$anonfun$veryLongFunctionNameIsHereAaaaaaaaa$9 (Lscala/collection/immutable/List;Ljava/lang/String;)Lscala/collection/immutable/List;
+FNDA:1,coverage/D1$::<clinit> ()V
+FNDA:1,coverage/D1$::<init> ()V
+FNDA:1,coverage/D1$::veryLongFunctionNameIsHereAaaaaaaaa ()V
+FNDA:0,coverage/D1::veryLongFunctionNameIsHereAaaaaaaaa ()V
+FNF:33
+FNH:32
+DA:3,1
+DA:5,1
+DA:9,1
+DA:10,1
+DA:11,1
+DA:12,1
+DA:13,1
+DA:14,1
+DA:15,1
+DA:16,1
+DA:17,1
+DA:18,1
+DA:19,1
+DA:20,1
+DA:21,1
+DA:22,1
+DA:23,1
+DA:24,1
+DA:25,1
+DA:26,1
+DA:27,1
+DA:28,1
+DA:29,1
+DA:30,1
+DA:31,1
+DA:32,1
+DA:33,1
+DA:34,1
+DA:35,1
+DA:36,1
+DA:38,1
+DA:41,1
+LH:32
+LF:32
+end_of_record

--- a/manual_test/coverage_local_jacocorunner/test.sh
+++ b/manual_test/coverage_local_jacocorunner/test.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#
+# Test to be run for manual verification of built jacocorunner.
+#
+# It first builds custom jacocorunner and then verifies it.
+
+set -e
+
+if ! bazel_loc="$(type -p 'bazel')" || [[ -z "$bazel_loc" ]]; then
+  export PATH="$(cd "$(dirname "$0")"; pwd)"/tools:$PATH
+  echo 'Using ./tools/bazel directly for bazel calls'
+fi
+
+root_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/../../
+
+test_dir=$root_dir/test/shell
+. "${test_dir}"/test_runner.sh
+. "${test_dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_coverage_with_local_jacocorunner() {
+    bazel coverage --extra_toolchains="//manual_test/coverage_local_jacocorunner:local_jacocorunner_scala_toolchain" //test/coverage/...
+    diff $root_dir/manual_test/coverage_local_jacocorunner/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage/test-all/coverage.dat
+}
+
+build_local_jacocorunner() {
+    $root_dir/scripts/build_jacocorunner/build_jacocorunner.sh
+    cp /tmp/bazel_jacocorunner_build/JacocoCoverage_jarjar_deploy.jar $root_dir/manual_test/coverage_local_jacocorunner
+}
+
+build_local_jacocorunner
+$runner test_coverage_with_local_jacocorunner

--- a/scripts/build_jacocorunner/0001-Build-Jacoco-for-Bazel.patch
+++ b/scripts/build_jacocorunner/0001-Build-Jacoco-for-Bazel.patch
@@ -1,0 +1,25 @@
+From d4e6b4455e516e3a35058064d32979979cc4f80c Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gergely=20F=C3=A1bi=C3=A1n?= <gergo.fb@gmail.com>
+Date: Fri, 18 Dec 2020 11:43:59 +0100
+Subject: [PATCH 1/2] Build Jacoco for Bazel
+
+---
+ org.jacoco.build/pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/org.jacoco.build/pom.xml b/org.jacoco.build/pom.xml
+index edb2d126..fcb57f55 100644
+--- a/org.jacoco.build/pom.xml
++++ b/org.jacoco.build/pom.xml
+@@ -646,7 +646,7 @@
+                 project.getProperties().setProperty("build.date", buildDate);
+ 
+                 buildNumber = project.getProperties().get("buildNumber");
+-                pkgName = buildNumber.substring(buildNumber.length() - 7, buildNumber.length());
++                pkgName = "1f1cc91";
+                 project.getProperties().setProperty("jacoco.runtime.package.name", "org.jacoco.agent.rt.internal_" + pkgName);
+               ]]>
+               </script>
+-- 
+2.25.1
+

--- a/scripts/build_jacocorunner/0002-Build-Jacoco-behind-proxy.patch
+++ b/scripts/build_jacocorunner/0002-Build-Jacoco-behind-proxy.patch
@@ -1,0 +1,37 @@
+From c789ef7cc8e97d80b8dabd7267b714bcb04febad Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gergely=20F=C3=A1bi=C3=A1n?= <gergo.fb@gmail.com>
+Date: Sat, 19 Dec 2020 08:54:33 +0100
+Subject: [PATCH 2/2] Build Jacoco behind proxy
+
+---
+ jacoco-maven-plugin.test/it/settings.xml | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/jacoco-maven-plugin.test/it/settings.xml b/jacoco-maven-plugin.test/it/settings.xml
+index 31132fe4..6ae986d7 100644
+--- a/jacoco-maven-plugin.test/it/settings.xml
++++ b/jacoco-maven-plugin.test/it/settings.xml
+@@ -42,4 +42,20 @@
+       </pluginRepositories>
+     </profile>
+   </profiles>
++    <proxies>
++        <proxy>
++            <id>http_proxy</id>
++            <active>true</active>
++            <protocol>http</protocol>
++            <host>127.0.0.1</host>
++            <port>3128</port>
++        </proxy>
++        <proxy>
++            <id>https_proxy</id>
++            <active>true</active>
++            <protocol>https</protocol>
++            <host>127.0.0.1</host>
++            <port>3128</port>
++        </proxy>
++    </proxies>
+ </settings>
+-- 
+2.25.1
+

--- a/scripts/build_jacocorunner/build_jacocorunner.sh
+++ b/scripts/build_jacocorunner/build_jacocorunner.sh
@@ -42,7 +42,11 @@ set -e
 
 source_path=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
 
-jacoco_repo=$HOME/Work/jacoco
+build_dir=/tmp/bazel_jacocorunner_build
+
+mkdir -p $build_dir
+
+jacoco_repo=$build_dir/jacoco
 # Take a fork for Jacoco that contains Scala fixes.
 jacoco_remote=https://github.com/gergelyfabian/jacoco
 # Choose a branch you'd like to use.
@@ -62,7 +66,7 @@ jacoco_patches="$jacoco_patches 0001-Build-Jacoco-for-Bazel.patch"
 # Jacoco version should be 0.8.3 in any case as Bazel is only compatible with that at this moment.
 jacoco_version=0.8.3
 
-bazel_repo=$HOME/Work/bazel
+bazel_repo=$build_dir/bazel
 bazel_remote=https://github.com/bazelbuild/bazel
 bazel_branch=master
 # Advanced option: take a fork that has fixes for Jacoco LCOV formatter, to respect Jacoco filtering
@@ -72,7 +76,7 @@ bazel_branch=master
 
 bazel_build_target=JacocoCoverage_jarjar_deploy.jar
 
-destination_dir=$HOME
+destination_dir=$build_dir
 
 # Generate the jar.
 
@@ -125,4 +129,3 @@ chmod +w $destination_dir/$bazel_build_target
 
 echo "JacocoRunner is available at: $destination_dir/$bazel_build_target"
 )
-

--- a/scripts/build_jacocorunner/build_jacocorunner.sh
+++ b/scripts/build_jacocorunner/build_jacocorunner.sh
@@ -10,7 +10,7 @@
 #    https://github.com/bazelbuild/rules_scala/issues/1056
 #    https://github.com/bazelbuild/bazel/issues/11674
 #
-#    Backported fix from Jacoco 0.8.5 to Jacoco 0.8.3:
+#    Backported fix from Jacoco 0.8.5 to Jacoco 0.8.3 (current Bazel is not compatible with Jacoco 0.8.5):
 #    https://github.com/gergelyfabian/jacoco/tree/0.8.3-scala-lambda-fix
 #
 # 2. Bazel ignores Jacoco's filtering for branch coverage metrics:
@@ -37,10 +37,36 @@
 # and then provide the built jar as a parameter of `java_toolchain` and/or `scala_toolchain` to use the changed behavior for coverage.
 #
 # Choose the fixes from the above list by configuring the used branches for Bazel and Jacoco repos below.
+#
+# Patches:
+#
+# There are also some patches that may need to be applied for Jacoco, according to your preferences:
+#
+# 1. Bazel is compatible only with Jacoco in a specific package name. This is not Jacoco-specific, so not committed to the Jacoco fork.
+#    See 0001-Build-Jacoco-for-Bazel.patch.
+# 2. Building Jacoco behind a proxy needs a workaround.
+#    See 0002-Build-Jacoco-behind-proxy.patch.
+#
+# Set up the patch file names in `jacoco_patches`.
+#
+# Dependencies:
+#
+# On OS X greadlink is needed (by running `brew install coreutils`).
 
 set -e
 
-source_path=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+
+if [[ "$OSTYPE" == "linux-gnu"* ]]; then
+  readlink_cmd="readlink"
+elif [[ "$OSTYPE" == "darwin"* ]]; then
+  readlink_cmd="greadlink"
+else
+  echo "OS not supported: $OSTYPE"
+  exit 1
+fi
+
+source_path=$($readlink_cmd -f $(dirname ${BASH_SOURCE[0]}))
 
 build_dir=/tmp/bazel_jacocorunner_build
 

--- a/scripts/build_jacocorunner/build_jacocorunner.sh
+++ b/scripts/build_jacocorunner/build_jacocorunner.sh
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+#
+# Script to build custom version of `JacocoCoverage_jarjar_deploy.jar` from Jacoco and Bazel repositories.
+#
+# The default `JacocoCoverage_jarjar_deploy.jar` has some issues:
+#
+# 1. Bazel uses Jacoco 0.8.3 that has poor Scala support, including a bug that filters out Scala lambdas on Scala >=2.12
+#
+#    Bug report:
+#    https://github.com/bazelbuild/rules_scala/issues/1056
+#    https://github.com/bazelbuild/bazel/issues/11674
+#
+#    Backported fix from Jacoco 0.8.5 to Jacoco 0.8.3:
+#    https://github.com/gergelyfabian/jacoco/tree/0.8.3-scala-lambda-fix
+#
+# 2. Bazel ignores Jacoco's filtering for branch coverage metrics:
+#
+#    Bug report:
+#    https://github.com/bazelbuild/bazel/issues/12696
+#
+#    Proposed fix:
+#    https://github.com/gergelyfabian/bazel/tree/branch_coverage_respect_jacoco_filtering
+#
+# 3. Scala support on newer Jacoco versions (including 0.8.5) is still lacking some functionality
+#
+#    E.g. a lot of generated methods for case classes, lazy vals or other Scala features are causing falsely missed branches in branch coverage.
+#
+#    Proposed changes in:
+#    https://github.com/gergelyfabian/jacoco/tree/scala
+#
+#    Backported to 0.8.3 (to be usable with current Bazel):
+#    https://github.com/gergelyfabian/jacoco/tree/0.8.3-scala
+#
+#    These branches also include the Scala 2.12 lambda coverage fix.
+#
+# You can use this script to build a custom version of `JacocoCoverage_jarjar_deploy.jar`, including any fixes from the above list you wish
+# and then provide the built jar as a parameter of `java_toolchain` and/or `scala_toolchain` to use the changed behavior for coverage.
+#
+# Choose the fixes from the above list by configuring the used branches for Bazel and Jacoco repos below.
+
+set -e
+
+source_path=$(readlink -f $(dirname ${BASH_SOURCE[0]}))
+
+jacoco_repo=$HOME/Work/jacoco
+# Take a fork for Jacoco that contains Scala fixes.
+jacoco_remote=https://github.com/gergelyfabian/jacoco
+# Choose a branch you'd like to use.
+# Default option, take only fixes for Scala 2.12 lambdas backported to Jacoco 0.8.3:
+jacoco_branch=0.8.3-scala-lambda-fix
+# Advanced option, take further fixes for Scala (2.11, 2.12 and 2.13) - branch in development:
+#jacoco_branch=0.8.3-scala
+
+# Choose the patches that you'd like to use:
+jacoco_patches=""
+# Bazel needs to have a certain Jacoco package version:
+jacoco_patches="$jacoco_patches 0001-Build-Jacoco-for-Bazel.patch"
+# Uncomment this if you are behind a proxy:
+#jacoco_patches="$jacoco_patches 0002-Build-Jacoco-behind-proxy.patch"
+
+
+# Jacoco version should be 0.8.3 in any case as Bazel is only compatible with that at this moment.
+jacoco_version=0.8.3
+
+bazel_repo=$HOME/Work/bazel
+bazel_remote=https://github.com/bazelbuild/bazel
+bazel_branch=master
+# Advanced option: take a fork that has fixes for Jacoco LCOV formatter, to respect Jacoco filtering
+# (fixes for Scala in Jacoco respected in Bazel branch coverage):
+#bazel_remote=https://github.com/gergelyfabian/bazel
+#bazel_branch=branch_coverage_respect_jacoco_filtering
+
+bazel_build_target=JacocoCoverage_jarjar_deploy.jar
+
+destination_dir=$HOME
+
+# Generate the jar.
+
+if [ ! -d $jacoco_repo ]; then
+  (
+  cd $(dirname $jacoco_repo)
+  git clone $jacoco_remote
+  )
+fi
+
+if [ ! -d $bazel_repo ]; then
+  (
+  cd $(dirname $bazel_repo)
+  git clone $bazel_remote
+  )
+fi
+
+(
+cd $jacoco_repo
+git remote update
+git checkout origin/$jacoco_branch
+# Need to patch Jacoco:
+for patch in $jacoco_patches; do
+  git am $source_path/$patch
+done
+mvn clean install
+)
+
+(
+cd $bazel_repo
+git remote update
+git checkout origin/$bazel_branch
+
+# Prepare Jacoco version.
+cd third_party/java/jacoco
+# Remove any previously unpacked Jacoco files.
+rm -rf coverage/ doc/ index.html lib/ test/
+unzip $HOME/.m2/repository/org/jacoco/jacoco/${jacoco_version}/jacoco-${jacoco_version}.zip
+cp lib/jacocoagent.jar jacocoagent-${jacoco_version}.jar
+cp lib/org.jacoco.agent-* org.jacoco.agent-${jacoco_version}.jar
+cp lib/org.jacoco.core-* org.jacoco.core-${jacoco_version}.jar
+cp lib/org.jacoco.report-* org.jacoco.report-${jacoco_version}.jar
+cd ../../..
+
+# Build JacocoRunner.
+bazel build src/java_tools/junitrunner/java/com/google/testing/coverage:$bazel_build_target
+cp bazel-bin/src/java_tools/junitrunner/java/com/google/testing/coverage/$bazel_build_target $destination_dir/
+# Make the jar writable to enable re-running the script.
+chmod +w $destination_dir/$bazel_build_target
+
+echo "JacocoRunner is available at: $destination_dir/$bazel_build_target"
+)
+


### PR DESCRIPTION
### Description
This is a script that can be used manually to generate custom jacocorunner, that then can be used to
e.g. fix Scala 2.12 code coverage for lambdas.

Takes Jacoco, builds and and then use it to build jacocorunner in Bazel repo.

### Motivation
Motivated by the idea to add the generated jacocorunner to rules_scala.

More info at: https://github.com/bazelbuild/bazel/issues/11674#issuecomment-748422907.
