### PR TITLE
Remove ubuntu1604 from presubmit.yml

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,17 +1,6 @@
 ---
 validate_config: 1
 tasks:
-  ubuntu1604:
-    name: "bazel test //test/..."       
-    platform: ubuntu1604
-    shell_commands:
-    # Disable local disk caching on CI.
-    - mv tools/bazel.rc.buildkite tools/bazel.rc
-    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
   ubuntu1804:
     name: "bazel test //test/..."      
     platform: ubuntu1804


### PR DESCRIPTION
Ubuntu 16.04 is end-of-life, we're going to remove it from Bazel CI.
