### PR TITLE
Restored check with latest version

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -57,8 +57,9 @@ tasks:
     shell_commands:
     - "./test_rules_scala.sh"
   test_rules_scala_linux_latest:
-    name: "USE_BAZEL_VERSION=latest ./test_rules_scala || buildkite-agent annotate --style 'warning' 'Latest version failed to run!' "
+    name: "./test_rules_scala (latest bazel)"
     platform: ubuntu1804
+    bazel: latest
     shell_commands:
     - "./test_rules_scala.sh"
   test_rules_scala_macos:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,99 +1,96 @@
----
-validate_config: 1
-tasks:
-  ubuntu1604:
-    name: "bazel test //test/..."       
-    platform: ubuntu1604
-    shell_commands:
-    # Disable local disk caching on CI.
-    - mv tools/bazel.rc.buildkite tools/bazel.rc
-    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
-  ubuntu1804:
-    name: "bazel test //test/..."      
-    platform: ubuntu1804
-    shell_commands:
-    # Disable local disk caching on CI.
-    - mv tools/bazel.rc.buildkite tools/bazel.rc
-    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
-  ubuntu2004:
-    name: "bazel test //test/..."
+--- 
+tasks: 
+  examples_ubuntu2004: 
+    name: ./test_examples
     platform: ubuntu2004
-    shell_commands:
-    - mv tools/bazel.rc.buildkite tools/bazel.rc
-    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
-  macos:
-    name: "bazel test //test/..."
-    platform: macos
-    shell_commands:
-    # Disable local disk caching on CI.
-    - mv tools/bazel.rc.buildkite tools/bazel.rc
-    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
-  rbe_ubuntu1604:
-    name: "bazel test //test/..."
-    platform: rbe_ubuntu1604
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
-  test_rules_scala_linux:
-    name: "./test_rules_scala"
-    platform: ubuntu1804
-    shell_commands:
-    - "./test_rules_scala.sh"
-  test_rules_scala_linux_latest:
-    name: "./test_rules_scala (latest bazel)"
-    platform: ubuntu1804
-    bazel: latest
-    shell_commands:
-    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' 'Latest version failed to run!'"
-  test_rules_scala_macos:
-    name: "./test_rules_scala"
-    platform: macos
-    shell_commands:
-    - "./test_rules_scala.sh"
-  test_reproducibility_linux:
-    name: "./test_reproducibility.sh"
-    platform: ubuntu1804
-    shell_commands:
-    - "./test_reproducibility.sh"
-  test_reproducibility_macos:
-    name: "./test_reproducibility.sh"
-    platform: macos
-    shell_commands:
-    - "./test_reproducibility.sh"
-  versions_ubuntu2004:
-    name: "./test_version.sh"      
-    platform: ubuntu2004
-    shell_commands:
-    - "./test_version.sh"
-  versions_macos:
-    name: "./test_version.sh"
-    platform: macos
-    shell_commands:
-    - "./test_version.sh"
-  examples_ubuntu2004:
-    name: "./test_examples"
-    platform: ubuntu2004
-    shell_commands:
-      - "./test_examples.sh"
-  lint_ubuntu2004:
+    shell_commands: 
+      - ./test_examples.sh
+  lint_ubuntu2004: 
     name: "bazel //tools:lint_check"
     platform: ubuntu2004
