### PR TITLE
Remove specs2 binds

### DIFF
--- a/specs2/BUILD
+++ b/specs2/BUILD
@@ -9,7 +9,6 @@ java_import(
         "//testing/toolchain:specs2_classpath",
     ],
     deps = [
-        "//scala/private/toolchain_deps:scala_library_classpath",
         "//scala/private/toolchain_deps:scala_xml",
     ],
 )

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -22,10 +22,5 @@ def specs2_repositories(
         overriden_artifacts = overriden_artifacts,
     )
 
-    native.bind(
-        name = "io_bazel_rules_scala/dependency/specs2/specs2",
-        actual = "@io_bazel_rules_scala//specs2:specs2",
-    )
-
 def specs2_dependencies():
-    return ["//external:io_bazel_rules_scala/dependency/specs2/specs2"]
+    return ["@io_bazel_rules_scala//specs2:specs2"]

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -26,12 +26,7 @@ def specs2_junit_repositories(
         overriden_artifacts = overriden_artifacts,
     )
 
-    native.bind(
-        name = "io_bazel_rules_scala/dependency/specs2/specs2_junit",
-        actual = "@io_bazel_rules_scala_org_specs2_specs2_junit",
-    )
-
 def specs2_junit_dependencies():
     return specs2_dependencies() + [
-        "//external:io_bazel_rules_scala/dependency/specs2/specs2_junit",
+        "@io_bazel_rules_scala//testing/toolchain:specs2_junit_classpath",
     ]

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -40,9 +40,8 @@ def _rule_impl(ctx):
             "//test/aspect:scala_specs2_junit_test",
             "//testing/toolchain:junit_classpath",
             # From specs2/specs2.bzl:specs2_dependencies()
-            "@io_bazel_rules_scala//specs2:specs2",
-            "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_xml",
-            "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
+            "//specs2:specs2",
+            "//scala/private/toolchain_deps:scala_xml",
             # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
             "//testing/toolchain:specs2_junit_classpath",
         ],

--- a/test/aspect/aspect.bzl
+++ b/test/aspect/aspect.bzl
@@ -41,14 +41,10 @@ def _rule_impl(ctx):
             "//testing/toolchain:junit_classpath",
             # From specs2/specs2.bzl:specs2_dependencies()
             "@io_bazel_rules_scala//specs2:specs2",
-            "@io_bazel_rules_scala_org_specs2_specs2_common//:io_bazel_rules_scala_org_specs2_specs2_common",
-            "@io_bazel_rules_scala_org_specs2_specs2_core//:io_bazel_rules_scala_org_specs2_specs2_core",
-            "@io_bazel_rules_scala_org_specs2_specs2_fp//:io_bazel_rules_scala_org_specs2_specs2_fp",
-            "@io_bazel_rules_scala_org_specs2_specs2_matcher//:io_bazel_rules_scala_org_specs2_specs2_matcher",
             "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_xml",
             "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
             # From specs2/specs2_junit.bzl:specs2_junit_dependencies()
-            "@io_bazel_rules_scala_org_specs2_specs2_junit//:io_bazel_rules_scala_org_specs2_specs2_junit",
+            "//testing/toolchain:specs2_junit_classpath",
         ],
     }
     content = ""

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -103,6 +103,6 @@ declare_deps_provider(
     deps_id = "specs2_junit_classpath",
     visibility = ["//visibility:public"],
     deps = [
-        "//external:io_bazel_rules_scala/dependency/specs2/specs2_junit",
+        "@io_bazel_rules_scala_org_specs2_specs2_junit",
     ],
 )


### PR DESCRIPTION
Removes binds from specs2 test rules. Users should use testing toolchain deps to customize specs2 dependencies. 