### PR TITLE
Fix missing directories in JaCoCo instrumented jars

### DIFF
--- a/src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java
+++ b/src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java
@@ -5,6 +5,7 @@ import io.bazel.rulesscala.jar.JarCreator;
 import io.bazel.rulesscala.worker.Worker;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
+import java.io.IOException;
 import java.io.UnsupportedEncodingException;
 import java.nio.file.FileSystem;
 import java.nio.file.FileSystems;
@@ -21,6 +22,7 @@ import org.jacoco.core.runtime.OfflineInstrumentationAccessGenerator;
 import java.net.URLDecoder;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 public final class JacocoInstrumenter implements Worker.Interface {
@@ -101,6 +103,19 @@ public final class JacocoInstrumenter implements Worker.Interface {
                 } catch (final Exception e) {
                     throw new RuntimeException(e);
                 }
+            }
+
+            @Override
+            public FileVisitResult preVisitDirectory(Path dir, BasicFileAttributes attrs)
+                throws IOException
+            {
+                Objects.requireNonNull(dir);
+                Objects.requireNonNull(attrs);
+                // Adding non-root directories to the jar
+                if(!dir.toString().equals("/")){
+                    jarCreator.addEntry(dir.toString(),dir);
+                }
+                return FileVisitResult.CONTINUE;
             }
 
             private FileVisitResult actuallyVisitFile(Path inPath, BasicFileAttributes attrs) throws Exception {

--- a/test/coverage_scalatest_resources/consumer/BUILD.bazel
+++ b/test/coverage_scalatest_resources/consumer/BUILD.bazel
@@ -2,15 +2,15 @@ load("//scala:scala.bzl", "scala_library", "scala_test")
 
 scala_library(
     name = "consumer",
+    srcs = ["src/main/scala/com/example/consumer/Consumer.scala"],
     deps = ["//test/coverage_scalatest_resources/resource"],
-    srcs = ["src/main/scala/com/example/consumer/Consumer.scala"]
 )
 
 scala_test(
     name = "tests",
-    deps = ["//test/coverage_scalatest_resources/resource"],
     srcs = [
         "src/main/scala/com/example/consumer/Consumer.scala",
         "src/test/scala/com/example/consumer/ConsumerSpec.scala",
-        ]
+    ],
+    deps = ["//test/coverage_scalatest_resources/resource"],
 )

--- a/test/coverage_scalatest_resources/consumer/BUILD.bazel
+++ b/test/coverage_scalatest_resources/consumer/BUILD.bazel
@@ -1,0 +1,14 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("//scala:scala.bzl", "scala_library", "scala_test")
+
+scala_library(
+    name = "consumer",
+    deps = ["//test/coverage_scalatest_resources/resource"],
+    srcs = ["src/main/scala/com/example/consumer/Consumer.scala"]
+)
+
+scala_test(
+    name = "tests",
+    deps = ["//test/coverage_scalatest_resources/resource"],
+    srcs = glob(include = ["{}/**".format("src/main/scala")]) + glob(include = ["{}/**".format("src/test/scala")])
+)

