### PR TITLE
Remove to-be-removed flags from default_java_toolchain

### DIFF
--- a/test_expect_failure/compilers_javac_opts/BUILD
+++ b/test_expect_failure/compilers_javac_opts/BUILD
@@ -8,8 +8,6 @@ scala_library(
 
 default_java_toolchain(
     name = "a_java_toolchain",
-    bootclasspath = ["@bazel_tools//tools/jdk:platformclasspath.jar"],
-    javac = ["@bazel_tools//third_party/java/jdk/langtools:javac_jar"],
     javacopts = ["-InvalidFlag"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
### Description

Attempt to fix https://github.com/bazelbuild/rules_scala/issues/1224

Test `java_toolchain_javacopts_are_used` fails because of failing `default_java_toolchain` declaration.

Root cause is that `javac` parameter was removed from `java_toolchain`.

Test `java_toolchain_javacopts_are_used` only cares about `javacopts` flag on a toolchain.

So this PR removes `bootclasspath` and `javac` from `default_java_toolchain` and these values will be taken from [DEFAULT_TOOLCHAIN_CONFIGURATION](https://github.com/bazelbuild/bazel/blob/667ae2adc793d376267c85e81ca6be600a4f2fbd/tools/jdk/default_java_toolchain.bzl#L80)/[_BASE_TOOLCHAIN_CONFIGURATION](https://github.com/bazelbuild/bazel/blob/667ae2adc793d376267c85e81ca6be600a4f2fbd/tools/jdk/default_java_toolchain.bzl#L55)