-    run_targets:
-    -  "//tools:lint_check"
+    run_targets: 
+      - "//tools:lint_check"
+  macos: 
+    build_targets: 
+      - //test/...
+    name: "bazel test //test/..."
+    platform: macos
+    shell_commands: 
+      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
+      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
+    test_targets: 
+      - //test/...
+  rbe_ubuntu1604: 
+    build_targets: 
+      - //test/...
+    name: "bazel test //test/..."
+    platform: rbe_ubuntu1604
+    test_targets: 
+      - //test/...
+  test_reproducibility_linux: 
+    name: ./test_reproducibility.sh
+    platform: ubuntu1804
+    shell_commands: 
+      - ./test_reproducibility.sh
+  test_reproducibility_macos: 
+    name: ./test_reproducibility.sh
+    platform: macos
+    shell_commands: 
+      - ./test_reproducibility.sh
+  test_rules_scala_linux: 
+    name: ./test_rules_scala
+    platform: ubuntu1804
+    shell_commands: 
+      - ./test_rules_scala.sh
+  test_rules_scala_linux_latest: 
+    bazel: latest
+    name: "./test_rules_scala (latest bazel)"
+    platform: ubuntu1804
+    shell_commands: 
+      - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Latest version failed to run! [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_STEP_ID})\""
+  test_rules_scala_macos: 
+    name: ./test_rules_scala
+    platform: macos
+    shell_commands: 
+      - ./test_rules_scala.sh
+  ubuntu1604: 
+    build_targets: 
+      - //test/...
+    name: "bazel test //test/..."
+    platform: ubuntu1604
+    shell_commands: 
+      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
+      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
+    test_targets: 
+      - //test/...
+  ubuntu1804: 
+    build_targets: 
+      - //test/...
+    name: "bazel test //test/..."
+    platform: ubuntu1804
+    shell_commands: 
+      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
+      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
+    test_targets: 
+      - //test/...
+  ubuntu2004: 
+    build_targets: 
+      - //test/...
+    name: "bazel test //test/..."
+    platform: ubuntu2004
+    shell_commands: 
+      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
+      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
+    test_targets: 
+      - //test/...
+  versions_macos: 
+    name: ./test_version.sh
+    platform: macos
+    shell_commands: 
+      - ./test_version.sh
+  versions_ubuntu2004: 
+    name: ./test_version.sh
+    platform: ubuntu2004
+    shell_commands: 
+      - ./test_version.sh
+validate_config: 1

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,96 +1,99 @@
---- 
-tasks: 
-  examples_ubuntu2004: 
-    name: ./test_examples
+---
+validate_config: 1
+tasks:
+  ubuntu1604:
+    name: "bazel test //test/..."       
+    platform: ubuntu1604
+    shell_commands:
+    # Disable local disk caching on CI.
+    - mv tools/bazel.rc.buildkite tools/bazel.rc
+    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
+    build_targets:
+    - "//test/..."
+    test_targets:
+    - "//test/..."
+  ubuntu1804:
+    name: "bazel test //test/..."      
+    platform: ubuntu1804
+    shell_commands:
+    # Disable local disk caching on CI.
+    - mv tools/bazel.rc.buildkite tools/bazel.rc
+    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
+    build_targets:
+    - "//test/..."
+    test_targets:
+    - "//test/..."
+  ubuntu2004:
+    name: "bazel test //test/..."
     platform: ubuntu2004
-    shell_commands: 
-      - ./test_examples.sh
-  lint_ubuntu2004: 
-    name: "bazel //tools:lint_check"
-    platform: ubuntu2004
-    run_targets: 
-      - "//tools:lint_check"
-  macos: 
-    build_targets: 
-      - //test/...
+    shell_commands:
+    - mv tools/bazel.rc.buildkite tools/bazel.rc
+    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
+    build_targets:
+    - "//test/..."
+    test_targets:
+    - "//test/..."
+  macos:
     name: "bazel test //test/..."
     platform: macos
-    shell_commands: 
-      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
-      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
-    test_targets: 
-      - //test/...
-  rbe_ubuntu1604: 
-    build_targets: 
-      - //test/...
+    shell_commands:
+    # Disable local disk caching on CI.
+    - mv tools/bazel.rc.buildkite tools/bazel.rc
+    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
+    build_targets:
+    - "//test/..."
+    test_targets:
+    - "//test/..."
+  rbe_ubuntu1604:
     name: "bazel test //test/..."
     platform: rbe_ubuntu1604
-    test_targets: 
-      - //test/...
-  test_reproducibility_linux: 
-    name: ./test_reproducibility.sh
+    build_targets:
+    - "//test/..."
+    test_targets:
+    - "//test/..."
+  test_rules_scala_linux:
+    name: "./test_rules_scala"
     platform: ubuntu1804
-    shell_commands: 
-      - ./test_reproducibility.sh
-  test_reproducibility_macos: 
-    name: ./test_reproducibility.sh
-    platform: macos
-    shell_commands: 
-      - ./test_reproducibility.sh
-  test_rules_scala_linux: 
-    name: ./test_rules_scala
-    platform: ubuntu1804
-    shell_commands: 
-      - ./test_rules_scala.sh
-  test_rules_scala_linux_latest: 
-    bazel: latest
+    shell_commands:
+    - "./test_rules_scala.sh"
+  test_rules_scala_linux_latest:
     name: "./test_rules_scala (latest bazel)"
     platform: ubuntu1804
-    shell_commands: 
-      - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Latest version failed to run! [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_STEP_ID})\""
-  test_rules_scala_macos: 
-    name: ./test_rules_scala
+    bazel: latest
+    shell_commands:
+    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Latest version failed to run! [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_STEP_ID})\""
+  test_rules_scala_macos:
+    name: "./test_rules_scala"
     platform: macos
