### PR TITLE
Remove bad path element warnings in bazel 4

### DIFF
--- a/third_party/java_tools/ijar/BUILD
+++ b/third_party/java_tools/ijar/BUILD
@@ -146,31 +146,30 @@ EOF""",
 
 genrule(
     name = "test-input-jar",
-    outs = ["input.jar"],
-    cmd = "$(JAVABASE)/bin/jar -cfm $@ $(location :test-input-manifest)",
     srcs = [":test-input-manifest"],
+    outs = ["input.jar"],
+    cmd = "$(JAVABASE)/bin/jar -cfm $@ $<",
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )
 
 genrule(
     name = "test-modified-jar",
-    outs = ["modified.jar"],
-    cmd = "$(location :ijar) --nostrip_jar --target_label label $(location :test-input-jar) $@",
     srcs = [":test-input-jar"],
+    outs = ["modified.jar"],
+    cmd = "$(location :ijar) --nostrip_jar --target_label label $< $@",
     tools = [":ijar"],
 )
 
 genrule(
     name = "test-modified-manifest",
-    outs = ["modified.mf"],
-    cmd = "$(JAVABASE)/bin/jar -xf $(location :test-modified-jar) META-INF/MANIFEST.MF && mv META-INF/MANIFEST.MF $@",
     srcs = [":test-modified-jar"],
+    outs = ["modified.mf"],
+    cmd = "$(JAVABASE)/bin/jar -xf $< META-INF/MANIFEST.MF && mv META-INF/MANIFEST.MF $@",
     toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
 )
 
 file_test(
     name = "test-modified-manifest-content",
-    file = ":test-modified-manifest",
     content = "\r\n".join([
         "Manifest-Version: 1.0",
         "Created-By: bazel",
@@ -178,4 +177,5 @@ file_test(
         "",
         "",
     ]),
+    file = ":test-modified-manifest",
 )

--- a/third_party/java_tools/ijar/BUILD
+++ b/third_party/java_tools/ijar/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@bazel_tools//tools/build_rules:test_rules.bzl", "file_test")
 
 package(
     default_visibility = [
@@ -132,3 +133,49 @@ filegroup(
 #    cmd = "$(location //src:zip_files) ijar $@ $(SRCS)",
 #    tools = ["//src:zip_files"],
 #)
+
+genrule(
+    name = "test-input-manifest",
+    outs = ["input.mf"],
+    cmd = """cat <<EOF >> $@
+Manifest-Version: 1.0
+Created-By: bazel
+Class-Path: class-path-entry
+EOF""",
+)
+
+genrule(
+    name = "test-input-jar",
+    outs = ["input.jar"],
+    cmd = "$(JAVABASE)/bin/jar -cfm $@ $(location :test-input-manifest)",
+    srcs = [":test-input-manifest"],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+)
+
+genrule(
+    name = "test-modified-jar",
+    outs = ["modified.jar"],
+    cmd = "$(location :ijar) --nostrip_jar --target_label label $(location :test-input-jar) $@",
+    srcs = [":test-input-jar"],
+    tools = [":ijar"],
+)
+
+genrule(
+    name = "test-modified-manifest",
+    outs = ["modified.mf"],
+    cmd = "$(JAVABASE)/bin/jar -xf $(location :test-modified-jar) META-INF/MANIFEST.MF && mv META-INF/MANIFEST.MF $@",
+    srcs = [":test-modified-jar"],
+    toolchains = ["@bazel_tools//tools/jdk:current_java_runtime"],
+)
+
+file_test(
+    name = "test-modified-manifest-content",
+    file = ":test-modified-manifest",
+    content = "\r\n".join([
+        "Manifest-Version: 1.0",
+        "Created-By: bazel",
+        "Target-Label: label",
+        "",
+        "",
+    ]),
+)

--- a/third_party/java_tools/ijar/ijar.cc
+++ b/third_party/java_tools/ijar/ijar.cc
@@ -54,6 +54,8 @@ const char *TARGET_LABEL_KEY = "Target-Label: ";
 const size_t TARGET_LABEL_KEY_LENGTH = strlen(TARGET_LABEL_KEY);
 const char *INJECTING_RULE_KIND_KEY = "Injecting-Rule-Kind: ";
 const size_t INJECTING_RULE_KIND_KEY_LENGTH = strlen(INJECTING_RULE_KIND_KEY);
+const char *CLASS_PATH_KEY = "Class-Path: ";
+const size_t CLASS_PATH_KEY_LENGTH = strlen(CLASS_PATH_KEY);
 
 class JarExtractorProcessor : public ZipExtractorProcessor {
  public:
@@ -305,11 +307,12 @@ u1 *JarCopierProcessor::AppendTargetLabelToManifest(
     // Go past return char to point to next line, or to end of data buffer
     line_end = line_end != nullptr ? line_end + 1 : data_end;
 
-    // Copy line unless it's Target-Label/Injecting-Rule-Kind and we're writing
-    // that ourselves
+    // Copy line unless it's Target-Label/Injecting-Rule-Kind/Class-Path
+    // Target-Label/Injecting-Rule-Kind we're writing that ourselves
+    // Class-Path is removed as it causes noise during build (see issue #1257)
     if (strncmp(line_start, TARGET_LABEL_KEY, TARGET_LABEL_KEY_LENGTH) != 0 &&
-        strncmp(line_start, INJECTING_RULE_KIND_KEY,
-                INJECTING_RULE_KIND_KEY_LENGTH) != 0) {
+        strncmp(line_start, INJECTING_RULE_KIND_KEY, INJECTING_RULE_KIND_KEY_LENGTH) != 0 &&
+        strncmp(line_start, CLASS_PATH_KEY, CLASS_PATH_KEY_LENGTH) != 0) {
       size_t len = line_end - line_start;
       memcpy(buf, line_start, len);
       buf += len;


### PR DESCRIPTION
### Description

Remove `[path] bad path element` warnings during build in bazel 4.

Bazel 4.0.0 sets `-Xlint:path` for `javac` invocations, which validates `Class-Path` entries and emits warnings.

This PR takes same approach as [rules_jvm_external](https://github.com/bazelbuild/rules_jvm_external/pull/518) ie remove `Class-Path` entry from imported jar's manifest.

Reproduce with:

`USE_BAZEL_VERSION=4.0.0 bash -c 'bazel build //src/java/io/bazel/rulesscala/scalac:scalac 2>&1 | grep "bad path element"'`

Related issues:
* https://github.com/bazelbuild/bazel/issues/12968
* https://github.com/bazelbuild/rules_jvm_external/pull/518

### Motivation

Resolves https://github.com/bazelbuild/rules_scala/issues/1257
