### PR TITLE
Baseclass is direct

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -195,6 +195,7 @@ repositories(
         "org_spire_math_kind_projector",
         # For testing that we don't include sources jars to the classpath
         "org_typelevel__cats_core",
+        "org_typelevel__cats_kernel",
     ],
     maven_servers = MAVEN_SERVER_URLS,
 )

--- a/test/shell/test_strict_dependency.sh
+++ b/test/shell/test_strict_dependency.sh
@@ -104,7 +104,7 @@ test_base_class_is_direct_dependecy() {
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message \
     "${expected_message}" ${test_target} \
     "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error" \
-    "eq"
+    "ne"
 }
 
 $runner test_scala_import_library_passes_labels_of_direct_deps

--- a/test/shell/test_strict_dependency.sh
+++ b/test/shell/test_strict_dependency.sh
@@ -97,6 +97,16 @@ test_scala_proto_library_custom_phase_stamping() {
     "eq"
 }
 
+test_base_class_is_direct_dependecy() {
+  local test_target="//test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro"
+  local expected_message="buildozer 'add deps @io_bazel_rules_scala_org_specs2_specs2_common//:io_bazel_rules_scala_org_specs2_specs2_common' ${test_target}"
+
+  test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message \
+    "${expected_message}" ${test_target} \
+    "--extra_toolchains=//test/toolchains:ast_plus_one_deps_strict_deps_error" \
+    "eq"
+}
+
 $runner test_scala_import_library_passes_labels_of_direct_deps
 $runner test_plus_one_deps_only_works_for_java_info_targets
 $runner test_scala_import_expect_failure_on_missing_direct_deps_warn_mode
@@ -107,3 +117,4 @@ $runner test_strict_deps_filter_included_target
 $runner test_demonstrate_INCORRECT_scala_proto_library_stamp
 $runner test_scala_proto_library_stamp_by_convention
 $runner test_scala_proto_library_custom_phase_stamping
+$runner test_base_class_is_direct_dependecy

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_import")
-load("//scala:scala.bzl", "scala_library", "scala_specs2_junit_test")
+load("//scala:scala.bzl", "scala_specs2_junit_test")
 load("//scala:scala_import.bzl", "scala_import")
 load(":scala_import_stamp_test.bzl", "scala_import_stamping_test_suite")
 

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -44,14 +44,6 @@ scala_specs2_junit_test(
     deps = [":relate"],
 )
 
-scala_library(
-    name = "source_jar_not_oncp",
-    testonly = True,
-    srcs = ["ReferCatsImplicits.scala"],
-    # jvm_maven_import_external doesn't fetch source jars automatically
-    deps = ["@org_typelevel__cats_core//jar"],
-)
-
 ##Runtime deps
 scala_import(
     name = "indirection_for_transitive_runtime_deps",

--- a/test/src/main/scala/scalarules/test/scala_import/ReferCatsImplicits.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ReferCatsImplicits.scala
@@ -1,6 +1,0 @@
-package scalarules.test.scala_import
-
-import cats.implicits._
-
-object TestObj {}
-

--- a/test/src/main/scala/scalarules/test/sources_jars_in_deps/BUILD
+++ b/test/src/main/scala/scalarules/test/sources_jars_in_deps/BUILD
@@ -6,5 +6,6 @@ scala_library(
     srcs = ["ReferCatsImplicits.scala"],
     deps = [
         "@org_typelevel__cats_core//jar",
+        "@org_typelevel__cats_kernel",
     ],
 )

--- a/test/src/main/scala/scalarules/test/sources_jars_in_deps/BUILD
+++ b/test/src/main/scala/scalarules/test/sources_jars_in_deps/BUILD
@@ -6,6 +6,5 @@ scala_library(
     srcs = ["ReferCatsImplicits.scala"],
     deps = [
         "@org_typelevel__cats_core//jar",
-        "@org_typelevel__cats_kernel",
     ],
 )

--- a/test/src/main/scala/scalarules/test/sources_jars_in_deps/ReferCatsImplicits.scala
+++ b/test/src/main/scala/scalarules/test/sources_jars_in_deps/ReferCatsImplicits.scala
@@ -1,6 +1,6 @@
 package scala_rules.bazel
-import cats.implicits._
 
-
-object TestObj {}
+object TestObj {
+  val t = cats.Always
+}
 

--- a/test_expect_failure/missing_direct_deps/repros/BUILD
+++ b/test_expect_failure/missing_direct_deps/repros/BUILD
@@ -1,0 +1,11 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "specs2_matcher_repro",
+    srcs = ["Specs2MatchersRepro.scala"],
+    deps = [
+        # Repro code depends on specs2_fp via specs2_common: "@io_bazel_rules_scala_org_specs2_specs2_common",
+        "@io_bazel_rules_scala_org_specs2_specs2_fp",
+        "@io_bazel_rules_scala_org_specs2_specs2_matcher",
+    ],
+)

