### PR TITLE
Fix action_should_fail_with_message sh helper

### DIFF
--- a/test/shell/test_helper.sh
+++ b/test/shell/test_helper.sh
@@ -55,6 +55,7 @@ action_should_fail_with_message() {
     exit 1
   elif [ $GREP_RES -ne 0 ]; then
     echo -e "${RED} \"bazel $TEST_ARG\" should have failed with message \"$MSG\" but did not. $NC"
+    exit 1
   else
     exit 0
   fi

--- a/test/shell/test_scalac_jvm_flags.sh
+++ b/test/shell/test_scalac_jvm_flags.sh
@@ -26,7 +26,7 @@ test_scalac_jvm_flags_are_configured(){
 
 test_scalac_jvm_flags_are_expanded(){
   action_should_fail_with_message \
-    "--ExpandedFlag=test_expect_failure/compilers_jvm_flags/args.txt" \
+    "--made_up_flag_to_expand=test_expect_failure/compilers_jvm_flags/args.txt" \
     build --verbose_failures //test_expect_failure/compilers_jvm_flags:can_expand_jvm_flags_for_scalac
 }
 

--- a/test/shell/test_scalac_jvm_flags.sh
+++ b/test/shell/test_scalac_jvm_flags.sh
@@ -26,7 +26,7 @@ test_scalac_jvm_flags_are_configured(){
 
 test_scalac_jvm_flags_are_expanded(){
   action_should_fail_with_message \
-    "--jvm_flag=test_expect_failure/compilers_jvm_flags/args.txt" \
+    "--ExpandedFlag=test_expect_failure/compilers_jvm_flags/args.txt" \
     build --verbose_failures //test_expect_failure/compilers_jvm_flags:can_expand_jvm_flags_for_scalac
 }
 

--- a/test_expect_failure/compilers_javac_opts/BUILD
+++ b/test_expect_failure/compilers_javac_opts/BUILD
@@ -10,9 +10,6 @@ default_java_toolchain(
     name = "a_java_toolchain",
     bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath.jar"],
     javac = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar"],
-    jvm_opts = ["-Xbootclasspath/p:$(location @bazel_tools//third_party/java/jdk/langtools:javac_jar)"],
-    misc = [
-        "-InvalidFlag",
-    ],
+    javacopts = ["-InvalidFlag"],
     visibility = ["//visibility:public"],
 )

--- a/test_expect_failure/compilers_jvm_flags/BUILD
+++ b/test_expect_failure/compilers_jvm_flags/BUILD
@@ -24,7 +24,7 @@ scala_library(
     name = "can_expand_jvm_flags_for_scalac",
     srcs = ["WillNotCompileScalaSinceXmxTooLow.scala"],
     data = [":args.txt"],
-    scalac_jvm_flags = ["$(location :args.txt)"],
+    scalac_jvm_flags = ["--ExpandedFlag=$(location :args.txt)"],
 )
 
 scala_library(

--- a/test_expect_failure/compilers_jvm_flags/BUILD
+++ b/test_expect_failure/compilers_jvm_flags/BUILD
@@ -24,7 +24,7 @@ scala_library(
     name = "can_expand_jvm_flags_for_scalac",
     srcs = ["WillNotCompileScalaSinceXmxTooLow.scala"],
     data = [":args.txt"],
-    scalac_jvm_flags = ["--ExpandedFlag=$(location :args.txt)"],
+    scalac_jvm_flags = ["--made_up_flag_to_expand=$(location :args.txt)"],
 )
 
 scala_library(


### PR DESCRIPTION

### Description
Add missing `exit 1` to make test actually fail.

Had to remove `jvm_opts = ["-Xbootclasspath/p:$(location
@bazel_tools//third_party/java/jdk/langtools:javac_jar)"],`
because test fails for wrong reason `-Xbootclasspath/p is no longer a
supported option.`

### Motivation
Tried to write a test using `action_should_fail_with_message` and couldn't make it fail with a wrong error message. 
