### PR TITLE
Load @com_google_protobuf//:protoc via rules_proto

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,11 +46,10 @@ http_archive(
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
 
-rules_scala_version = "5df8033f752be64fbe2cedfd1bdbad56e2033b15"
-
+rules_scala_version = "e7a948ad1948058a7a5ddfbd9d1629d6db839933"
 http_archive(
     name = "io_bazel_rules_scala",
-    sha256 = "b7fa29db72408a972e6b6685d1bc17465b3108b620cb56d9b1700cf6f70f624a",
+    sha256 = "76e1abb8a54f61ada974e6e9af689c59fd9f0518b49be6be7a631ce9fa45f236",
     strip_prefix = "rules_scala-%s" % rules_scala_version,
     type = "zip",
     url = "https://github.com/bazelbuild/rules_scala/archive/%s.zip" % rules_scala_version,
@@ -64,6 +63,10 @@ scala_config()
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 scala_repositories()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 scala_register_toolchains()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -11,25 +11,6 @@ http_archive(
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "8e7d59a5b12b233be5652e3d29f42fba01c7cbab09f6b3a8d0a57ed6d1e9a0da",
-    strip_prefix = "rules_proto-7e4afce6fe62dbff0a4a03450143146f9f2d7488",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-    ],
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-# Declares @com_google_protobuf//:protoc pointing to released binary
-# This should stop building protoc during bazel build
-# See https://github.com/bazelbuild/rules_proto/pull/36
-rules_proto_dependencies()
-
-rules_proto_toolchains()
-
 _build_tools_release = "3.5.0"
 
 http_archive(
@@ -46,6 +27,15 @@ scala_config()
 load("//scala:scala.bzl", "scala_repositories")
 
 scala_repositories(fetch_sources = True)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+# Declares @com_google_protobuf//:protoc pointing to released binary
+# This should stop building protoc during bazel build
+# See https://github.com/bazelbuild/rules_proto/pull/36
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -11,22 +11,6 @@ http_archive(
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "8e7d59a5b12b233be5652e3d29f42fba01c7cbab09f6b3a8d0a57ed6d1e9a0da",
-    strip_prefix = "rules_proto-7e4afce6fe62dbff0a4a03450143146f9f2d7488",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-    ],
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-rules_proto_dependencies()
-
-rules_proto_toolchains()
-
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../../..",
@@ -39,6 +23,12 @@ scala_config()
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
 scala_repositories()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -11,22 +11,6 @@ http_archive(
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "8e7d59a5b12b233be5652e3d29f42fba01c7cbab09f6b3a8d0a57ed6d1e9a0da",
-    strip_prefix = "rules_proto-7e4afce6fe62dbff0a4a03450143146f9f2d7488",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-    ],
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-rules_proto_dependencies()
-
-rules_proto_toolchains()
-
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../../..",
@@ -39,6 +23,12 @@ scala_config()
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
 scala_repositories()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -11,22 +11,6 @@ http_archive(
     url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "8e7d59a5b12b233be5652e3d29f42fba01c7cbab09f6b3a8d0a57ed6d1e9a0da",
-    strip_prefix = "rules_proto-7e4afce6fe62dbff0a4a03450143146f9f2d7488",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-    ],
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-rules_proto_dependencies()
-
-rules_proto_toolchains()
-
 local_repository(
     name = "io_bazel_rules_scala",
     path = "../../..",
@@ -39,6 +23,12 @@ scala_config()
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
 scala_repositories()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -6,21 +6,14 @@ load(
 load("//third_party/repositories:repositories.bzl", "repositories")
 
 def rules_scala_setup():
-    if not native.existing_rule("com_google_protobuf"):
+    if not native.existing_rule("bazel_skylib"):
+        skylib_version = "1.0.3"
         http_archive(
-            name = "com_google_protobuf",
-            sha256 = "cf754718b0aa945b00550ed7962ddc167167bd922b842199eeb6505e6f344852",
-            strip_prefix = "protobuf-3.11.3",
-            urls = [
-                "https://mirror.bazel.build/github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
-                "https://github.com/protocolbuffers/protobuf/archive/v3.11.3.tar.gz",
-            ],
+            name = "bazel_skylib",
+            sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+            type = "tar.gz",
+            url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
         )
-
-    native.bind(
-        name = "io_bazel_rules_scala/dependency/com_google_protobuf/protobuf_java",
-        actual = "@com_google_protobuf//:protobuf_java",
-    )
 
     if not native.existing_rule("rules_cc"):
         http_archive(
@@ -48,43 +41,27 @@ def rules_scala_setup():
             ],
         )
 
-    if not native.existing_rule("rules_python"):
-        http_archive(
-            name = "rules_python",
-            sha256 = "e5470e92a18aa51830db99a4d9c492cc613761d5bdb7131c04bd92b9834380f6",
-            strip_prefix = "rules_python-4b84ad270387a7c439ebdccfd530e2339601ef27",
-            urls = ["https://github.com/bazelbuild/rules_python/archive/4b84ad270387a7c439ebdccfd530e2339601ef27.tar.gz"],
-        )
-
-    if not native.existing_rule("zlib"):  # needed by com_google_protobuf
-        http_archive(
-            name = "zlib",
-            build_file = "@com_google_protobuf//third_party:zlib.BUILD",
-            sha256 = "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1",
-            strip_prefix = "zlib-1.2.11",
-            urls = [
-                "https://mirror.bazel.build/zlib.net/zlib-1.2.11.tar.gz",
-                "https://zlib.net/zlib-1.2.11.tar.gz",
-            ],
-        )
-
 def scala_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {},
+        load_dep_rules = True,
+        load_jar_deps = True,
         fetch_sources = False):
-    rules_scala_setup()
+    if load_dep_rules:
+        rules_scala_setup()
 
-    repositories(
-        for_artifact_ids = [
-            "io_bazel_rules_scala_scala_library",
-            "io_bazel_rules_scala_scala_compiler",
-            "io_bazel_rules_scala_scala_reflect",
-            "io_bazel_rules_scala_scalatest",
-            "io_bazel_rules_scala_scalactic",
-            "io_bazel_rules_scala_scala_xml",
-            "io_bazel_rules_scala_scala_parser_combinators",
-        ],
-        maven_servers = maven_servers,
-        fetch_sources = fetch_sources,
-        overriden_artifacts = overriden_artifacts,
-    )
+    if load_jar_deps:
+        repositories(
+            for_artifact_ids = [
+                "io_bazel_rules_scala_scala_library",
+                "io_bazel_rules_scala_scala_compiler",
+                "io_bazel_rules_scala_scala_reflect",
+                "io_bazel_rules_scala_scalatest",
+                "io_bazel_rules_scala_scalactic",
+                "io_bazel_rules_scala_scala_xml",
+                "io_bazel_rules_scala_scala_parser_combinators",
+            ],
+            maven_servers = maven_servers,
+            fetch_sources = fetch_sources,
+            overriden_artifacts = overriden_artifacts,
+        )

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -2,21 +2,14 @@ workspace(name = "proto")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
+skylib_version = "1.0.3"
+
 http_archive(
-    name = "rules_proto",
-    sha256 = "8e7d59a5b12b233be5652e3d29f42fba01c7cbab09f6b3a8d0a57ed6d1e9a0da",
-    strip_prefix = "rules_proto-7e4afce6fe62dbff0a4a03450143146f9f2d7488",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-        "https://github.com/bazelbuild/rules_proto/archive/7e4afce6fe62dbff0a4a03450143146f9f2d7488.tar.gz",
-    ],
+    name = "bazel_skylib",
+    sha256 = "1c531376ac7e5a180e0237938a2536de0c54d93f5c278634818e0efc952dd56c",
+    type = "tar.gz",
+    url = "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
 )
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
-
-rules_proto_dependencies()
-
-rules_proto_toolchains()
 
 local_repository(
     name = "io_bazel_rules_scala",
@@ -30,6 +23,12 @@ scala_config()
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
 scala_repositories()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
 


### PR DESCRIPTION
- Reorganize how `rules_proto` are loaded
- Update too old `@com_google_protobuf//:protoc` version in scala repositories
- Update example/test/WORKSPACE/README code