### PR TITLE
Fix docs: use external label for minimal deps toolchain

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,7 +230,7 @@ With these settings, we also will error on dependencies which are unneeded, and 
 
 The dependency tracking method `ast` is experimental but so far proves to be better than the default for computing the direct dependencies for `plus-one` mode code. In the future we hope to make this the default for `plus-one` mode and remove the option altogether.
 
-To try it out you can use the following toolchain: `//scala:minimal_direct_source_deps`.
+To try it out you can use the following toolchain: `@io_bazel_rules_scala//scala:minimal_direct_source_deps`.
 
 ### [Experimental] Dependency mode
 


### PR DESCRIPTION
Must be external label to be used outside the rules_scala repo