### PR TITLE
Add directory scanning support to JUnit test discovery

### DIFF
--- a/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
@@ -24,7 +24,7 @@ object ArchiveEntries {
 
   private def jarEntries(jarInputStream: JarInputStream): Stream[String] =
     Stream.continually(getJarEntryOrCloseStream(jarInputStream))
-      .takeWhile(_.isDefined)
+      .takeWhile(_.isEmpty)
       .flatten
       .map(_.getName)
 

--- a/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
@@ -6,7 +6,7 @@ import java.util.jar.{JarEntry, JarInputStream}
 object ArchiveEntries {
   def listClassFiles(file: File): Stream[String] = {
     val allEntries = if (file.isDirectory)
-      directoryEntries(file).map(_.stripPrefix(file.toString).stripPrefix("/"))
+      directoryEntries(file).map(_.stripPrefix(file.getPath).stripPrefix("/"))
     else
       jarEntries(new JarInputStream(new FileInputStream(file)))
 

--- a/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
@@ -1,0 +1,36 @@
+package io.bazel.rulesscala.test_discovery
+
+import java.io.{File, FileInputStream}
+import java.util.jar.{JarEntry, JarInputStream}
+
+object ArchiveEntries {
+  def listClassFiles(file: File): Stream[String] = {
+    val allEntries = if (file.isDirectory)
+      directoryEntries(file).map(_.stripPrefix(file.toString).stripPrefix("/"))
+    else
+      jarEntries(new JarInputStream(new FileInputStream(file)))
+
+    allEntries.filter(_.endsWith(".class"))
+  }
+
+  private def getJarEntryOrCloseStream(jarInputStream: JarInputStream): Option[JarEntry] = {
+    val entry = Option(jarInputStream.getNextJarEntry)
+
+    if (entry.isEmpty)
+      jarInputStream.close()
+
+    entry
+  }
+
+  private def jarEntries(jarInputStream: JarInputStream): Stream[String] =
+    Stream.continually(getJarEntryOrCloseStream(jarInputStream))
+      .takeWhile(_.isDefined)
+      .flatten
+      .map(_.getName)
+
+  private def directoryEntries(file: File): Stream[String] =
+    file.toString #:: (file.listFiles match {
+      case null => Stream.empty
+      case files => files.toStream.flatMap(directoryEntries)
+    })
+}

--- a/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
@@ -6,7 +6,7 @@ import java.util.jar.{JarEntry, JarInputStream}
 object ArchiveEntries {
   def listClassFiles(file: File): Stream[String] = {
     val allEntries = if (file.isDirectory)
-      directoryEntries(file).map(_.stripPrefix(file.getPath).stripPrefix("/"))
+      directoryEntries(file).map(_.stripPrefix(file.toString).stripPrefix("/"))
     else
       jarEntries(new JarInputStream(new FileInputStream(file)))
 
@@ -24,7 +24,7 @@ object ArchiveEntries {
 
   private def jarEntries(jarInputStream: JarInputStream): Stream[String] =
     Stream.continually(getJarEntryOrCloseStream(jarInputStream))
-      .takeWhile(_.isEmpty)
+      .takeWhile(_.nonEmpty)
       .flatten
       .map(_.getName)
 

--- a/src/java/io/bazel/rulesscala/test_discovery/BUILD
+++ b/src/java/io/bazel/rulesscala/test_discovery/BUILD
@@ -3,6 +3,7 @@ load("//scala:scala.bzl", "scala_library")
 scala_library(
     name = "test_discovery",
     srcs = [
+        "ArchiveEntries.scala",
         "DiscoveredTestSuite.scala",
         "FilteredRunnerBuilder.scala",
     ],

--- a/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
@@ -1,0 +1,25 @@
+package io.bazel.rulesscala.test_discovery
+
+import io.bazel.rulesscala.test_discovery.ArchiveEntries.listClassFiles
+import org.specs2.mutable.SpecWithJUnit
+
+import java.io.File
+import java.nio.file.{Files, Paths}
+
+class ArchiveEntriesTest extends SpecWithJUnit {
+  "List only class files from a directory" in {
+    val dir = Files.createTempDirectory("temp")
+    Files.createFile(Paths.get(dir.toString, "SomeFile"))
+    Files.createFile(Paths.get(dir.toString, "Another.class"))
+
+    listClassFiles(dir.toFile) must containTheSameElementsAs(Seq("Another.class"))
+  }
+
+  "List only class files from a jar file" in {
+    val archives = System.getProperty("bazel.discover.classes.archives.file.paths").split(",")
+    val thisTestJar = archives.head
+
+    val expectedClassFile = "io/bazel/rulesscala/test_discovery/ArchiveEntriesTest.class"
+    listClassFiles(new File(thisTestJar)) must containTheSameElementsAs(Seq(expectedClassFile))
+  }
+}

--- a/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
@@ -9,8 +9,8 @@ import java.nio.file.{Files, Paths}
 class ArchiveEntriesTest extends SpecWithJUnit {
   "List only class files from a directory" in {
     val dir = Files.createTempDirectory("temp")
-    Files.createFile(Paths.get(dir.toString, "SomeFile"))
-    Files.createFile(Paths.get(dir.toString, "Another.class"))
+    Files.createFile(dir.resolve("SomeFile"))
+    Files.createFile(dir.resolve( "Another.class"))
 
     listClassFiles(dir.toFile) must containTheSameElementsAs(Seq("Another.class"))
   }

--- a/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
@@ -4,13 +4,13 @@ import io.bazel.rulesscala.test_discovery.ArchiveEntries.listClassFiles
 import org.specs2.mutable.SpecWithJUnit
 
 import java.io.File
-import java.nio.file.{Files, Paths}
+import java.nio.file.Files
 
 class ArchiveEntriesTest extends SpecWithJUnit {
   "List only class files from a directory" in {
     val dir = Files.createTempDirectory("temp")
     Files.createFile(dir.resolve("SomeFile"))
-    Files.createFile(dir.resolve( "Another.class"))
+    Files.createFile(dir.resolve("Another.class"))
 
     listClassFiles(dir.toFile) must containTheSameElementsAs(Seq("Another.class"))
   }

--- a/test/src/main/scala/scalarules/test/junit/test_discovery/BUILD
+++ b/test/src/main/scala/scalarules/test/junit/test_discovery/BUILD
@@ -1,0 +1,10 @@
+load("//scala:scala.bzl", "scala_specs2_junit_test")
+
+scala_specs2_junit_test(
+    name = "ArchiveEntriesTest",
+    srcs = ["ArchiveEntriesTest.scala"],
+    suffixes = ["Test"],
+    deps = [
+        "//src/java/io/bazel/rulesscala/test_discovery",
+    ],
+)


### PR DESCRIPTION
I'm trying to make Intellij's [Fast Build](https://ij.bazel.build/docs/fast-builds.html) work with Specs2 tests, but currently JUnit test discovery only knows how to scan jars and fails id directories are passed. For fast build to work we need to prepend directories to the classpath. 
This PR adds support for listing class files from directories.