### PR TITLE
Extra jmh options: testonly, runtime_deps

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -81,6 +81,7 @@ def scala_benchmark_jmh(**kw):
     data = kw.get("data", [])
     generator_type = kw.get("generator_type", "reflection")
     lib = "%s_generator" % name
+    testonly = kw.get("testonly", False)
     scalacopts = kw.get("scalacopts", [])
     main_class = kw.get("main_class", "org.openjdk.jmh.Main")
 
@@ -94,6 +95,7 @@ def scala_benchmark_jmh(**kw):
         resources = kw.get("resources", []),
         resource_jars = kw.get("resource_jars", []),
         visibility = ["//visibility:public"],
+        testonly = testonly,
         unused_dependency_checker_mode = "off",
     )
 
@@ -102,6 +104,7 @@ def scala_benchmark_jmh(**kw):
         name = codegen,
         src = lib,
         generator_type = generator_type,
+        testonly = testonly,
     )
     compiled_lib = name + "_compiled_benchmark_lib"
     scala_library(
@@ -112,6 +115,7 @@ def scala_benchmark_jmh(**kw):
             lib,
         ],
         resource_jars = ["%s_resources.jar" % codegen],
+        testonly = testonly,
         unused_dependency_checker_mode = "off",
     )
     scala_binary(
@@ -122,5 +126,6 @@ def scala_benchmark_jmh(**kw):
         ],
         data = data,
         main_class = main_class,
+        testonly = testonly,
         unused_dependency_checker_mode = "off",
     )

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -77,6 +77,7 @@ scala_generate_benchmark = rule(
 def scala_benchmark_jmh(**kw):
     name = kw["name"]
     deps = kw.get("deps", [])
+    runtime_deps = kw.get("runtime_deps", [])
     srcs = kw["srcs"]
     data = kw.get("data", [])
     generator_type = kw.get("generator_type", "reflection")
@@ -91,6 +92,7 @@ def scala_benchmark_jmh(**kw):
         deps = deps + [
             "@io_bazel_rules_scala//jmh:jmh_core",
         ],
+        runtime_deps = runtime_deps,
         scalacopts = scalacopts,
         resources = kw.get("resources", []),
         resource_jars = kw.get("resource_jars", []),

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -28,11 +28,34 @@ scala_library(
     ],
 )
 
+scala_library(
+    name = "add_numbers_testonly",
+    testonly = True,
+    srcs = ["AddNumbers.scala"],
+    visibility = ["//visibility:public"],
+    exports = [
+        ":java_type",
+        ":scala_type",
+    ],
+    deps = [
+        ":java_type",
+        ":scala_type",
+    ],
+)
+
 scala_benchmark_jmh(
     name = "test_benchmark",
     srcs = ["TestBenchmark.scala"],
     data = ["data.txt"],
     deps = [":add_numbers"],
+)
+
+scala_benchmark_jmh(
+    name = "test_benchmark_testonly",
+    testonly = True,
+    srcs = ["TestBenchmark.scala"],
+    data = ["data.txt"],
+    deps = [":add_numbers_testonly"],
 )
 
 scala_test(


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Adding 2 options to JMH rules:
- `testonly` to allow marking JMH as `testonly` and consuming `testonly` dependencies, which allows re-using various test-kits and test helpers.
- `runtime_deps`, which might (and is in our case) required for benchmark dependencies

Both are optional, so should be fully backwards-compatible.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

We have many test-kits and test helpers marked with `testonly`, because we're using them for testing mainly and `testonly` protects us from getting them into production. They are very useful for benchmarks as well, which is why we need this flag.
