### PR TITLE
Scala Import stamping

### DIFF
--- a/docs/scala_import.md
+++ b/docs/scala_import.md
@@ -1,6 +1,6 @@
 # scala_import
 
-```python
+```starlark
 scala_import(
     name,
     jars,
@@ -8,7 +8,8 @@ scala_import(
     runtime_deps,
     exports,
     neverlink,
-    srcjar
+    srcjar,
+    stamp,
 )
 ```
 
@@ -17,6 +18,13 @@ like `scala_library`, similar to `java_import` from Java rules.
 
 This rule reimplements `java_import` without support for ijars, which break Scala macros.
 Generally, ijars don’t help much for external dependencies, which rarely change.
+
+The jar's compile MANIFEST.MD is stamped with a Target-Label attribute for dependency tracking 
+reporting. This behaviour can be changed per `scala_import` target with an attribute or globally 
+with a setting:
+```
+bazel build //my:target --//scala/settings:stamp_scala_import=False
+```
 
 ## Attributes
 
@@ -29,3 +37,4 @@ Generally, ijars don’t help much for external dependencies, which rarely chang
 | exports               | `List of labels, optional` <br> List of targets to add to the dependencies of those that depend on this target.
 | neverlink             | `boolean, optional (default False)` <br> If true only use this library for compilation and not at runtime.
 | srcjar                | `Label, optional` <br> The source jar that was used to create the jar.
+| stamp                 | `Label, optional` <br> Setting to control Target-Label stamping into compile jar Manifest <br> Default value is `@io_bazel_rules_scala//scala/settings:stamp_scala_import`

--- a/docs/scala_import.md
+++ b/docs/scala_import.md
@@ -19,7 +19,7 @@ like `scala_library`, similar to `java_import` from Java rules.
 This rule reimplements `java_import` without support for ijars, which break Scala macros.
 Generally, ijars don’t help much for external dependencies, which rarely change.
 
-The jar's compile MANIFEST.MD is stamped with a Target-Label attribute for dependency tracking 
+The jar's compile MANIFEST.MF is stamped with a Target-Label attribute for dependency tracking 
 reporting. This behaviour can be changed per `scala_import` target with an attribute or globally 
 with a setting:
 ```

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -34,9 +34,9 @@ def _stamp_jar(ctx, jar):
 
     return stamped_file
 
-#intellij part is tested manually, tread lightly when changing there
-#if you change make sure to manually re-import an intellij project and see imports
-#are resolved (not red) and clickable
+# intellij part is tested manually, tread lightly when changing there
+# if you change make sure to manually re-import an intellij project and see imports
+# are resolved (not red) and clickable
 def _scala_import_impl(ctx):
     target_data = _code_jars_and_intellij_metadata_from(
         ctx.attr.jars,
@@ -55,8 +55,7 @@ def _scala_import_impl(ctx):
     current_jars = depset(current_target_compile_jars)
 
     exports = java_common.merge([export[JavaInfo] for export in ctx.attr.exports])
-    transitive_runtime_jars = \
-        java_common.merge([dep[JavaInfo] for dep in ctx.attr.runtime_deps]).transitive_runtime_jars
+
     jars2labels = {}
     _collect_labels(ctx.attr.deps, jars2labels)
     _collect_labels(ctx.attr.exports, jars2labels)  #untested

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -45,7 +45,7 @@ def _scala_import_impl(ctx):
     )
 
     compile_jars = target_data.code_jars
-    intellij_metadata = arget_data.intellij_metadata
+    intellij_metadata = target_data.intellij_metadata
 
     stamping_enabled = ctx.attr.stamp[StampScalaImport].enabled
 

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -1,7 +1,13 @@
 load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
 
 stamp_scala_import(
-    name = "stamp_scala_import",
+    name = "stamp_scala_import_on",
     build_setting_default = True,
+    visibility = ["//visibility:public"],
+)
+
+stamp_scala_import(
+    name = "stamp_scala_import_off",
+    build_setting_default = False,
     visibility = ["//visibility:public"],
 )

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -1,0 +1,7 @@
+load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
+
+stamp_scala_import(
+    name = "stamp_scala_import",
+    build_setting_default = True,
+    visibility = ["//visibility:public"],
+)

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -1,13 +1,7 @@
 load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
 
 stamp_scala_import(
-    name = "stamp_scala_import_on",
+    name = "stamp_scala_import",
     build_setting_default = True,
-    visibility = ["//visibility:public"],
-)
-
-stamp_scala_import(
-    name = "stamp_scala_import_off",
-    build_setting_default = False,
     visibility = ["//visibility:public"],
 )

--- a/scala/settings/stamp_settings.bzl
+++ b/scala/settings/stamp_settings.bzl
@@ -1,0 +1,9 @@
+StampScalaImport = provider(fields = ["enabled"])
+
+def _impl(ctx):
+    return StampScalaImport(enabled = ctx.build_setting_value)
+
+stamp_scala_import = rule(
+    implementation = _impl,
+    build_setting = config.bool(flag = True),
+)

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -1,6 +1,7 @@
 load("@rules_java//java:defs.bzl", "java_import")
 load("//scala:scala.bzl", "scala_library", "scala_specs2_junit_test")
 load("//scala:scala_import.bzl", "scala_import")
+load(":scala_import_stamp_test.bzl", "scala_import_stamping_test_suite")
 
 #Many jars
 scala_import(
@@ -128,4 +129,9 @@ scala_import(
 scala_import(
     name = "stamping_second_time",
     jars = ["relate_2.11-2.1.1.jar"],
+)
+
+scala_import_stamping_test_suite(
+    name = "stamping_tests",
+    jar = "relate_2.11-2.1.1.jar",
 )

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -117,3 +117,15 @@ scala_specs2_junit_test(
     suffixes = ["Test"],
     deps = [":guava_and_commons_lang_as_exports"],
 )
+
+# test stamping of the same dep twice
+# https://github.com/bazelbuild/rules_scala/issues/1188
+scala_import(
+    name = "stamping_first_time",
+    jars = ["relate_2.11-2.1.1.jar"],
+)
+
+scala_import(
+    name = "stamping_second_time",
+    jars = ["relate_2.11-2.1.1.jar"],
+)

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -5,8 +5,6 @@ import org.apache.commons.lang3.ArrayUtils
 import org.specs2.mutable.SpecWithJUnit
 
 class ScalaImportExposesJarsTest extends SpecWithJUnit {
-  val targetLabel = "//test/src/main/scala/scalarules/test/scala_import:guava_and_commons_lang"
-
   "scala_import" should {
     "enable using the jars it exposes" in {
       println(classOf[Cache[String, String]])
@@ -14,5 +12,4 @@ class ScalaImportExposesJarsTest extends SpecWithJUnit {
       success
     }
   }
-
 }

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -1,16 +1,10 @@
 package scalarules.test.scala_import
 
-import java.util.jar
-import java.util.jar.JarFile
-
 import com.google.common.cache.Cache
 import org.apache.commons.lang3.ArrayUtils
-import org.specs2.matcher.Matcher
-import org.specs2.mutable.SpecificationWithJUnit
+import org.specs2.mutable.SpecWithJUnit
 
-import scala.reflect.{ClassTag, _}
-
-class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
+class ScalaImportExposesJarsTest extends SpecWithJUnit {
   val targetLabel = "//test/src/main/scala/scalarules/test/scala_import:guava_and_commons_lang"
 
   "scala_import" should {
@@ -18,22 +12,6 @@ class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
       println(classOf[Cache[String, String]])
       println(classOf[ArrayUtils])
       success
-    }
-  }
-
-  def findManifest[T: ClassTag]: jar.Manifest = {
-    val file = classTag[T].runtimeClass.getProtectionDomain.getCodeSource.getLocation.getFile
-    val jar = new JarFile(file)
-    val manifest = jar.getManifest
-    jar.close()
-    manifest
-  }
-
-  def haveTargetLabel: Matcher[jar.Manifest] = haveMainAttribute("Target-Label")
-
-  def haveMainAttribute(attribute: String): Matcher[jar.Manifest] = {
-    not(beNull[String]) ^^ { (m: jar.Manifest) =>
-      m.getMainAttributes.getValue(attribute) aka s"an attribute $attribute"
     }
   }
 

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -20,6 +20,11 @@ class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
       success
     }
 
+    "stamp jars with a target label" in {
+      findManifest[Cache[String, String]] must haveTargetLabel
+      findManifest[ArrayUtils] must haveTargetLabel
+    }.pendingUntilFixed("runtime jars are not stamped")
+
     "preserve existing Manifest attributes" in {
       findManifest[ArrayUtils] must haveMainAttribute("Bundle-Name")
     }

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -19,15 +19,6 @@ class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
       println(classOf[ArrayUtils])
       success
     }
-
-    "stamp jars with a target label" in {
-      findManifest[Cache[String, String]] must haveTargetLabel
-      findManifest[ArrayUtils] must haveTargetLabel
-    }.pendingUntilFixed("runtime jars are not stamped")
-
-    "preserve existing Manifest attributes" in {
-      findManifest[ArrayUtils] must haveMainAttribute("Bundle-Name")
-    }
   }
 
   def findManifest[T: ClassTag]: jar.Manifest = {

--- a/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
@@ -1,0 +1,61 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("//scala:scala_import.bzl", "scala_import")
+
+def _assert_compile_dep_stamped(ctx):
+    env = analysistest.begin(ctx)
+    jar = ctx.attr.jar.files.to_list()[0].basename
+    target_under_test = analysistest.target_under_test(env)
+    stamp_action = analysistest.target_actions(env)[0]
+
+    expected_action_mnemonic = "StampWithIjar"
+    actual_action_mnemonic = stamp_action.mnemonic
+    asserts.equals(env, expected_action_mnemonic, actual_action_mnemonic)
+
+    expected_input = jar
+    actual_input = stamp_action.inputs.to_list()[0].basename
+    asserts.equals(env, expected_input, actual_input)
+
+    expected_stamped_output = jar.rstrip(".jar") + "-stamped.jar"
+    actual_stamped_output = stamp_action.outputs.to_list()[0].basename
+    asserts.equals(env, expected_stamped_output, actual_stamped_output)
+
+    # all compiles jars are stamped
+    for dep in target_under_test[JavaInfo].compile_jars.to_list():
+        asserts.true(env, dep.basename.endswith("-stamped.jar"))
+
+    # full jars are not stamped
+    for dep in target_under_test[JavaInfo].full_compile_jars.to_list():
+        asserts.false(env, dep.basename.endswith("-stamped.jar"))
+
+    return analysistest.end(env)
+
+stamp_deps_test = analysistest.make(
+    _assert_compile_dep_stamped,
+    attrs = {"jar": attr.label(allow_files = True)},
+)
+
+def _test_dep_stamp(name, jar):
+    scala_import_target_name = "scala_import_for_%s" % name
+    scala_import(
+        name = scala_import_target_name,
+        jars = [jar],
+        tags = ["manual"],
+    )
+
+    stamp_deps_test(
+        name = name,
+        jar = jar,
+        target_under_test = scala_import_target_name,
+    )
+
+def scala_import_stamping_test_suite(name, jar):
+    test_name = "%s_%s" % (name, "stamping_test")
+    _test_dep_stamp(
+        name = test_name,
+        jar = jar,
+    )
+
+    native.test_suite(
+        name = name,
+        tests = [test_name],
+    )

--- a/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
@@ -3,60 +3,88 @@ load("//scala:scala_import.bzl", "scala_import")
 
 def _assert_compile_dep_stamped(ctx):
     env = analysistest.begin(ctx)
+    stamping_enabled = ctx.attr.stamp
     jar = ctx.attr.jar.files.to_list()[0].basename
-    target_under_test = analysistest.target_under_test(env)
-    stamp_action = analysistest.target_actions(env)[0]
-
     expected_action_mnemonic = "StampWithIjar"
-    actual_action_mnemonic = stamp_action.mnemonic
-    asserts.equals(env, expected_action_mnemonic, actual_action_mnemonic)
-
     expected_input = jar
-    actual_input = stamp_action.inputs.to_list()[0].basename
-    asserts.equals(env, expected_input, actual_input)
-
     expected_stamped_output = jar.rstrip(".jar") + "-stamped.jar"
-    actual_stamped_output = stamp_action.outputs.to_list()[0].basename
-    asserts.equals(env, expected_stamped_output, actual_stamped_output)
+
+    target_under_test = analysistest.target_under_test(env)
+
+    if stamping_enabled:
+        stamp_action = analysistest.target_actions(env)[0]
+
+        actual_action_mnemonic = stamp_action.mnemonic
+        asserts.equals(env, expected_action_mnemonic, actual_action_mnemonic)
+
+        actual_input = stamp_action.inputs.to_list()[0].basename
+        asserts.equals(env, expected_input, actual_input)
+
+        actual_stamped_output = stamp_action.outputs.to_list()[0].basename
+        asserts.equals(env, expected_stamped_output, actual_stamped_output)
 
     # all compiles jars are stamped
     for dep in target_under_test[JavaInfo].compile_jars.to_list():
-        asserts.true(env, dep.basename.endswith("-stamped.jar"))
+        asserts.equals(
+            env,
+            expected_stamped_output if stamping_enabled else jar,
+            dep.basename,
+            "compile jar",
+        )
 
     # full jars are not stamped
     for dep in target_under_test[JavaInfo].full_compile_jars.to_list():
-        asserts.false(env, dep.basename.endswith("-stamped.jar"))
+        asserts.equals(
+            env,
+            jar,
+            dep.basename,
+            "runtime jar",
+        )
 
     return analysistest.end(env)
 
 stamp_deps_test = analysistest.make(
     _assert_compile_dep_stamped,
-    attrs = {"jar": attr.label(allow_files = True)},
+    attrs = {"jar": attr.label(allow_files = True), "stamp": attr.bool()},
 )
 
-def _test_dep_stamp(name, jar):
-    scala_import_target_name = "scala_import_for_%s" % name
+def _test_dep_stamp(suite, name, jar, stamp_on):
+    test_name = "%s_%s_%s" % (suite, name, stamp_on)
+
+    scala_import_target_name = "scala_import_for_%s" % test_name
     scala_import(
         name = scala_import_target_name,
         jars = [jar],
         tags = ["manual"],
+        stamp = "//scala/settings:stamp_scala_import_%s" % ("on" if stamp_on else "off"),
     )
 
     stamp_deps_test(
-        name = name,
+        name = test_name,
         jar = jar,
+        stamp = stamp_on,
         tags = ["no-ide"],
         target_under_test = scala_import_target_name,
     )
 
+    return test_name
+
 def scala_import_stamping_test_suite(name, jar):
-    test_name = "%s_%s" % (name, "stamping_test")
-    _test_dep_stamp(
-        name = test_name,
+    test_with_stamping = _test_dep_stamp(
+        suite = name,
+        name = "stamping_test",
         jar = jar,
+        stamp_on = True,
+    )
+
+    test_without_stamping = _test_dep_stamp(
+        suite = name,
+        name = "stamping_test",
+        jar = jar,
+        stamp_on = False,
     )
 
     native.test_suite(
         name = name,
-        tests = [test_name],
+        tests = [test_with_stamping, test_without_stamping],
     )

--- a/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
@@ -1,5 +1,6 @@
 load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
 load("//scala:scala_import.bzl", "scala_import")
+load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
 
 def _assert_compile_dep_stamped(ctx):
     env = analysistest.begin(ctx)
@@ -51,12 +52,20 @@ stamp_deps_test = analysistest.make(
 def _test_dep_stamp(suite, name, jar, stamp_on):
     test_name = "%s_%s_%s" % (suite, name, stamp_on)
 
+    setting_name = "stamp_scala_import_%s" % stamp_on
+
+    stamp_scala_import(
+        name = setting_name,
+        build_setting_default = stamp_on,
+        visibility = ["//visibility:public"],
+    )
+
     scala_import_target_name = "scala_import_for_%s" % test_name
     scala_import(
         name = scala_import_target_name,
         jars = [jar],
         tags = ["manual"],
-        stamp = "//scala/settings:stamp_scala_import_%s" % ("on" if stamp_on else "off"),
+        stamp = setting_name,
     )
 
     stamp_deps_test(

--- a/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
@@ -45,6 +45,7 @@ def _test_dep_stamp(name, jar):
     stamp_deps_test(
         name = name,
         jar = jar,
+        tags = ["no-ide"],
         target_under_test = scala_import_target_name,
     )
 


### PR DESCRIPTION
Another to address broken signed jars after stamping with Target-Label their manifests. 

- stamps only compile jars
- original jars are passed for runtime/full compile jars
- adds setting to disable stamping in case there are issues