--- a/test/coverage_scalatest_resources/consumer/BUILD.bazel
+++ b/test/coverage_scalatest_resources/consumer/BUILD.bazel
@@ -10,5 +10,8 @@ scala_library(
 scala_test(
     name = "tests",
     deps = ["//test/coverage_scalatest_resources/resource"],
-    srcs = glob(include = ["{}/**".format("src/main/scala")]) + glob(include = ["{}/**".format("src/test/scala")])
+    srcs = [
+        "src/main/scala/com/example/consumer/Consumer.scala",
+        "src/test/scala/com/example/consumer/ConsumerSpec.scala",
+        ]
 )

--- a/test/coverage_scalatest_resources/consumer/BUILD.bazel
+++ b/test/coverage_scalatest_resources/consumer/BUILD.bazel
@@ -1,4 +1,3 @@
-load("@rules_java//java:defs.bzl", "java_library")
 load("//scala:scala.bzl", "scala_library", "scala_test")
 
 scala_library(

--- a/test/coverage_scalatest_resources/consumer/BUILD.bazel
+++ b/test/coverage_scalatest_resources/consumer/BUILD.bazel
@@ -9,8 +9,7 @@ scala_library(
 scala_test(
     name = "tests",
     srcs = [
-        "src/main/scala/com/example/consumer/Consumer.scala",
         "src/test/scala/com/example/consumer/ConsumerSpec.scala",
     ],
-    deps = ["//test/coverage_scalatest_resources/resource"],
+    deps = [":consumer"],
 )

--- a/test/coverage_scalatest_resources/consumer/src/main/scala/com/example/consumer/Consumer.scala
+++ b/test/coverage_scalatest_resources/consumer/src/main/scala/com/example/consumer/Consumer.scala
@@ -1,0 +1,14 @@
+package com.example.consumer
+
+import com.example.resource.Util
+
+import java.lang.Thread
+import java.net.URL
+import java.util.Enumeration
+
+class Consumer {
+  val hello: String = Util.hello
+
+  val classLoader = Thread.currentThread.getContextClassLoader
+  val resourceList: Enumeration[URL] = classLoader.getResources("com/example/resource")
+}

--- a/test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala
+++ b/test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala
@@ -1,0 +1,23 @@
+package com.example.consumer
+
+import java.net.URL
+
+import org.scalatest.flatspec._
+import org.scalatest.matchers.should._
+
+class ConsumerSpec extends AnyFlatSpec with Matchers {
+
+    "ConsumerSpec" should "fetch hello" in {
+        val fixture = new Consumer()
+        fixture.hello should === ("Hello!")
+    }
+
+    it should "have valid classloaders" in {
+      val fixture = new Consumer()
+      fixture.resourceList.hasMoreElements should be (true)
+      val element = fixture.resourceList.nextElement
+      element shouldBe a [URL]
+      println(element)
+    }
+
+}

--- a/test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala
+++ b/test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala
@@ -7,12 +7,7 @@ import org.scalatest.matchers.should._
 
 class ConsumerSpec extends AnyFlatSpec with Matchers {
 
-    "ConsumerSpec" should "fetch hello" in {
-        val fixture = new Consumer()
-        fixture.hello should === ("Hello!")
-    }
-
-    it should "have valid classloaders" in {
+    "ConsumerSpec" should "have valid classloaders" in {
       val fixture = new Consumer()
       fixture.resourceList.hasMoreElements should be (true)
       val element = fixture.resourceList.nextElement

--- a/test/coverage_scalatest_resources/expected-coverage.dat
+++ b/test/coverage_scalatest_resources/expected-coverage.dat
@@ -1,0 +1,17 @@
+SF:test/coverage_scalatest_resources/resource/src/main/scala/com/example/resource/Util.scala
+FN:-1,com/example/resource/Util$::<clinit> ()V
+FN:3,com/example/resource/Util$::<init> ()V
+FN:4,com/example/resource/Util$::hello ()Ljava/lang/String;
+FN:-1,com/example/resource/Util::hello ()Ljava/lang/String;
+FNDA:1,com/example/resource/Util$::<clinit> ()V
+FNDA:1,com/example/resource/Util$::<init> ()V
+FNDA:1,com/example/resource/Util$::hello ()Ljava/lang/String;
+FNDA:0,com/example/resource/Util::hello ()Ljava/lang/String;
+FNF:4
+FNH:3
+DA:3,1
+DA:4,2
+DA:5,4
+LH:3
+LF:3
+end_of_record

--- a/test/coverage_scalatest_resources/expected-coverage.dat
+++ b/test/coverage_scalatest_resources/expected-coverage.dat
@@ -1,3 +1,22 @@
+SF:test/coverage_scalatest_resources/consumer/src/main/scala/com/example/consumer/Consumer.scala
+FN:9,com/example/consumer/Consumer::<init> ()V
+FN:12,com/example/consumer/Consumer::classLoader ()Ljava/lang/ClassLoader;
+FN:10,com/example/consumer/Consumer::hello ()Ljava/lang/String;
+FN:13,com/example/consumer/Consumer::resourceList ()Ljava/util/Enumeration;
+FNDA:1,com/example/consumer/Consumer::<init> ()V
+FNDA:1,com/example/consumer/Consumer::classLoader ()Ljava/lang/ClassLoader;
+FNDA:0,com/example/consumer/Consumer::hello ()Ljava/lang/String;
+FNDA:1,com/example/consumer/Consumer::resourceList ()Ljava/util/Enumeration;
+FNF:4
+FNH:3
+DA:9,1
+DA:10,4
+DA:12,7
+DA:13,9
+DA:14,2
+LH:5
+LF:5
+end_of_record
 SF:test/coverage_scalatest_resources/resource/src/main/scala/com/example/resource/Util.scala
 FN:-1,com/example/resource/Util$::<clinit> ()V
 FN:3,com/example/resource/Util$::<init> ()V

--- a/test/coverage_scalatest_resources/resource/BUILD.bazel
+++ b/test/coverage_scalatest_resources/resource/BUILD.bazel
@@ -3,7 +3,10 @@ load("//scala:scala.bzl", "scala_library")
 scala_library(
     name = "resource",
     srcs = ["src/main/scala/com/example/resource/Util.scala"],
-    resources =  ["src/main/resources/com/example/resource/example.sql"],
-    resource_strip_prefix = "{}/{}".format(package_name(), "src/main/resources"),
-    visibility = ["//visibility:public"]
+    resource_strip_prefix = "{}/{}".format(
+        package_name(),
+        "src/main/resources",
+    ),
+    resources = ["src/main/resources/com/example/resource/example.sql"],
+    visibility = ["//visibility:public"],
 )

--- a/test/coverage_scalatest_resources/resource/BUILD.bazel
+++ b/test/coverage_scalatest_resources/resource/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_library")
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary", "scala_test")
+load("//scala:scala.bzl", "scala_library", "scala_test")
 
 scala_library(
     name = "resource",

--- a/test/coverage_scalatest_resources/resource/BUILD.bazel
+++ b/test/coverage_scalatest_resources/resource/BUILD.bazel
@@ -1,0 +1,10 @@
+load("@rules_java//java:defs.bzl", "java_library")
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary", "scala_test")
+
+scala_library(
+    name = "resource",
+    srcs = ["src/main/scala/com/example/resource/Util.scala"],
+    resources =  ["src/main/resources/com/example/resource/example.sql"],
+    resource_strip_prefix = "{}/{}".format(package_name(), "src/main/resources"),
+    visibility = ["//visibility:public"]
+)

--- a/test/coverage_scalatest_resources/resource/BUILD.bazel
+++ b/test/coverage_scalatest_resources/resource/BUILD.bazel
@@ -1,5 +1,4 @@
-load("@rules_java//java:defs.bzl", "java_library")
-load("//scala:scala.bzl", "scala_library", "scala_test")
+load("//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "resource",

--- a/test/coverage_scalatest_resources/resource/src/main/resources/com/example/resource/example.sql
+++ b/test/coverage_scalatest_resources/resource/src/main/resources/com/example/resource/example.sql
@@ -1,0 +1,1 @@
+Select * from TBL;

--- a/test/coverage_scalatest_resources/resource/src/main/scala/com/example/resource/Util.scala
+++ b/test/coverage_scalatest_resources/resource/src/main/scala/com/example/resource/Util.scala
@@ -1,0 +1,5 @@
+package com.example.resource
+
+object Util {
+  def hello: String = "Hello!"
+}

--- a/test/shell/test_coverage_scalatest_resources.sh
+++ b/test/shell/test_coverage_scalatest_resources.sh
@@ -4,17 +4,17 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
-test_coverage_on() {
+test_coverage_succeeds_resource_call() {
     bazel coverage //test/coverage_scalatest_resources/consumer:tests
     diff test/coverage_scalatest_resources/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 
-test_coverage_includes_test_targets() {
+test_coverage_includes_resource_test_targets() {
     bazel coverage \
           --instrument_test_targets=True \
           //test/coverage_scalatest_resources/consumer:tests
     grep -q "SF:test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 
-$runner test_coverage_on
-$runner test_coverage_includes_test_targets
+$runner test_coverage_succeeds_resource_call
+$runner test_coverage_includes_resource_test_targets

--- a/test/shell/test_coverage_scalatest_resources.sh
+++ b/test/shell/test_coverage_scalatest_resources.sh
@@ -1,0 +1,20 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_coverage_on() {
+    bazel coverage //test/coverage_scalatest_resources/consumer:tests
+    diff test/coverage_scalatest_resources/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
+}
+
+test_coverage_includes_test_targets() {
+    bazel coverage \
+          --instrument_test_targets=True \
+          //test/coverage_scalatest_resources/consumer:tests
+    grep -q "SF:test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
+}
+
+$runner test_coverage_on
+$runner test_coverage_includes_test_targets

--- a/test_coverage.sh
+++ b/test_coverage.sh
@@ -12,3 +12,4 @@ test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
 . "${test_dir}"/test_coverage_specs2_with_junit.sh
 . "${test_dir}"/test_coverage_scalatest.sh
 . "${test_dir}"/test_coverage_equals_in_target.sh
+. "${test_dir}"/test_coverage_scalatest_resources.sh


### PR DESCRIPTION
### Description
Added directories to the `packagename-offline.jar` artifacts that get created by [JaCoCoInstrumenter.java](src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java).

### Motivation
Fixes #1280.  This fix allows calls for `ClassLoader.getResources("path/in/jar")` to succeed.  Any code that tries to fetch resources at a given path will get no results in `bazel coverage`, even if `bazel test` allows the path to be explored properly.
