### PR TITLE
rules_scala stewardship update

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -11,3 +11,4 @@ Dino Wernli <dinowernli@gmail.com>
 Oscar Boykin <oscar.boykin@gmail.com>
 John T. Sullivan <john.t.sullivan@gmail.com>
 Andy Scott <andy.g.scott@gmail.com>
+Ittai Zeidman <ittaiz@gmail.com>

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ittaiz @liucijus
+* @liucijus @simuons

--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -21,3 +21,4 @@ Oscar Boykin <oscar.boykin@gmail.com>
 Justine Alexandra Roberts Tunney <jart@google.com>
 Natan Silnitsky <natans@wix.com>
 Nadav Wexler <nadavwe@wix.com>
+Ittai Zeidman <ittaiz@gmail.com>

--- a/Governance.md
+++ b/Governance.md
@@ -55,7 +55,7 @@ Maintainers are selected by 2/3 or more approval of the current set of maintaine
 
 #### Current maintainers: (edit as needed)  
 Vaidas Pilkauskas, @liucijus  
-Simonas (Pinevicius) Pinevičius, @simuons
+Simonas Pinevičius, @simuons
 #### Past maintainers:  
 Oscar Boykin, @johnynek  
 Ittai Zeidman, @ittaiz   

--- a/Governance.md
+++ b/Governance.md
@@ -54,9 +54,10 @@ Maintainers are selected by 2/3 or more approval of the current set of maintaine
 
 
 #### Current maintainers: (edit as needed)  
-Ittai Zeidman, @ittaiz   
 Vaidas Pilkauskas, @liucijus  
+Simonas (Pinevicius) Pinevičius, @simuons
 #### Past maintainers:  
 Oscar Boykin, @johnynek  
+Ittai Zeidman, @ittaiz   
 
 


### PR DESCRIPTION
Over the past few months @simuons has become a very important part of rules_scala d2d (helping on issues, reviewing PRs, and authoring PRs).  
Seeing as he’s been fulfilling the maintainer roles without being named as one I feel it is only natural to add him as an official maintainer.   

I want to take this opportunity to re-iterate that we are very interested in adding more maintainers (individuals and companies) to make sure rules_scala remains a thriving project and an important part of the bazel ecosystem.   

This close and engaging work by him and @liucijus has gladly brought me to the place where I can leave rules_scala stewardship in their trusted hands and continue to new adventures.  

I want to thank you for your help over this time, I’m very excited about where rules_scala is right now and where it’s going, and I’m sure that we will meet again in the bazel community.  