### PR TITLE
Touch file like it's 2010

### DIFF
--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -261,8 +261,8 @@ def _build_nosrc_jar(ctx):
 rm -f {jar_output}
 {zipper} c {jar_output} @{path}
 # ensures that empty src targets still emit a statsfile and a diagnosticsfile
-touch {statsfile}
-touch {diagnosticsfile}
+TZ=UTC touch -t 201001010000 {statsfile}
+TZ=UTC touch -t 201001010000 {diagnosticsfile}
 """ + ijar_cmd
 
     cmd = cmd.format(

--- a/test/BUILD
+++ b/test/BUILD
@@ -13,6 +13,7 @@ load(
     "scala_test",
     "scala_test_suite",
 )
+load(":check_2010.bzl", "check_2010")
 load(":check_statsfile.bzl", "check_statsfile")
 
 package(default_testonly = 1)
@@ -235,6 +236,16 @@ scala_library(
         "//test/src/main/resources/scalarules/test:generated-hello",
         "//test/src/main/resources/scalarules/test:more-byes",
         "//test/src/main/resources/scalarules/test:more-hellos",
+    ],
+)
+
+scala_binary(
+    name = "NoSourceBinary",
+    srcs = [],
+    main_class = "scalarules.test.ScalaLibBinary",
+    resources = [
+        "//test/data:foo.txt",
+        "//test/data:more.txt",
     ],
 )
 
@@ -668,6 +679,8 @@ scala_library(
 check_statsfile("ScalaBinary")
 
 check_statsfile("ScalaLibBinary")
+
+check_2010("NoSourceBinary")
 
 #discovering tests from a separate target
 scala_library(

--- a/test/check_2010.bzl
+++ b/test/check_2010.bzl
@@ -1,0 +1,22 @@
+def check_2010(target):
+    statsfile = ":%s.statsfile" % target
+    outfile = "%s.statsfile.good" % target
+
+    cmd = """
+TIMESTAMP=`TZ=UTC date -r {statsfile} "+%Y-%m-%d %H:%M:%S"`
+if [ "$$TIMESTAMP" == "2010-01-01 00:00:00" ]; then
+  touch '{outfile}'
+fi
+"""
+    cmd = cmd.format(
+        statsfile = "$(location %s)" % statsfile,
+        outfile = "$(location %s)" % outfile,
+    )
+
+    native.genrule(
+        name = "%s_statsfile" % target,
+        outs = [outfile],
+        tools = [statsfile],
+        cmd = cmd,
+        visibility = ["//visibility:public"],
+    )


### PR DESCRIPTION
### Description

This calls touch with `TZ=UTC touch -t 201001010000` to set the timestamp to 2010.

### Motivation

I was looking at `-s` log and noticed that there were some log entries
related to touching statsfile and diagnosticsproto. Maybe I'm being paranoid about this, but I feel like this could be contributing to cache misses.

To prevent unnecessary cache invalidation, I think we should touch using
2010 timestamp.