### PR TITLE
Pass along tags in scala_test_suite

### DIFF
--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -127,6 +127,7 @@ def scala_test_suite(
         srcs = [],
         visibility = None,
         use_short_names = False,
+        tags = [],
         **kwargs):
     ts = []
     i = 0
@@ -138,7 +139,8 @@ def scala_test_suite(
             srcs = [test_file],
             visibility = visibility,
             unused_dependency_checker_mode = "off",
+            tags = tags,
             **kwargs
         )
         ts.append(n)
-    native.test_suite(name = name, tests = ts, visibility = visibility)
+    native.test_suite(name = name, tests = ts, visibility = visibility, tags = tags)


### PR DESCRIPTION
### Description

Pass along tags passed to `scala_test_suite` to the test suite target.


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation

This is useful to set a suite to `manual` for example.