### PR TITLE
implement multiplexer for scalac

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -125,7 +125,7 @@ def compile_scala(
         executable = scalac,
         mnemonic = "Scalac",
         progress_message = "scala %s" % target_label,
-        execution_requirements = {"supports-workers": "1"},
+        execution_requirements = {"supports-workers": "1", "supports-multiplex-workers": "1"},
         #  when we run with a worker, the `@argfile.path` is removed and passed
         #  line by line as arguments in the protobuf. In that case,
         #  the rest of the arguments are passed to the process that

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -119,13 +119,18 @@ def compile_scala(
     # scalac_jvm_flags passed in on the target override scalac_jvm_flags passed in on the toolchain
     final_scalac_jvm_flags = first_non_empty(scalac_jvm_flags, toolchain.scalac_jvm_flags)
 
+    if toolchain.multiplex_worker:
+        execution_requirements = {"supports-workers": "1", "supports-multiplex-workers": "1"}
+    else:
+        execution_requirements = {"supports-workers": "1"}
+
     ctx.actions.run(
         inputs = ins,
         outputs = outs,
         executable = scalac,
         mnemonic = "Scalac",
         progress_message = "scala %s" % target_label,
-        execution_requirements = {"supports-workers": "1", "supports-multiplex-workers": "1"},
+        execution_requirements = execution_requirements,
         #  when we run with a worker, the `@argfile.path` is removed and passed
         #  line by line as arguments in the protobuf. In that case,
         #  the rest of the arguments are passed to the process that

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -68,6 +68,8 @@ def _scala_toolchain_impl(ctx):
     all_unused_deps_patterns = ctx.attr.dependency_tracking_unused_deps_patterns
     unused_deps_includes, unused_deps_excludes = _partition_patterns(all_unused_deps_patterns)
 
+    multiplex_worker = ctx.attr.multiplex_worker
+
     toolchain = platform_common.ToolchainInfo(
         scalacopts = ctx.attr.scalacopts,
         dep_providers = ctx.attr.dep_providers,
@@ -84,6 +86,7 @@ def _scala_toolchain_impl(ctx):
         enable_diagnostics_report = enable_diagnostics_report,
         jacocorunner = ctx.attr.jacocorunner,
         enable_stats_file = enable_stats_file,
+        multiplex_worker = multiplex_worker,
     )
     return [toolchain]
 
@@ -136,6 +139,10 @@ scala_toolchain = rule(
         "enable_stats_file": attr.bool(
             default = True,
             doc = "Enable writing of statsfile",
+        ),
+        "multiplex_worker": attr.bool(
+            default = False,
+            doc = "Enable multiplex worker",
         ),
     },
     fragments = ["java"],

--- a/src/java/io/bazel/rulesscala/scalac/211/StreamReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/211/StreamReporter.java
@@ -1,0 +1,23 @@
+package io.bazel.rulesscala.scalac;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import scala.tools.nsc.Settings;
+import scala.tools.nsc.reporters.ConsoleReporter;
+
+class StreamReporter extends ConsoleReporter {
+  public StreamReporter(Settings settings, PrintStream out, PrintStream err) {
+    super(
+        settings,
+        new BufferedReader(new InputStreamReader(new ByteArrayInputStream(new byte[0]))),
+        new PrintWriter(out));
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+  }
+}

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -22,11 +22,14 @@ java_binary(
     ],
 )
 
+REPORTER_COMPATIBILITY = "211/" if SCALA_MAJOR_VERSION == "2.11" else ""
+
 filegroup(
     name = "scalac_files",
     srcs = ["CompileOptions.java"] + ([
         "ScalacWorker.java",
         "ProtoReporter.java",
+        "%sStreamReporter.java" % REPORTER_COMPATIBILITY,
         "ReportableMainClass.java",
     ] if SCALA_MAJOR_VERSION.startswith("2") else ["ScalacWorker3.java"]),
     visibility = ["//visibility:public"],

--- a/src/java/io/bazel/rulesscala/scalac/ProtoReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/ProtoReporter.java
@@ -2,6 +2,7 @@ package io.bazel.rulesscala.scalac;
 
 import io.bazel.rules_scala.diagnostics.Diagnostics;
 import java.io.IOException;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardOpenOption;
@@ -9,14 +10,14 @@ import java.util.*;
 import scala.reflect.internal.util.Position;
 import scala.reflect.internal.util.RangePosition;
 import scala.tools.nsc.Settings;
-import scala.tools.nsc.reporters.ConsoleReporter;
 
-public class ProtoReporter extends ConsoleReporter {
+public class ProtoReporter extends StreamReporter {
 
   private final Map<String, List<Diagnostics.Diagnostic>> builder;
 
-  public ProtoReporter(Settings settings) {
-    super(settings);
+  public ProtoReporter(Settings settings, PrintStream out, PrintStream err) {
+    super(settings, out, err);
+
     builder = new LinkedHashMap<>();
   }
 

--- a/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
+++ b/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
@@ -1,9 +1,7 @@
 package io.bazel.rulesscala.scalac;
 
-import java.io.BufferedReader;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.PrintStream;
 import java.nio.file.Files;
@@ -32,8 +30,6 @@ public class ReportableMainClass extends MainClass {
     if (!ops.enableDiagnosticsReport) {
       createDiagnosticsFile();
       Settings settings = super.settings();
-      InputStream inputStream = new ByteArrayInputStream(new byte[0]);
-      BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
       reporter = new StreamReporter(settings, out, err);
       Global global = new Global(settings, reporter);
 

--- a/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
+++ b/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
@@ -1,6 +1,11 @@
 package io.bazel.rulesscala.scalac;
 
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -13,17 +18,25 @@ public class ReportableMainClass extends MainClass {
   private Global compiler;
   private Reporter reporter;
   private final CompileOptions ops;
+  private PrintStream out;
+  private PrintStream err;
 
-  public ReportableMainClass(CompileOptions ops) {
+  public ReportableMainClass(CompileOptions ops, PrintStream out, PrintStream err) {
     this.ops = ops;
+    this.out = out;
+    this.err = err;
   }
 
   @Override
   public Global newCompiler() {
     if (!ops.enableDiagnosticsReport) {
       createDiagnosticsFile();
-      Global global = super.newCompiler();
-      reporter = global.reporter();
+      Settings settings = super.settings();
+      InputStream inputStream = new ByteArrayInputStream(new byte[0]);
+      BufferedReader br = new BufferedReader(new InputStreamReader(inputStream));
+      reporter = new StreamReporter(settings, out, err);
+      Global global = new Global(settings, reporter);
+
       return global;
     }
 
@@ -31,7 +44,7 @@ public class ReportableMainClass extends MainClass {
       createDiagnosticsFile();
 
       Settings settings = super.settings();
-      reporter = new ProtoReporter(settings);
+      reporter = new ProtoReporter(settings, out, err);
 
       compiler = new Global(settings, reporter);
     }

--- a/src/java/io/bazel/rulesscala/scalac/StreamReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/StreamReporter.java
@@ -1,0 +1,24 @@
+package io.bazel.rulesscala.scalac;
+
+import java.io.BufferedReader;
+import java.io.ByteArrayInputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import scala.tools.nsc.Settings;
+import scala.tools.nsc.reporters.ConsoleReporter;
+
+class StreamReporter extends ConsoleReporter {
+  public StreamReporter(Settings settings, PrintStream out, PrintStream err) {
+    super(
+        settings,
+        new BufferedReader(new InputStreamReader(new ByteArrayInputStream(new byte[0]))),
+        new PrintWriter(out),
+        new PrintWriter(err));
+  }
+
+  @Override
+  public void reset() {
+    super.reset();
+  }
+}

--- a/src/java/io/bazel/rulesscala/worker/BUILD
+++ b/src/java/io/bazel/rulesscala/worker/BUILD
@@ -2,7 +2,12 @@ load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
 java_library(
     name = "worker",
-    srcs = ["Worker.java"],
+    srcs = [
+        "ExitTrapped.java",
+        "MultiplexWorker.java",
+        "PermissionSecurityManager.java",
+        "Worker.java",
+    ],
     visibility = ["//visibility:public"],
     deps = [
         "//third_party/bazel/src/main/protobuf:worker_protocol_java_proto",

--- a/src/java/io/bazel/rulesscala/worker/ExitTrapped.java
+++ b/src/java/io/bazel/rulesscala/worker/ExitTrapped.java
@@ -1,0 +1,10 @@
+package io.bazel.rulesscala.worker;
+
+class ExitTrapped extends RuntimeException {
+  final int code;
+
+  ExitTrapped(int code) {
+    super();
+    this.code = code;
+  }
+}

--- a/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
+++ b/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
@@ -130,6 +130,11 @@ public final class MultiplexWorker {
   }
 
   private static String[] stringListToArray(List<String> argList) {
-    return argList.toArray(String[]::new);
+    int numArgs = argList.size();
+    String[] args = new String[numArgs];
+    for (int i = 0; i < numArgs; i++) {
+      args[i] = argList.get(i);
+    }
+    return args;
   }
 }

--- a/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
+++ b/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
@@ -130,11 +130,6 @@ public final class MultiplexWorker {
   }
 
   private static String[] stringListToArray(List<String> argList) {
-    int numArgs = argList.size();
-    String[] args = new String[numArgs];
-    for (int i = 0; i < numArgs; i++) {
-      args[i] = argList.get(i);
-    }
-    return args;
+    return argList.toArray(String[]::new);
   }
 }

--- a/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
+++ b/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
@@ -1,0 +1,140 @@
+package io.bazel.rulesscala.worker;
+
+import com.google.devtools.build.lib.worker.WorkerProtocol;
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.PrintStream;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+/**
+ * Multiplex JVM worker.
+ *
+ * <p>This supports regular workers as well as persisent workers.
+ *
+ * <p>Worker implementations should implement the `MultiplexWorker.Interface` interface and provide
+ * a main method that calls `MultiplexWorker.workerMain`.
+ */
+public final class MultiplexWorker {
+
+  private static ExecutorService executorService = Executors.newCachedThreadPool();
+
+  public static interface Interface {
+    public void work(String[] args, PrintStream out) throws Exception;
+  }
+
+  /**
+   * The entry point for multiplex workers.
+   *
+   * <p>This should be the only thing called by a main method in a worker process.
+   */
+  public static void workerMain(String workerArgs[], Interface workerInterface) throws Exception {
+    if (workerArgs.length > 0 && workerArgs[0].equals("--persistent_worker")) {
+      persistentWorkerMain(workerInterface);
+    } else {
+      Worker.ephemeralWorkerMain(
+          workerArgs,
+          new Worker.Interface() {
+            @Override
+            public void work(String[] args) throws Exception {
+              workerInterface.work(args, System.out);
+            }
+          });
+    }
+  }
+
+  /** The main loop for persistent worker processes */
+  private static void persistentWorkerMain(Interface workerInterface) {
+    System.setSecurityManager(new PermissionSecurityManager());
+
+    InputStream stdin = System.in;
+
+    // We can't support stdin, so assign it to read from an empty buffer
+    System.setIn(new ByteArrayInputStream(new byte[0]));
+
+    try {
+      while (true) {
+        try {
+          WorkerProtocol.WorkRequest request = WorkerProtocol.WorkRequest.parseDelimitedFrom(stdin);
+
+          // The request will be null if stdin is closed.  We're
+          // not sure if this happens in TheRealWorld™ but it is
+          // useful for testing (to shut down a persistent
+          // worker process).
+          if (request == null) {
+            break;
+          }
+
+          if (request.getRequestId() == 0) {
+            processWorkRequest(workerInterface, request);
+          } else {
+            executorService.submit(
+                () -> {
+                  processWorkRequest(workerInterface, request);
+                });
+          }
+
+        } catch (IOException e) {
+          // for now we swallow IOExceptions when
+          // reading proto
+        }
+      }
+    } finally {
+      System.setIn(stdin);
+    }
+  }
+
+  private static Object lock = new Object();
+
+  private static void processWorkRequest(
+      Interface workerInterface, WorkerProtocol.WorkRequest request) {
+    int code = 0;
+    ByteArrayOutputStream outStream = new ByteArrayOutputStream();
+    PrintStream out = new PrintStream(outStream);
+
+    try {
+      workerInterface.work(stringListToArray(request.getArgumentsList()), out);
+    } catch (ExitTrapped e) {
+      code = e.code;
+    } catch (Exception e) {
+      out.println(e.getMessage());
+      e.printStackTrace(out);
+      code = 1;
+    }
+
+    try {
+      out.flush();
+      WorkerProtocol.WorkResponse response =
+          WorkerProtocol.WorkResponse.newBuilder()
+              .setExitCode(code)
+              .setOutput(outStream.toString())
+              .setRequestId(request.getRequestId())
+              .build();
+
+      synchronized (lock) {
+        response.writeDelimitedTo(System.out);
+      }
+    } catch (IOException exception) {
+      // for now we swallow IOExceptions when
+      // writing proto
+    } finally {
+      try {
+        outStream.close();
+      } catch (IOException exception) {
+      }
+      System.gc();
+    }
+  }
+
+  private static String[] stringListToArray(List<String> argList) {
+    int numArgs = argList.size();
+    String[] args = new String[numArgs];
+    for (int i = 0; i < numArgs; i++) {
+      args[i] = argList.get(i);
+    }
+    return args;
+  }
+}

--- a/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
+++ b/src/java/io/bazel/rulesscala/worker/MultiplexWorker.java
@@ -131,10 +131,6 @@ public final class MultiplexWorker {
 
   private static String[] stringListToArray(List<String> argList) {
     int numArgs = argList.size();
-    String[] args = new String[numArgs];
-    for (int i = 0; i < numArgs; i++) {
-      args[i] = argList.get(i);
-    }
-    return args;
+    return argList.toArray(new String[numArgs]);
   }
 }

--- a/src/java/io/bazel/rulesscala/worker/PermissionSecurityManager.java
+++ b/src/java/io/bazel/rulesscala/worker/PermissionSecurityManager.java
@@ -1,0 +1,15 @@
+package io.bazel.rulesscala.worker;
+
+import java.security.Permission;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+class PermissionSecurityManager extends SecurityManager {
+  @Override
+  public void checkPermission(Permission permission) {
+    Matcher matcher = exitPattern.matcher(permission.getName());
+    if (matcher.find()) throw new ExitTrapped(Integer.parseInt(matcher.group(1)));
+  }
+
+  private static Pattern exitPattern = Pattern.compile("exitVM\\.(-?\\d+)");
+}

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -158,11 +158,6 @@ public final class Worker {
   }
 
   private static String[] stringListToArray(List<String> argList) {
-    int numArgs = argList.size();
-    String[] args = new String[numArgs];
-    for (int i = 0; i < numArgs; i++) {
-      args[i] = argList.get(i);
-    }
-    return args;
+    return argList.toArray(String[]::new);
   }
 }

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -158,6 +158,11 @@ public final class Worker {
   }
 
   private static String[] stringListToArray(List<String> argList) {
-    return argList.toArray(String[]::new);
+    int numArgs = argList.size();
+    String[] args = new String[numArgs];
+    for (int i = 0; i < numArgs; i++) {
+      args[i] = argList.get(i);
+    }
+    return args;
   }
 }

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -159,10 +159,6 @@ public final class Worker {
 
   private static String[] stringListToArray(List<String> argList) {
     int numArgs = argList.size();
-    String[] args = new String[numArgs];
-    for (int i = 0; i < numArgs; i++) {
-      args[i] = argList.get(i);
-    }
-    return args;
+    return argList.toArray(new String[numArgs]);
   }
 }

--- a/src/java/io/bazel/rulesscala/worker/WorkerTest.java
+++ b/src/java/io/bazel/rulesscala/worker/WorkerTest.java
@@ -37,8 +37,7 @@ public class WorkerTest {
         };
 
     int code =
-        assertThrows(Worker.ExitTrapped.class, () -> Worker.workerMain(new String[] {}, worker))
-            .code;
+        assertThrows(ExitTrapped.class, () -> Worker.workerMain(new String[] {}, worker)).code;
 
     assert (code == 99);
   }


### PR DESCRIPTION
### Description
Add multiplexer support for the scalac worker.

This creates a thread pool inside of the scalac worker and uses threads in order to use a singular process.

### Motivation
Potential speed improvement and memory usage improvement because we use a single JVM process which warms up faster. 

### Implementation
The current implementation passes dedicated output streams to each worker which collect the output and then returns it to bazel. 