### PR TITLE
Add Domino Data Lab as a rules_scala adopter

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ Here's a (non-exhaustive) list of companies that use `rules_scala` in production
 
 * [Ascend](https://ascend.io/)
 * [Canva](https://www.canva.com/)
+* [Domino Data Lab](https://www.dominodatalab.com/)
 * [Etsy](https://www.etsy.com/)
 * [Gemini](https://gemini.com/)
 * [Grand Rounds](http://grandrounds.com/)


### PR DESCRIPTION
### Description
Adds [Domino Data Lab](https://www.dominodatalab.com/) as an adopter of `rules_scala`.

### Motivation
We're currently using `rules_scala` to build and test code in our monorepo. Hopefully our adoption encourages others to also use `rules_scala`.