--- a/test_expect_failure/missing_direct_deps/repros/Specs2MatchersRepro.scala
+++ b/test_expect_failure/missing_direct_deps/repros/Specs2MatchersRepro.scala
@@ -1,0 +1,8 @@
+package repros
+
+import org.specs2.matcher.Matchers
+
+object Specs2MatchersRepro {
+
+  def fooSome(bar: String) = Matchers.beSome(bar)
+}

--- a/test_expect_failure/missing_direct_deps/scala_proto_deps/BUILD
+++ b/test_expect_failure/missing_direct_deps/scala_proto_deps/BUILD
@@ -25,7 +25,12 @@ scala_library(
 java_library(
     name = "transitive",
     srcs = ["UseTestMessage.java"],
-    deps = [":some_scala_proto"],
+    exports = [
+        "@scala_proto_rules_scalapb_lenses",  # required due to plus one
+    ],
+    deps = [
+        ":some_scala_proto",
+    ],
 )
 
 scala_proto_toolchain(
@@ -52,11 +57,16 @@ custom_stamping_scala_proto_library(
 java_library(
     name = "custom_transitive",
     srcs = ["UseTestMessage.java"],
+    exports = [
+        "@scala_proto_rules_scalapb_lenses",  # required due to plus one
+    ],
     deps = [":some_proto_custom_suffix"],
 )
 
 scala_library(
     name = "uses_transitive_some_proto_custom_suffix",
     srcs = ["UseScalaProtoIndirectly.scala"],
-    deps = [":custom_transitive"],
+    deps = [
+        ":custom_transitive",
+    ],
 )

--- a/third_party/dependency_analyzer/src/main/BUILD
+++ b/third_party/dependency_analyzer/src/main/BUILD
@@ -28,6 +28,7 @@ scala_library_for_plugin_bootstrapping(
         "io/bazel/rulesscala/dependencyanalyzer/HighLevelCrawlUsedJarFinder.scala",
         "io/bazel/rulesscala/dependencyanalyzer/OptionsParser.scala",
         "io/bazel/rulesscala/dependencyanalyzer/Reporter%s.scala" % REPORTER_COMPATIBILITY,
+        "io/bazel/rulesscala/dependencyanalyzer/Usage.scala",
     ],
     resources = ["resources/scalac-plugin.xml"],
     visibility = ["//visibility:public"],

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinder.scala
@@ -20,6 +20,12 @@ class AstUsedJarFinder(
     }
 
     def handleType(tpe: Type, pos: Position): Unit = {
+      tpe.baseClasses.foreach { baseClass =>
+        baseClass.associatedFile.underlyingSource.foreach { source =>
+          recordUse(source, pos)
+        }
+      }
+
       val sym = tpe.typeSymbol
       val assocFile = sym.associatedFile
       if (assocFile.path.endsWith(".class"))

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/HighLevelCrawlUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/HighLevelCrawlUsedJarFinder.scala
@@ -8,13 +8,13 @@ class HighLevelCrawlUsedJarFinder(
 ) {
   import global.Symbol
 
-  def findUsedJars: Map[AbstractFile, Global#Position] = {
+  def findUsedJars: Map[AbstractFile, Usage] = {
     val jars = collection.mutable.Set[AbstractFile]()
 
     global.exitingTyper {
       walkTopLevels(global.RootClass, jars)
     }
-    jars.map(jar => jar -> global.NoPosition).toMap
+    jars.map(jar => jar -> Usage(global.NoPosition, Direct)).toMap
   }
 
   private def walkTopLevels(root: Symbol, jars: collection.mutable.Set[AbstractFile]): Unit = {

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/Usage.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/Usage.scala
@@ -1,0 +1,11 @@
+package io.bazel.rulesscala.dependencyanalyzer
+
+import scala.tools.nsc.Global
+
+trait UsageType
+
+case object Direct extends UsageType
+
+case object BaseClass extends UsageType
+
+case class Usage(position: Global#Position, usageType: UsageType)

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -54,9 +54,9 @@ class AstUsedJarFinderTest extends AnyFunSuite {
     }
 
     def checkStrictDepsErrorsReported(
-                                       code: String,
-                                       expectedStrictDeps: List[String]
-                                     ): List[StoreReporter#Info] = {
+      code: String,
+      expectedStrictDeps: List[String]
+    ): List[StoreReporter#Info] = {
       val errors =
         TestUtil.runCompiler(
           code = code,

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/ScalaVersionTest.scala
@@ -1,7 +1,6 @@
 package io.bazel.rulesscala.dependencyanalyzer
 
 import org.scalatest.funsuite._
-import io.bazel.rulesscala.dependencyanalyzer.ScalaVersion
 
 class ScalaVersionTest extends AnyFunSuite {
   test("version comparison works") {

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/StrictDepsTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/StrictDepsTest.scala
@@ -1,7 +1,6 @@
 package io.bazel.rulesscala.dependencyanalyzer
 
 import org.scalatest.funsuite._
-import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
 import io.bazel.rulesscala.utils.TestUtil
 import io.bazel.rulesscala.utils.TestUtil._
 

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/UnusedDependencyCheckerTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/UnusedDependencyCheckerTest.scala
@@ -1,7 +1,6 @@
 package io.bazel.rulesscala.dependencyanalyzer
 
 import org.scalatest.funsuite._
-import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod
 import io.bazel.rulesscala.utils.TestUtil
 import io.bazel.rulesscala.utils.TestUtil._
 

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -435,7 +435,7 @@ artifacts = {
         "artifact": "org.typelevel:cats-core_2.11:0.9.0",
         "sha256": "3fda7a27114b0d178107ace5c2cf04e91e9951810690421768e65038999ffca5",
         "deps": [
-            "@org_typelevel__cats_kernel"
+            "@org_typelevel__cats_kernel",
         ],
     },
     "com_google_guava_guava_21_0_with_file": {

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -425,10 +425,18 @@ artifacts = {
         "artifact": "com.twitter:scalding-date_2.11:0.17.0",
         "sha256": "bf743cd6d224a4568d6486a2b794143e23145d2afd7a1d2de412d49e45bdb308",
     },
+    "org_typelevel__cats_kernel": {
+        "testonly": True,
+        "artifact": "org.typelevel:cats-kernel_2.11:0.9.0",
+        "sha256": "7569a2f96da3ab31f5c1ddc885cb1e436dabbcf7f5368a3f0eccb0d4f22cffc5",
+    },
     "org_typelevel__cats_core": {
         "testonly": True,
         "artifact": "org.typelevel:cats-core_2.11:0.9.0",
         "sha256": "3fda7a27114b0d178107ace5c2cf04e91e9951810690421768e65038999ffca5",
+        "deps": [
+            "@org_typelevel__cats_kernel"
+        ],
     },
     "com_google_guava_guava_21_0_with_file": {
         "testonly": True,

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -425,10 +425,18 @@ artifacts = {
         "artifact": "com.twitter:scalding-date_2.12:0.17.0",
         "sha256": "973a7198121cc8dac9eeb3f325c93c497fe3b682f68ba56e34c1b210af7b15b3",
     },
+    "org_typelevel__cats_kernel": {
+        "testonly": True,
+        "artifact": "org.typelevel:cats-kernel_2.12:0.9.0",
+        "sha256": "b544a2aed029bbf71e1d1dea9346a21a040f9ddfe1828578e73b01f938177006",
+    },
     "org_typelevel__cats_core": {
         "testonly": True,
         "artifact": "org.typelevel:cats-core_2.12:0.9.0",
         "sha256": "3ca705cba9dc0632e60477d80779006f8c636c0e2e229dda3410a0c314c1ea1d",
+        "deps": [
+            "@org_typelevel__cats_kernel"
+        ],
     },
     "com_google_guava_guava_21_0_with_file": {
         "testonly": True,

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -435,7 +435,7 @@ artifacts = {
         "artifact": "org.typelevel:cats-core_2.12:0.9.0",
         "sha256": "3ca705cba9dc0632e60477d80779006f8c636c0e2e229dda3410a0c314c1ea1d",
         "deps": [
-            "@org_typelevel__cats_kernel"
+            "@org_typelevel__cats_kernel",
         ],
     },
     "com_google_guava_guava_21_0_with_file": {

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -441,7 +441,7 @@ artifacts = {
         "artifact": "org.typelevel:cats-core_2.13:2.2.0",
         "sha256": "6058d02418e4eb5f1919a1156d63d2d1b93f2c6190b1a1806ee2b73f8726a92f",
         "deps": [
-            "@org_typelevel__cats_kernel"
+            "@org_typelevel__cats_kernel",
         ],
     },
     "com_google_guava_guava_21_0_with_file": {

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -431,10 +431,18 @@ artifacts = {
         "artifact": "com.twitter:scalding-date_2.13:0.17.0",
         "sha256": "973a7198121cc8dac9eeb3f325c93c497fe3b682f68ba56e34c1b210af7b15b4",
     },
+    "org_typelevel__cats_kernel": {
+        "testonly": True,
+        "artifact": "org.typelevel:cats-kernel_2.13:2.2.0",
+        "sha256": "f55782b7aa7f05b7d7516a441dada4a491587b9ff49a318772297c8a642a8539",
+    },
     "org_typelevel__cats_core": {
         "testonly": True,
         "artifact": "org.typelevel:cats-core_2.13:2.2.0",
-        "sha256": "6058d02418e4eb5f1919a1156d63d2d1b93f2c6190b1a1806ee2b73f8726a923",
+        "sha256": "6058d02418e4eb5f1919a1156d63d2d1b93f2c6190b1a1806ee2b73f8726a92f",
+        "deps": [
+            "@org_typelevel__cats_kernel"
+        ],
     },
     "com_google_guava_guava_21_0_with_file": {
         "testonly": True,

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
@@ -126,7 +126,10 @@ object TestUtil {
     // tests verify that positions are reported successfully.
     val toCompile = new BatchSourceFile("CompiledCode.scala", code)
     run.compileSources(List(toCompile))
-    reporter.infos.filter(_.severity == reporter.ERROR).toList
+    reporter
+      .infos
+      .filter(info => info.severity == reporter.ERROR || info.severity == reporter.WARNING)
+      .toList
   }
 
   private lazy val baseDir = System.getProperty("user.dir")


### PR DESCRIPTION
Attempt to please compiler by making base classes direct.

Repro demonstrates the following case:
1. Without the `specs2_fp` and `specs2_common` deps
```

ERROR: /rules_scala/test_expect_failure/missing_direct_deps/repros/BUILD:3:14: scala //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro failed (Exit 1)
test_expect_failure/missing_direct_deps/repros/Specs2MatchersRepro.scala:7: error: Symbol 'type org.specs2.fp.Functor' is missing from the classpath.
This symbol is required by 'value org.specs2.matcher.Expectable.ExpectableFunctor'.
Make sure that type Functor is in your classpath and check for conflicting dependencies with `-Ylog-classpath`.
A full rebuild may help if 'Expectable.class' was compiled against an incompatible version of org.specs2.fp.
  def fooSome(bar: String) = Matchers.beSome(bar)

```
2. After `specs2_fp` dep is added
```
ERROR: /rules_scala/test_expect_failure/missing_direct_deps/repros/BUILD:3:14: scala //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro failed (Exit 1)
error: Target '@io_bazel_rules_scala_org_specs2_specs2_fp//:io_bazel_rules_scala_org_specs2_specs2_fp' is specified as a dependency to //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro but isn't used, please remove it from the deps.
You can use the following buildozer command:
buildozer 'remove deps @io_bazel_rules_scala_org_specs2_specs2_fp//:io_bazel_rules_scala_org_specs2_specs2_fp' //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro
one error found
Build failed
```

3. After the fix (suggests `specs2_common`, which actually uses `specs2_fp`, and suggest to remove direct `specs2_fp`)
```
ERROR: /rules_scala/test_expect_failure/missing_direct_deps/repros/BUILD:3:14: scala //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro failed (Exit 1)
error: Target '@io_bazel_rules_scala_org_specs2_specs2_fp//:io_bazel_rules_scala_org_specs2_specs2_fp' is specified as a dependency to //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro but isn't used, please remove it from the deps.
You can use the following buildozer command:
buildozer 'remove deps @io_bazel_rules_scala_org_specs2_specs2_fp//:io_bazel_rules_scala_org_specs2_specs2_fp' //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro
test_expect_failure/missing_direct_deps/repros/Specs2MatchersRepro.scala:7: error: Target '@io_bazel_rules_scala_org_specs2_specs2_common//:io_bazel_rules_scala_org_specs2_specs2_common' is used but isn't explicitly declared, please add it to the deps.
You can use the following buildozer command:
buildozer 'add deps @io_bazel_rules_scala_org_specs2_specs2_common//:io_bazel_rules_scala_org_specs2_specs2_common' //test_expect_failure/missing_direct_deps/repros:specs2_matcher_repro
  def fooSome(bar: String) = Matchers.beSome(bar)
                             ^
two errors found
Build failed

```
