### PR TITLE
Update linter settings after buildifier update

### DIFF
--- a/tools/BUILD
+++ b/tools/BUILD
@@ -12,6 +12,7 @@ WARNINGS_CONFIG = [
     "-print",
     "-bzl-visibility",
     "-no-effect",
+    "-provider-params",
 ]
 
 buildifier(


### PR DESCRIPTION
Excludes new linting warning introduced with #1194 which broke master build.