### PR TITLE
Report exceptions from protoc generator

### DIFF
--- a/src/scala/scripts/ScalaPBWorker.scala
+++ b/src/scala/scripts/ScalaPBWorker.scala
@@ -8,6 +8,8 @@ import io.bazel.rulesscala.jar.JarCreator
 import io.bazel.rulesscala.worker.Worker
 import protocbridge.{ProtocBridge, ProtocCodeGenerator}
 
+import scala.sys.process._
+
 object ScalaPBWorker extends Worker.Interface {
 
   private val MainGenerator = {
@@ -60,5 +62,5 @@ object ScalaPBWorker extends Worker.Interface {
   }
 
   protected def exec(protoc: Path): Seq[String] => Int = (args: Seq[String]) =>
-    new ProcessBuilder(protoc.toString +: args: _*).inheritIO().start().waitFor()
+    Process(protoc.toString, args).!(ProcessLogger(stderr.println(_)))
 }

--- a/test/proto/custom_generator/BUILD.bazel
+++ b/test/proto/custom_generator/BUILD.bazel
@@ -8,6 +8,10 @@ load("//scala_proto:scala_proto_toolchain.bzl", "scala_proto_deps_toolchain", "s
 # bazel test //test/proto/custom_generator:DummyGeneratorTest \
 # --extra_toolchains=//test/proto/custom_generator:scala_proto_deps_toolchain \
 # --extra_toolchains=//test/proto/custom_generator:scala_proto_toolchain
+#
+# bazel build //test/proto/custom_generator:any_proto_scala \
+# --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_deps_toolchain \
+# --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_toolchain
 
 scala_proto_library(
     name = "any_proto_scala",
@@ -65,5 +69,50 @@ scala_proto_toolchain(
 toolchain(
     name = "scala_proto_toolchain",
     toolchain = ":scala_proto_toolchain_def",
+    toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+)
+
+scala_library(
+    name = "FailingGenerator",
+    srcs = ["FailingGenerator.scala"],
+    deps = [
+        "@scala_proto_rules_protoc_bridge",
+    ],
+)
+
+declare_deps_provider(
+    name = "failing_scalapb_worker_deps_provider",
+    deps_id = "scalapb_worker_deps",
+    deps = [
+        ":FailingGenerator",
+        "@com_google_protobuf//:protobuf_java",
+        "@scala_proto_rules_protoc_bridge",
+        "@scala_proto_rules_scalapb_plugin",
+    ],
+)
+
+scala_proto_deps_toolchain(
+    name = "failing_scala_proto_deps_toolchain_def",
+    dep_providers = [
+        ":failing_scalapb_worker_deps_provider",
+        "@io_bazel_rules_scala//scala_proto:scalapb_compile_deps_provider",
+        "@io_bazel_rules_scala//scala_proto:scalapb_grpc_deps_provider",
+    ],
+)
+
+toolchain(
+    name = "failing_scala_proto_deps_toolchain",
+    toolchain = ":failing_scala_proto_deps_toolchain_def",
+    toolchain_type = "@io_bazel_rules_scala//scala_proto:deps_toolchain_type",
+)
+
+scala_proto_toolchain(
+    name = "failing_scala_proto_toolchain_def",
+    main_generator = "test.proto.custom_generator.FailingGenerator",
+)
+
+toolchain(
+    name = "failing_scala_proto_toolchain",
+    toolchain = ":failing_scala_proto_toolchain_def",
     toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
 )

--- a/test/proto/custom_generator/FailingGenerator.scala
+++ b/test/proto/custom_generator/FailingGenerator.scala
@@ -1,0 +1,6 @@
+package test.proto.custom_generator
+
+object FailingGenerator extends protocbridge.ProtocCodeGenerator {
+  override def run(request: Array[Byte]): Array[Byte] =
+    throw new RuntimeException("expected generator failure")
+}

--- a/test/shell/test_scala_proto_library.sh
+++ b/test/shell/test_scala_proto_library.sh
@@ -20,6 +20,15 @@ test_scala_proto_custom_generator() {
   --extra_toolchains=//test/proto/custom_generator:scala_proto_toolchain
 }
 
+test_scala_proto_show_generator_exception() {
+  action_should_fail_with_message \
+    "java.lang.RuntimeException: expected generator failure" \
+    build //test/proto/custom_generator:any_proto_scala \
+    --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_deps_toolchain \
+    --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_toolchain
+}
+
 export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat ../../../.bazelversion)}
 $runner test_scala_proto_library_action_label
 $runner test_scala_proto_custom_generator
+$runner test_scala_proto_show_generator_exception


### PR DESCRIPTION
### Description
When generator fails with exception display cause stacktrace in bazel output.

Before
```
Exit with code 1
java.lang.RuntimeException: Exit with code 1
        at scala.sys.package$.error(package.scala:30)
        at scripts.ScalaPBWorker$.work(ScalaPBWorker.scala:56)
        at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)
        at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)
        at scripts.ScalaPBWorker$.main(ScalaPBWorker.scala:21)
        at scripts.ScalaPBWorker.main(ScalaPBWorker.scala)
```

After
```
java.lang.RuntimeException: expected generator failure
        at test.proto.custom_generator.FailingGenerator$.run(FailingGenerator.scala:5)
        at protocbridge.frontend.PluginFrontend$.$anonfun$runWithBytes$1(PluginFrontend.scala:52)
        at scala.util.Try$.apply(Try.scala:213)
        at protocbridge.frontend.PluginFrontend$.runWithBytes(PluginFrontend.scala:52)
        at protocbridge.frontend.PluginFrontend$.runWithInputStream(PluginFrontend.scala:103)
        at protocbridge.frontend.PosixPluginFrontend$.$anonfun$prepare$1(PosixPluginFrontend.scala:33)
        at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.java:23)
        at scala.concurrent.Future$.$anonfun$apply$1(Future.scala:659)
        at scala.util.Success.$anonfun$map$1(Try.scala:255)
        at scala.util.Success.map(Try.scala:213)
        at scala.concurrent.Future.$anonfun$map$1(Future.scala:292)
        at scala.concurrent.impl.Promise.liftedTree1$1(Promise.scala:33)
        at scala.concurrent.impl.Promise.$anonfun$transform$1(Promise.scala:33)
        at scala.concurrent.impl.CallbackRunnable.run(Promise.scala:64)
        at java.base/java.util.concurrent.ForkJoinTask$RunnableExecuteAction.exec(ForkJoinTask.java:1426)
        at java.base/java.util.concurrent.ForkJoinTask.doExec(ForkJoinTask.java:290)
        at java.base/java.util.concurrent.ForkJoinPool$WorkQueue.topLevelExec(ForkJoinPool.java:1020)
        at java.base/java.util.concurrent.ForkJoinPool.scan(ForkJoinPool.java:1656)
        at java.base/java.util.concurrent.ForkJoinPool.runWorker(ForkJoinPool.java:1594)
        at java.base/java.util.concurrent.ForkJoinWorkerThread.run(ForkJoinWorkerThread.java:177)

Exit with code 1
java.lang.RuntimeException: Exit with code 1
        at scala.sys.package$.error(package.scala:30)
        at scripts.ScalaPBWorker$.work(ScalaPBWorker.scala:56)
        at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:92)
        at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:46)
        at scripts.ScalaPBWorker$.main(ScalaPBWorker.scala:21)
        at scripts.ScalaPBWorker.main(ScalaPBWorker.scala)
```
