### PR TITLE
Removes scala_version

### DIFF
--- a/docs/scala_proto_library.md
+++ b/docs/scala_proto_library.md
@@ -5,7 +5,7 @@ which adds a few dependencies needed for ScalaPB:
 
 ```starlark
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
-scala_proto_repositories(scala_version = "2.12.10") # or whatever scala_version you're on
+scala_proto_repositories() 
 ```
 
 Then you can import `scala_proto_library` in any `BUILD` file like this:


### PR DESCRIPTION
### Description
scala_proto_repositories does not accept scala_version

<!-- Mandatory: A crisp one or two line description of your proposed change. -->


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Clean up docs