### PR TITLE
Clean up package names related to dependencyanalyzer

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.Global

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/DependencyAnalyzer.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/DependencyAnalyzer.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import java.util.jar.JarFile
 

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/DependencyAnalyzerSettings.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/DependencyAnalyzerSettings.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 object AnalyzerMode {
   case object Error extends AnalyzerMode

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/HighLevelCrawlUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/HighLevelCrawlUsedJarFinder.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import scala.reflect.io.AbstractFile
 import scala.tools.nsc.Global

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/OptionsParser.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/OptionsParser.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import scala.collection.mutable
 

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/Reporter.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/Reporter.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import scala.tools.nsc.Global
 

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/Reporter213.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/Reporter213.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import scala.tools.nsc.Global
 

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/ScalaVersion.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/ScalaVersion.scala
@@ -1,4 +1,4 @@
-package third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import scala.language.experimental.macros
 import scala.reflect.macros.blackbox

--- a/third_party/dependency_analyzer/src/main/resources/scalac-plugin.xml
+++ b/third_party/dependency_analyzer/src/main/resources/scalac-plugin.xml
@@ -1,4 +1,4 @@
 <plugin>
   <name>dependency-analyzer</name>
-  <classname>third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer</classname>
+  <classname>io.bazel.rulesscala.dependencyanalyzer.DependencyAnalyzer</classname>
 </plugin>

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -1,15 +1,15 @@
-package third_party.dependency_analyzer.src.test.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import java.nio.file.Files
 import java.nio.file.Path
 import io.bazel.rulesscala.io_utils.DeleteRecursively
 import org.scalatest.funsuite._
 import scala.tools.nsc.reporters.StoreReporter
-import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
-import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
-import third_party.utils.src.test.io.bazel.rulesscala.utils.JavaCompileUtil
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil.DependencyAnalyzerTestParams
+import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
+import io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
+import io.bazel.rulesscala.utils.JavaCompileUtil
+import io.bazel.rulesscala.utils.TestUtil
+import io.bazel.rulesscala.utils.TestUtil.DependencyAnalyzerTestParams
 
 // NOTE: Some tests are version-dependent as some false positives
 // cannot be fixed in older versions of Scala for various reasons.

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala
@@ -1,7 +1,7 @@
-package third_party.dependency_analyzer.src.test.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import org.scalatest.funsuite._
-import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
+import io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
 
 class ScalaVersionTest extends AnyFunSuite {
   test("version comparison works") {

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalacDependencyTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalacDependencyTest.scala
@@ -1,12 +1,12 @@
-package third_party.dependency_analyzer.src.test.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import java.nio.file.Files
 import java.nio.file.Path
 import java.util.UUID
 import io.bazel.rulesscala.io_utils.DeleteRecursively
 import org.scalatest.funsuite._
-import third_party.utils.src.test.io.bazel.rulesscala.utils.JavaCompileUtil
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil
+import io.bazel.rulesscala.utils.JavaCompileUtil
+import io.bazel.rulesscala.utils.TestUtil
 
 /**
  * Test that the scalac compiler behaves how we expect it to around

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/StrictDepsTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/StrictDepsTest.scala
@@ -1,9 +1,9 @@
-package third_party.dependency_analyzer.src.test.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import org.scalatest.funsuite._
-import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil._
+import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
+import io.bazel.rulesscala.utils.TestUtil
+import io.bazel.rulesscala.utils.TestUtil._
 
 class StrictDepsTest extends AnyFunSuite {
   val pluginName = "dependency_analyzer"

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/UnusedDependencyCheckerTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/UnusedDependencyCheckerTest.scala
@@ -1,9 +1,9 @@
-package third_party.dependency_analyzer.src.test.io.bazel.rulesscala.dependencyanalyzer
+package io.bazel.rulesscala.dependencyanalyzer
 
 import org.scalatest.funsuite._
-import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil
-import third_party.utils.src.test.io.bazel.rulesscala.utils.TestUtil._
+import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
+import io.bazel.rulesscala.utils.TestUtil
+import io.bazel.rulesscala.utils.TestUtil._
 
 class UnusedDependencyCheckerTest extends AnyFunSuite {
   def compileWithUnusedDependencyChecker(code: String, withDirect: List[(String, String)] = Nil): List[String] = {

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/JavaCompileUtil.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/JavaCompileUtil.scala
@@ -1,4 +1,4 @@
-package third_party.utils.src.test.io.bazel.rulesscala.utils
+package io.bazel.rulesscala.utils
 
 import java.io.File
 import java.io.IOException

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
@@ -1,4 +1,4 @@
-package third_party.utils.src.test.io.bazel.rulesscala.utils
+package io.bazel.rulesscala.utils
 
 import java.nio.file.Path
 import java.nio.file.Paths
@@ -12,7 +12,7 @@ import scala.tools.nsc.CompilerCommand
 import scala.tools.nsc.Global
 import scala.tools.nsc.Settings
 import scala.tools.nsc.reporters.StoreReporter
-import third_party.dependency_analyzer.src.main.io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
+import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
 
 object TestUtil {
   final val defaultTarget = "//..."


### PR DESCRIPTION
Normalizing package names under `third_party`. I guess they were generated by some tool automatically.