### PR TITLE
Fix error reporting on 2.11

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
+++ b/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
@@ -5,12 +5,13 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import scala.tools.nsc.Settings;
-import scala.tools.nsc.reporters.ConsoleReporter;
+import scala.tools.nsc.reporters.Reporter;
 import scala.tools.nsc.MainClass;
 import scala.tools.nsc.Global;
 
 public class ReportableMainClass extends MainClass {
     private Global compiler;
+    private Reporter reporter;
     private final CompileOptions ops;
 
     public ReportableMainClass(CompileOptions ops) {
@@ -21,14 +22,16 @@ public class ReportableMainClass extends MainClass {
     public Global newCompiler() {
         if (!ops.enableDiagnosticsReport) {
             createDiagnosticsFile();
-            return super.newCompiler();
+            Global global = super.newCompiler();
+            reporter = global.reporter();
+            return global;
         }
 
         if (compiler == null) {
             createDiagnosticsFile();
 
             Settings settings = super.settings();
-            ConsoleReporter reporter = new ProtoReporter(settings);
+            reporter = new ProtoReporter(settings);
 
             compiler = new Global(settings, reporter);
         }
@@ -43,5 +46,9 @@ public class ReportableMainClass extends MainClass {
         } catch (IOException e) {
             throw new RuntimeException("Could not delete/make diagnostics proto file", e);
         }
+    }
+
+    public Reporter getReporter(){
+        return this.reporter;
     }
 }

--- a/test_version.sh
+++ b/test_version.sh
@@ -157,7 +157,6 @@ TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${no_diagnostics_
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${no_diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${no_diagnostics_reporter_toolchain}"
 
-#TODO: Uncomment this out after diagnostics reporter properly reports errors for scala 2.11
-#TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${diagnostics_reporter_toolchain}"
+TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${diagnostics_reporter_toolchain}"
 TESTs_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_toolchain}"

--- a/test_version.sh
+++ b/test_version.sh
@@ -159,4 +159,4 @@ TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${no_diagnostics_
 
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_11_version}" "${diagnostics_reporter_toolchain}"
 TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${diagnostics_reporter_toolchain}"
-TESTs_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_toolchain}"
+TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_toolchain}"


### PR DESCRIPTION
### Description
Closes #1161 . Changed how the reporter is obtained from the `MainClass`, since the call to `getDeclaredField` is obtaining the wrong reporter for scala 2.11.

### Motivation
Fixes problems regarding building for scala 2.11, where the build was exiting without flagging errors, whenever the `DiagnosticsReporter` was used
