### PR TITLE
Fixing scalap version for Scala 2.11.12

### DIFF
--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -110,7 +110,7 @@ artifacts = {
         "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.11.10",
+        "artifact": "org.scala-lang:scalap:2.11.12",
         "sha256": "a6dd7203ce4af9d6185023d5dba9993eb8e80584ff4b1f6dec574a2aba4cd2b7",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",


### PR DESCRIPTION
### Description

The hash and version for scalap for Scala 2.11.12 conflicted.
Set up both version and hash for scalap to be for Scala 2.11.12 (as other Scala components are set for Scala 2.11).

### Motivation

The sha256 is set for scalap:2.11.12, but the version set was 2.11.10 which
caused a hash conflict.

$ sha256sum scalap-2.11.12.jar
a6dd7203ce4af9d6185023d5dba9993eb8e80584ff4b1f6dec574a2aba4cd2b7  scalap-2.11.12.jar
$ sha256sum scalap-2.11.10.jar
3f6f352fce91c33055398a7081e35e5091fd5e095130905633e72f52124c1d27  scalap-2.11.10.jar

