### PR TITLE
Add Bazel action mnemonic for Thrift archive generation

### DIFF
--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -91,6 +91,7 @@ rm -f {out}
             tools = [ctx.executable._zipper, zipper_arg_path],
             outputs = [ctx.outputs.libarchive],
             command = cmd,
+            mnemonic = "ScalaThriftArchive",
             progress_message = "making thrift archive %s (%s files)" %
                                (ctx.label, len(src_paths)),
         )
@@ -100,6 +101,7 @@ rm -f {out}
         ctx.actions.run_shell(
             tools = [ctx.executable._zipper],
             outputs = [ctx.outputs.libarchive],
+            mnemonic = "ScalaThriftArchive",
             command = """
 echo "empty" > {out}.contents
 rm -f {out}


### PR DESCRIPTION
### Description
Add a [mnemonic](https://docs.bazel.build/versions/main/skylark/lib/Action.html#mnemonic) (i.e., a label) to the action which produces thrift jars. This should have no observable effect on the build.

### Motivation
This would allow us to add this action to the allowlist for remote execution via [--strategy](https://docs.bazel.build/versions/main/command-line-reference.html#flag--strategy)
