### PR TITLE
Remove uses of host_javabase in java_common calls.

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -92,10 +92,6 @@ implicit_deps = {
     "_java_toolchain": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
     ),
-    "_host_javabase": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
-        cfg = "exec",
-    ),
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
     ),

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -3,7 +3,7 @@
 #
 # DOCUMENT THIS
 #
-load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_runtime_toolchain", "find_java_toolchain")
+load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
 load(
     "@io_bazel_rules_scala//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
@@ -309,7 +309,6 @@ def _pack_source_jar(ctx, scala_srcs, in_srcjars):
         sources = scala_srcs,
         source_jars = in_srcjars,
         java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
-        host_javabase = find_java_runtime_toolchain(ctx, ctx.attr._host_javabase),
     )
 
 def _try_to_compile_java_jar(

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -14,7 +14,7 @@
 """Rules for supporting the Scala language."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_runtime_toolchain", "find_java_toolchain")
+load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
 load(":common.bzl", _collect_plugin_paths = "collect_plugin_paths")
 load(":resources.bzl", _resource_paths = "paths")
 
@@ -158,7 +158,6 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
         exports = [],
         neverlink = getattr(ctx.attr, "neverlink", False),
         java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
-        host_javabase = find_java_runtime_toolchain(ctx, ctx.attr._host_javabase),
         strict_deps = ctx.fragments.java.strict_java_deps,
     )
 

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -5,7 +5,6 @@ load("//scala/private:rule_impls.bzl", "compile_scala")
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(
     "@bazel_tools//tools/jdk:toolchain_utils.bzl",
-    "find_java_runtime_toolchain",
     "find_java_toolchain",
 )
 load(
@@ -53,7 +52,6 @@ def _pack_sources(ctx, src_jars):
         source_jars = src_jars,
         output_source_jar = ctx.actions.declare_file(ctx.label.name + "_scalapb-src.jar"),
         java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
-        host_javabase = find_java_runtime_toolchain(ctx, ctx.attr._host_javabase),
     )
 
 def _generate_sources(ctx, toolchain, proto):
@@ -196,10 +194,6 @@ def make_scala_proto_aspect(*extras):
     attrs = {
         "_java_toolchain": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
-        ),
-        "_host_javabase": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
-            cfg = "exec",
         ),
     }
     return aspect(

--- a/test/shell/test_twitter_scrooge.sh
+++ b/test/shell/test_twitter_scrooge.sh
@@ -5,11 +5,17 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 scrooge_compile_with_jdk_11() {
+    # javabase and java_toolchain parameters are deprecated and may be
+    # removed in Bazel >= 5.0.0
     bazel build --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
         --host_javabase=@bazel_tools//tools/jdk:remote_jdk11 \
         --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
         --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
         --javacopt='--release 11' \
+        --java_language_version=11 \
+        --tool_java_language_version=11 \
+        --java_runtime_version=remotejdk_11 \
+        --tool_java_runtime_version=remotejdk_11 \
         test/src/main/scala/scalarules/test/twitter_scrooge/...
 }
 

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -462,10 +462,6 @@ scrooge_java_aspect = aspect(
         common_attrs,
         {
             "_java_toolchain": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),
-            "_host_javabase": attr.label(
-                default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
-                cfg = "exec",
-            ),
         },
     ),
     required_aspect_providers = common_aspect_providers,


### PR DESCRIPTION
### Description
Removes passing of host_javabase to java_common.compile and java_common.pack_source calls. The value is not needed since Bazel 4.x.x and the parameter is removed and reported as error in Bazel 5.x.x

The actual value is obtained from java_toolchain parameter.

### Motivation

To support Bazel 5.x.x (with backwards compatibility kept to Bazel 4.x.x)
