### PR TITLE
Remove imports which cause warnings

### DIFF
--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -5,8 +5,6 @@ import java.nio.file.Path
 import io.bazel.rulesscala.io_utils.DeleteRecursively
 import org.scalatest.funsuite._
 import scala.tools.nsc.reporters.StoreReporter
-import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
-import io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
 import io.bazel.rulesscala.utils.JavaCompileUtil
 import io.bazel.rulesscala.utils.TestUtil
 import io.bazel.rulesscala.utils.TestUtil.DependencyAnalyzerTestParams


### PR DESCRIPTION
I left some unneeded imports from the same package, which cause warning noise in the build log. This PR removes them. 