-    shell_commands: 
-      - ./test_rules_scala.sh
-  ubuntu1604: 
-    build_targets: 
-      - //test/...
-    name: "bazel test //test/..."
-    platform: ubuntu1604
-    shell_commands: 
-      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
-      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
-    test_targets: 
-      - //test/...
-  ubuntu1804: 
-    build_targets: 
-      - //test/...
-    name: "bazel test //test/..."
+    shell_commands:
+    - "./test_rules_scala.sh"
+  test_reproducibility_linux:
+    name: "./test_reproducibility.sh"
     platform: ubuntu1804
-    shell_commands: 
-      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
-      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
-    test_targets: 
-      - //test/...
-  ubuntu2004: 
-    build_targets: 
-      - //test/...
-    name: "bazel test //test/..."
-    platform: ubuntu2004
-    shell_commands: 
-      - "mv tools/bazel.rc.buildkite tools/bazel.rc"
-      - "echo \"import %workspace%/tools/bazel.rc\" > .bazelrc"
-    test_targets: 
-      - //test/...
-  versions_macos: 
-    name: ./test_version.sh
+    shell_commands:
+    - "./test_reproducibility.sh"
+  test_reproducibility_macos:
+    name: "./test_reproducibility.sh"
     platform: macos
-    shell_commands: 
-      - ./test_version.sh
-  versions_ubuntu2004: 
-    name: ./test_version.sh
+    shell_commands:
+    - "./test_reproducibility.sh"
+  versions_ubuntu2004:
+    name: "./test_version.sh"      
     platform: ubuntu2004
-    shell_commands: 
-      - ./test_version.sh
-validate_config: 1
+    shell_commands:
+    - "./test_version.sh"
+  versions_macos:
+    name: "./test_version.sh"
+    platform: macos
+    shell_commands:
+    - "./test_version.sh"
+  examples_ubuntu2004:
+    name: "./test_examples"
+    platform: ubuntu2004
+    shell_commands:
+      - "./test_examples.sh"
+  lint_ubuntu2004:
+    name: "bazel //tools:lint_check"
+    platform: ubuntu2004
+    run_targets:
+    -  "//tools:lint_check"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -61,7 +61,7 @@ tasks:
     platform: ubuntu1804
     bazel: latest
     shell_commands:
-    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Optional build with latest Bazel version failed. [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID})\nIt is not mandatory but worth checking!\""
+    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Optional build with latest Bazel version failed, [see here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}) (It is not mandatory but worth checking)\""
   test_rules_scala_macos:
     name: "./test_rules_scala"
     platform: macos

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -56,6 +56,11 @@ tasks:
     platform: ubuntu1804
     shell_commands:
     - "./test_rules_scala.sh"
+  test_rules_scala_linux_latest:
+    name: "USE_BAZEL_VERSION=latest ./test_rules_scala || buildkite-agent annotate --style 'warning' 'Latest version failed to run!' "
+    platform: ubuntu1804
+    shell_commands:
+    - "./test_rules_scala.sh"
   test_rules_scala_macos:
     name: "./test_rules_scala"
     platform: macos

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -61,7 +61,7 @@ tasks:
     platform: ubuntu1804
     bazel: latest
     shell_commands:
-    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Latest version failed to run! [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID})\""
+    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Optional build with latest Bazel version failed. [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID})\nIt is not mandatory but worth checking!\""
   test_rules_scala_macos:
     name: "./test_rules_scala"
     platform: macos

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -61,7 +61,7 @@ tasks:
     platform: ubuntu1804
     bazel: latest
     shell_commands:
-    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Latest version failed to run! [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_STEP_ID})\""
+    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Latest version failed to run! [See here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID})\""
   test_rules_scala_macos:
     name: "./test_rules_scala"
     platform: macos

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -61,7 +61,7 @@ tasks:
     platform: ubuntu1804
     bazel: latest
     shell_commands:
-    - "./test_rules_scala.sh"
+    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' 'Latest version failed to run!'"
   test_rules_scala_macos:
     name: "./test_rules_scala"
     platform: macos


### PR DESCRIPTION
### Description
In travis we used to have a non-failing test_rules_scala that checked if tests passs when working with latest bazel version

I wish to restore it.

Please kindly look only at the final changes and not by commits as I prefer to squash and merge it if it's accepted.

If latest version fails - it would add annotation like this:
![image](https://user-images.githubusercontent.com/2962963/106750801-fc29e700-6630-11eb-8749-866f0e18efaf.png)
(but won't fail the build)
Else - no annotation would be added.

I see that we're failing with `test_rules_scala.sh`, maybe we simply want to do the same thing with `bazel test //test/...` ?