### PR TITLE
Add file name encoding for JacocoIntrumenter

### DIFF
--- a/examples/testing/multi_frameworks_toolchain/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/BUILD
@@ -56,6 +56,7 @@ declare_deps_provider(
     deps_id = "specs2_junit_classpath",
     visibility = ["//visibility:public"],
     deps = [
+        "@io_bazel_rules_scala//scala:bazel_test_runner_deploy",
         "@io_bazel_rules_scala_org_specs2_specs2_junit",
     ],
 )

--- a/test/coverage_filename_encoding/A1.scala
+++ b/test/coverage_filename_encoding/A1.scala
@@ -1,0 +1,7 @@
+package coverage_filename_encoding
+
+object A1 {
+  def a1(flag: Boolean): String =
+    if (flag) "B1"
+    else sys.error("oh noes")
+}

--- a/test/coverage_filename_encoding/BUILD.bazel
+++ b/test/coverage_filename_encoding/BUILD.bazel
@@ -1,0 +1,20 @@
+load("//scala:scala.bzl", "scala_library", "scala_specs2_junit_test")
+
+scala_specs2_junit_test(
+    name = "name-with-equals",
+    size = "small",
+    srcs = ["Test.scala"],
+    prefixes = ["Test"],
+    deps = [
+        "a1%3D=%3D%2Bagg",
+    ],
+)
+
+scala_library(
+    name = "a1%3D=%3D%2Bagg",
+    srcs = [
+        "A1.scala",
+    ],
+    deps = [
+    ],
+)

--- a/test/coverage_filename_encoding/Test.scala
+++ b/test/coverage_filename_encoding/Test.scala
@@ -1,0 +1,10 @@
+package coverage_filename_encoding
+
+import org.specs2.mutable.SpecWithJUnit
+import org.specs2.specification.Scope
+
+class Test extends SpecWithJUnit {
+  "testA1" in new Scope {
+    A1.a1(true) must_!= 1
+  }
+}

--- a/test/coverage_filename_encoding/expected-coverage.dat
+++ b/test/coverage_filename_encoding/expected-coverage.dat
@@ -1,0 +1,21 @@
+SF:test/coverage_filename_encoding/A1.scala
+FN:-1,coverage_filename_encoding/A1$::<clinit> ()V
+FN:3,coverage_filename_encoding/A1$::<init> ()V
+FN:5,coverage_filename_encoding/A1$::a1 (Z)Ljava/lang/String;
+FN:-1,coverage_filename_encoding/A1::a1 (Z)Ljava/lang/String;
+FNDA:1,coverage_filename_encoding/A1$::<clinit> ()V
+FNDA:1,coverage_filename_encoding/A1$::<init> ()V
+FNDA:1,coverage_filename_encoding/A1$::a1 (Z)Ljava/lang/String;
+FNDA:0,coverage_filename_encoding/A1::a1 (Z)Ljava/lang/String;
+FNF:4
+FNH:3
+BA:5,2
+BRF:1
+BRH:1
+DA:3,1
+DA:5,4
+DA:6,1
+DA:7,4
+LH:4
+LF:4
+end_of_record

--- a/test/coverage_specs2_with_junit/BUILD
+++ b/test/coverage_specs2_with_junit/BUILD
@@ -11,6 +11,7 @@ scala_specs2_junit_test(
         ":a2",
         ":b1",
         ":d1",
+        ":e1",
     ],
 )
 
@@ -62,5 +63,17 @@ scala_library(
     name = "d1",
     srcs = [
         "D1.scala",
+    ],
+)
+
+scala_library(
+    name = "e1",
+    srcs = [
+        "A1.scala",
+        "D1.scala",
+        "E1.scala",
+    ],
+    deps = [
+        ":b1",
     ],
 )

--- a/test/coverage_specs2_with_junit/E1.scala
+++ b/test/coverage_specs2_with_junit/E1.scala
@@ -1,0 +1,6 @@
+package coverage_specs2_with_junit
+
+object E1 {
+  def e1(input: String): String =
+    input.reverse
+}

--- a/test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala
+++ b/test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala
@@ -15,4 +15,8 @@ class TestWithSpecs2WithJUnit extends SpecWithJUnit {
   "testD1" in new Scope {
     D1.veryLongFunctionNameIsHereAaaaaaaaa()
   }
+
+  "testE1" in new Scope {
+    E1.e1("test")
+  }
 }

--- a/test/coverage_specs2_with_junit/expected-coverage.dat
+++ b/test/coverage_specs2_with_junit/expected-coverage.dat
@@ -104,3 +104,20 @@ DA:41,4
 LH:4
 LF:4
 end_of_record
+SF:test/coverage_specs2_with_junit/E1.scala
+FN:-1,coverage_specs2_with_junit/E1$::<clinit> ()V
+FN:3,coverage_specs2_with_junit/E1$::<init> ()V
+FN:5,coverage_specs2_with_junit/E1$::e1 (Ljava/lang/String;)Ljava/lang/String;
+FN:-1,coverage_specs2_with_junit/E1::e1 (Ljava/lang/String;)Ljava/lang/String;
+FNDA:1,coverage_specs2_with_junit/E1$::<clinit> ()V
+FNDA:1,coverage_specs2_with_junit/E1$::<init> ()V
+FNDA:1,coverage_specs2_with_junit/E1$::e1 (Ljava/lang/String;)Ljava/lang/String;
+FNDA:0,coverage_specs2_with_junit/E1::e1 (Ljava/lang/String;)Ljava/lang/String;
+FNF:4
+FNH:3
+DA:3,1
+DA:5,9
+DA:6,4
+LH:3
+LF:3
+end_of_record

--- a/test/shell/test_coverage_equals_in_target.sh
+++ b/test/shell/test_coverage_equals_in_target.sh
@@ -1,0 +1,12 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_coverage_target_name_contains_equals_sign() {
+    bazel coverage //test/coverage_filename_encoding:name-with-equals
+    diff test/coverage_filename_encoding/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_filename_encoding/name-with-equals/coverage.dat
+}
+
+$runner test_coverage_target_name_contains_equals_sign

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -11,3 +11,4 @@ test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 
 . "${test_dir}"/test_coverage_specs2_with_junit.sh
 . "${test_dir}"/test_coverage_scalatest.sh
+. "${test_dir}"/test_coverage_equals_in_target.sh


### PR DESCRIPTION
### Description
Do not use  '=' as file names separator when providing them to JacocoInstrumenter .

Currently files provided as arguments for JacocoInstrumenter are separated by '='. That leads to problems if files or target names contain '=' in names. 

### Motivation
Currently `bazel coverage` cannot be run on targets where names include '=' sign. 
