### PR TITLE
Update docs to the latest master version

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,11 +41,11 @@ http_archive(
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
 
-rules_scala_version = "9bd9ffd3e52ab9e92b4f7b43051d83231743f231"
+rules_scala_version = "5df8033f752be64fbe2cedfd1bdbad56e2033b15"
 
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "438bc03bbb971c45385fde5762ab368a3321e9db5aa78b96252736d86396a9da",
+    sha256 = "b7fa29db72408a972e6b6685d1bc17465b3108b620cb56d9b1700cf6f70f624a",
     strip_prefix = "rules_scala-%s" % rules_scala_version,
     type = "zip",
     url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,


### PR DESCRIPTION
Updated to the latest master version because docs version had issues with 2.11 error reporting 