### PR TITLE
Add `coverage_runfiles` phase to `scala_junit_test`.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,7 +48,7 @@ Note that Skylint failures are ignored and that the fix
 command will modify your files in place.
 
 ### Additional Tests to Run
-Some changes reqiring running additional tests which are not currently
+Some changes require running additional tests which are not currently
 part of the CI pipeline.
 
 When editing code in `./third_party`, please run `./dangerous_test_thirdparty_version.sh`

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -14,6 +14,7 @@ load(
     "phase_collect_jars_junit_test",
     "phase_compile_junit_test",
     "phase_coverage_common",
+    "phase_coverage_runfiles",
     "phase_declare_executable",
     "phase_default_info",
     "phase_dependency_common",
@@ -47,6 +48,7 @@ def _scala_junit_test_impl(ctx):
             ("coverage", phase_coverage_common),
             ("merge_jars", phase_merge_jars),
             ("runfiles", phase_runfiles_common),
+            ("coverage_runfiles", phase_coverage_runfiles),
             ("jvm_flags", phase_jvm_flags),
             ("write_executable", phase_write_executable_junit_test),
             ("default_info", phase_default_info),
@@ -77,6 +79,9 @@ _scala_junit_test_attrs = {
             "@io_bazel_rules_scala//scala:bazel_test_runner_deploy",
         ),
         allow_files = True,
+    ),
+    "_lcov_merger": attr.label(
+        default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
     ),
 }
 


### PR DESCRIPTION
See title.

Previously:
`bazel coverage //test:JunitTestWithDeps` would fail.

Now it succeeds as expected.

Relates to: https://github.com/bazelbuild/rules_scala/issues/1238

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
