### PR TITLE
Remove test for development version of bazel for the diagnostics file.

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -190,7 +190,7 @@ DiagnosticsFile: {diagnostics_output}
         scalac_jvm_flags,
         ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags,
     )
-    if len(BAZEL_VERSION) == 0 and enable_diagnostics_report:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
+    if False:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
         ctx.actions.run(
             inputs = ins,
             outputs = outs,

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -20,7 +20,6 @@ load(
     _collect_plugin_paths = "collect_plugin_paths",
 )
 load(":resources.bzl", _resource_paths = "paths")
-load("@io_bazel_rules_scala_config//:config.bzl", "BAZEL_VERSION")
 
 def expand_location(ctx, flags):
     if hasattr(ctx.attr, "data"):
@@ -190,49 +189,28 @@ DiagnosticsFile: {diagnostics_output}
         scalac_jvm_flags,
         ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalac_jvm_flags,
     )
-    if False:  # TODO: Add case for released version of bazel with diagnostics whenever it is released.
-        ctx.actions.run(
-            inputs = ins,
-            outputs = outs,
-            executable = scalac,
-            mnemonic = "Scalac",
-            progress_message = "scala %s" % target_label,
-            execution_requirements = {"supports-workers": "1"},
-            #  when we run with a worker, the `@argfile.path` is removed and passed
-            #  line by line as arguments in the protobuf. In that case,
-            #  the rest of the arguments are passed to the process that
-            #  starts up and stays resident.
 
-            # In either case (worker or not), they will be jvm flags which will
-            # be correctly handled since the executable is a jvm app that will
-            # consume the flags on startup.
-            arguments = [
-                "--jvm_flag=%s" % f
-                for f in expand_location(ctx, final_scalac_jvm_flags)
-            ] + ["@" + argfile.path],
-            diagnostics_file = diagnosticsfile,
-        )
-    else:
-        ctx.actions.run(
-            inputs = ins,
-            outputs = outs,
-            executable = scalac,
-            mnemonic = "Scalac",
-            progress_message = "scala %s" % target_label,
-            execution_requirements = {"supports-workers": "1"},
-            #  when we run with a worker, the `@argfile.path` is removed and passed
-            #  line by line as arguments in the protobuf. In that case,
-            #  the rest of the arguments are passed to the process that
-            #  starts up and stays resident.
+    ctx.actions.run(
+        inputs = ins,
+        outputs = outs,
+        executable = scalac,
+        mnemonic = "Scalac",
+        progress_message = "scala %s" % target_label,
+        execution_requirements = {"supports-workers": "1"},
+        #  when we run with a worker, the `@argfile.path` is removed and passed
+        #  line by line as arguments in the protobuf. In that case,
+        #  the rest of the arguments are passed to the process that
+        #  starts up and stays resident.
 
-            # In either case (worker or not), they will be jvm flags which will
-            # be correctly handled since the executable is a jvm app that will
-            # consume the flags on startup.
-            arguments = [
-                "--jvm_flag=%s" % f
-                for f in expand_location(ctx, final_scalac_jvm_flags)
-            ] + ["@" + argfile.path],
-        )
+        # In either case (worker or not), they will be jvm flags which will
+        # be correctly handled since the executable is a jvm app that will
+        # consume the flags on startup.
+        arguments = [
+            "--jvm_flag=%s" % f
+            for f in expand_location(ctx, final_scalac_jvm_flags)
+        ] + ["@" + argfile.path],
+        # diagnostics_file = diagnosticsfile TODO: add diagnostics_file argument whenever this argument is supported: https://github.com/bazelbuild/rules_scala/issues/1215
+    )
 
 def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, providers_of_dependencies):
     return java_common.compile(


### PR DESCRIPTION
### Description
Closes #1211 . Removes branching off to the `diagnostics_file` proposed feature.

### Motivation
 This is being removed as `diagnostics_file`  is not yet featured in the bazel upstream and CI now seems to use a development version of bazel.
