### PR TITLE
Configure major scala version via repo_env

### DIFF
--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -5,9 +5,11 @@ def _default_scala_version():
     return "2.12.11"
 
 def _store_config(repository_ctx):
-    repository_ctx.file("BUILD", "exports_files(['def.bzl'])")
+    scala_version = repository_ctx.os.environ.get(
+        "SCALA_VERSION_OVERRIDE",
+        repository_ctx.attr.scala_version,
+    )
 
-    scala_version = repository_ctx.attr.scala_version
     scala_major_version = extract_major_version(scala_version)
 
     config_file_content = "\n".join([
@@ -16,6 +18,7 @@ def _store_config(repository_ctx):
     ])
 
     repository_ctx.file("config.bzl", config_file_content)
+    repository_ctx.file("BUILD")
 
 _config_repository = repository_rule(
     implementation = _store_config,
@@ -24,6 +27,7 @@ _config_repository = repository_rule(
             mandatory = True,
         ),
     },
+    environ = ["SCALA_VERSION_OVERRIDE"],
 )
 
 def scala_config(scala_version = _default_scala_version()):

--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -6,7 +6,7 @@ def _default_scala_version():
 
 def _store_config(repository_ctx):
     scala_version = repository_ctx.os.environ.get(
-        "SCALA_VERSION_OVERRIDE",
+        "SCALA_VERSION",
         repository_ctx.attr.scala_version,
     )
 
@@ -27,7 +27,7 @@ _config_repository = repository_rule(
             mandatory = True,
         ),
     },
-    environ = ["SCALA_VERSION_OVERRIDE"],
+    environ = ["SCALA_VERSION"],
 )
 
 def scala_config(scala_version = _default_scala_version()):

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -1,0 +1,19 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_default_scala_library_version_on_classpath() {
+  bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
+   | grep scala-library-2.12.11
+}
+
+test_overwritten_scala_library_version_on_classpath() {
+  bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
+   --repo_env=SCALA_VERSION_OVERRIDE=2.13.x \
+   | grep scala-library-2.13.3
+}
+
+$runner test_default_scala_library_version_on_classpath
+$runner test_overwritten_scala_library_version_on_classpath

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -16,5 +16,11 @@ test_classpath_contains_2_13() {
    | grep scala-library-2.13
 }
 
+test_scala_config_content() {
+  bazel build --repo_env=SCALA_VERSION=0.0.0 @io_bazel_rules_scala_config//:all 2> /dev/null
+  grep "SCALA_MAJOR_VERSION='0.0'" $(bazel info output_base)/external/io_bazel_rules_scala_config/config.bzl
+}
+
 $runner test_classpath_contains_2_12
 $runner test_classpath_contains_2_13
+$runner test_scala_config_content

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -4,16 +4,17 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
-test_default_scala_library_version_on_classpath() {
+test_classpath_contains_2_12() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   | grep scala-library-2.12.11
+   --repo_env=SCALA_VERSION=2.12.x \
+   | grep scala-library-2.12
 }
 
-test_overwritten_scala_library_version_on_classpath() {
+test_classpath_contains_2_13() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION_OVERRIDE=2.13.x \
-   | grep scala-library-2.13.3
+   --repo_env=SCALA_VERSION=2.13.x \
+   | grep scala-library-2.13
 }
 
-$runner test_default_scala_library_version_on_classpath
-$runner test_overwritten_scala_library_version_on_classpath
+$runner test_classpath_contains_2_12
+$runner test_classpath_contains_2_13

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -37,6 +37,7 @@ $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one
 . "${test_dir}"/test_scala_binary.sh
 . "${test_dir}"/test_scalac_jvm_flags.sh
 . "${test_dir}"/test_scala_classpath.sh
+. "${test_dir}"/test_scala_config.sh
 . "${test_dir}"/test_scala_import_source_jar.sh
 . "${test_dir}"/test_scala_jvm_flags.sh
 . "${test_dir}"/test_scala_jacocorunner.sh


### PR DESCRIPTION
### Description
Specify scala version that is written by `scala_config` rule in command line `--repo_env=SCALA_VERSION_OVERRIDE=x.y.z`. 

### Motivation
Allows to build a project with different scala versions without need for sed workspace.
