### PR TITLE
Change host_javabase cfg from host to exec

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -94,7 +94,7 @@ implicit_deps = {
     ),
     "_host_javabase": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
-        cfg = "host",
+        cfg = "exec",
     ),
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),


### PR DESCRIPTION
### Description

Looks like `cfg=host` is deprecated and needs to be changed to `cfg=exec`
