### PR TITLE
Require ProtoInfo for deps in scala_proto_library

### DIFF
--- a/scala_proto/private/scalapb_aspect.bzl
+++ b/scala_proto/private/scalapb_aspect.bzl
@@ -127,12 +127,6 @@ def _compile_sources(ctx, toolchain, proto, src_jars, deps):
 # or a scalapb_scala_library. Each proto_library will be one scalapb
 # invocation assuming it has some sources.
 def _scalapb_aspect_impl(target, ctx):
-    if ProtoInfo not in target:
-        # We allow some dependencies which are not protobuf, but instead
-        # are jvm deps. This is to enable cases of custom generators which
-        # add a needed jvm dependency.
-        return [ScalaPBAspectInfo(java_info = target[JavaInfo])]
-
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
     proto = target[ProtoInfo]
     deps = [d[ScalaPBAspectInfo].java_info for d in ctx.rule.attr.deps]

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -24,7 +24,7 @@ def _scala_proto_library_impl(ctx):
 scala_proto_library = rule(
     implementation = _scala_proto_library_impl,
     attrs = {
-        "deps": attr.label_list(aspects = [scalapb_aspect]),
+        "deps": attr.label_list(providers = [ProtoInfo], aspects = [scalapb_aspect]),
     },
     provides = [DefaultInfo, JavaInfo],
 )

--- a/scala_proto/scala_proto.bzl
+++ b/scala_proto/scala_proto.bzl
@@ -1,3 +1,4 @@
+load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
     "//scala:scala_cross_version.bzl",
     _default_maven_server_urls = "default_maven_server_urls",

--- a/test/BUILD
+++ b/test/BUILD
@@ -13,10 +13,6 @@ load(
     "scala_test",
     "scala_test_suite",
 )
-load(
-    "//scala_proto:scala_proto.bzl",
-    "scala_proto_library",
-)
 load(":check_statsfile.bzl", "check_statsfile")
 
 package(default_testonly = 1)

--- a/test/BUILD
+++ b/test/BUILD
@@ -664,24 +664,6 @@ scala_binary(
     deps = [":lib_with_scala_proto_dep"],
 )
 
-scala_proto_library(
-    name = "test_proto_scala_dep",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":HelloLib",
-        "//test/proto:test2",
-    ],
-)
-
-scala_proto_library(
-    name = "test_proto_scala_import_dep",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//test/proto:test2",
-        "@com_github_jnr_jffi_native",
-    ],
-)
-
 scala_library(
     name = "java_uses_scala_std_lib",
     srcs = ["JavaUsesScalaStdLib.java"],

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -1,4 +1,3 @@
-load("@rules_java//java:defs.bzl", "java_proto_library")
 load("@rules_proto//proto:defs.bzl", "proto_library")
 load(
     "//scala_proto:scala_proto.bzl",
@@ -120,23 +119,6 @@ scala_binary(
     main_class = "a.b.c",
     visibility = ["//visibility:public"],
     deps = [":test_proto_nogrpc"],
-)
-
-java_proto_library(
-    name = "test_proto_java_lib",
-    deps = [
-        ":test2",
-        "//test/proto2:test",
-    ],
-)
-
-scala_proto_library(
-    name = "test_proto_java_conversions",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":test2",
-        "//test/proto2:test",
-    ],
 )
 
 scala_proto_library(

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -173,12 +173,3 @@ scala_binary(
     main_class = "test.proto.TestServer",
     deps = [":lib_with_scala_proto_dep"],
 )
-
-scala_proto_library(
-    name = "test_proto_scala_dep",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":HelloLib",
-        "//proto:test2",
-    ],
-)

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -9,10 +9,6 @@ load(
     "scala_specs2_junit_test",
     "scala_test",
 )
-load(
-    "@io_bazel_rules_scala//scala_proto:scala_proto.bzl",
-    "scala_proto_library",
-)
 
 package(default_testonly = 1)
 

--- a/test_version/version_specific_tests_dir/proto/BUILD
+++ b/test_version/version_specific_tests_dir/proto/BUILD
@@ -1,4 +1,3 @@
-load("@rules_java//java:defs.bzl", "java_proto_library")
 load(
     "@io_bazel_rules_scala//scala_proto:scala_proto.bzl",
     "scala_proto_library",
@@ -34,24 +33,6 @@ scala_proto_library(
     name = "test_proto_nogrpc",
     visibility = ["//visibility:public"],
     deps = [":test2"],
-)
-
-java_proto_library(
-    name = "test_proto_java_lib",
-    deps = [
-        ":test2",
-        "//proto2:test",
-    ],
-)
-
-scala_proto_library(
-    name = "test_proto_java_conversions",
-    visibility = ["//visibility:public"],
-    deps = [
-        ":test2",
-        ":test_proto_java_lib",
-        "//proto2:test",
-    ],
 )
 
 scala_proto_library(


### PR DESCRIPTION
### Description

It made sense to accept `JavaInfo` as a dep in `scala_proto_library` when `with_java` flag was supported. But this flags is no longer supported since implementation moved to aspects. 

**Note:** this might be a breaking change if anyone is passing `JavaInfo` to `scala_proto_library`