### PR TITLE
Attempt to load target label from jar for unknown labels

### DIFF
--- a/test/shell/test_scala_library.sh
+++ b/test/shell/test_scala_library.sh
@@ -159,10 +159,20 @@ test_scala_library_expect_failure_on_java_in_src_jar_when_disabled() {
   test_expect_failure_with_message "${expected_message}" $test_target
 }
 
-test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules() {
+test_scala_library_expect_better_failure_with_target_label_from_stamped_jar_on_missing_transitive_dependency() {
   transitive_target='.*transitive_dependency-ijar.jar'
   direct_target='//test_expect_failure/missing_direct_deps/internal_deps:direct_java_provider_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:dependent_on_some_java_provider'
+
+  expected_message='//test_expect_failure/missing_direct_deps/internal_deps:transitive_dependency'
+
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message "${expected_message}" $test_target "--extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_error"
+}
+
+test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules() {
+  transitive_target='.*transitive_dependency_without_manifest.jar'
+  direct_target='//test_expect_failure/missing_direct_deps/internal_deps:unstamped_direct_java_provider_dependency'
+  test_target='//test_expect_failure/missing_direct_deps/internal_deps:unstamped_jar_dependent_on_some_java_provider'
 
   expected_message="Unknown label of file $transitive_target which came from $direct_target"
 
@@ -184,3 +194,4 @@ $runner test_scala_library_expect_no_java_recompilation_on_internal_change_of_sc
 $runner test_scala_library_expect_failure_on_missing_direct_java
 $runner test_scala_library_expect_failure_on_java_in_src_jar_when_disabled
 $runner test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules
+$runner test_scala_library_expect_better_failure_with_target_label_from_stamped_jar_on_missing_transitive_dependency

--- a/test_expect_failure/missing_direct_deps/internal_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/internal_deps/BUILD
@@ -97,3 +97,28 @@ java_library(
     srcs = ["Placeholder.java"],
     deps = ["transitive_dependency"],
 )
+
+genrule(
+    name = "transitive_dependency_jar_without_manifest",
+    srcs = ["transitive_dependency.jar"],
+    outs = ["transitive_dependency_without_manifest.jar"],
+    cmd = "zip -d $(location transitive_dependency.jar) META-INF/MANIFEST.MF --out $@",
+)
+
+custom_jvm(
+    name = "unstamped_direct_java_provider_dependency",
+    deps = [":transitive_dep_without_manifest"],
+)
+
+custom_jvm(
+    name = "transitive_dep_without_manifest",
+    jar = "transitive_dependency_without_manifest.jar",
+)
+
+scala_library(
+    name = "unstamped_jar_dependent_on_some_java_provider",
+    srcs = [
+        "HasCustomJavaProviderDependency.scala",
+    ],
+    deps = ["unstamped_direct_java_provider_dependency"],
+)

--- a/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
+++ b/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
@@ -1,7 +1,7 @@
 #This rule is an example for a jvm rule that doesn't support Jars2Labels
 def _custom_jvm_impl(ctx):
     # TODO(#8867): Migrate away from the placeholder jar hack when #8867 is fixed.
-    jar = ctx.file._placeholder_jar
+    jar = ctx.file.jar
     provider = JavaInfo(
         output_jar = jar,
         compile_jar = jar,
@@ -13,7 +13,7 @@ custom_jvm = rule(
     implementation = _custom_jvm_impl,
     attrs = {
         "deps": attr.label_list(),
-        "_placeholder_jar": attr.label(
+        "jar": attr.label(
             allow_single_file = True,
             default = Label("@io_bazel_rules_scala//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar"),
         ),


### PR DESCRIPTION
This should address problems like #553 if dependency comes with a stamped jar (for example _rules_jvm_external_ can be used with a setting to stamp third party jars). This is an opportunistic implementation - ideally the whole dep validation mechanism should be refactored to have a better API around "Unknow label", but that's much bigger effort for the future.