### PR TITLE
Remove uses of `incompatible_use_toolchain_transition` now that it is…

### DIFF
--- a/docs/toolchain_development.md
+++ b/docs/toolchain_development.md
@@ -99,7 +99,7 @@ my_toolchain_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//my_rules/toolchain:my_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+
 )
 ```
 
@@ -160,6 +160,6 @@ my_toolchain_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//my_rules/toolchain:my_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
+
 )
 ```

--- a/jmh/toolchain/toolchain.bzl
+++ b/jmh/toolchain/toolchain.bzl
@@ -33,5 +33,4 @@ export_toolchain_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//jmh/toolchain:jmh_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )

--- a/scala/plusone.bzl
+++ b/scala/plusone.bzl
@@ -24,5 +24,4 @@ collect_plus_one_deps_aspect = aspect(
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
 )

--- a/scala/private/coverage_replacements_provider.bzl
+++ b/scala/private/coverage_replacements_provider.bzl
@@ -68,7 +68,6 @@ _aspect = aspect(
     attr_aspects = _dependency_attributes,
     implementation = _aspect_impl,
     toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )
 
 coverage_replacements_provider = struct(

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -76,7 +76,6 @@ def make_scala_binary(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_binary_impl,
     )
 

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -125,7 +125,6 @@ def make_scala_junit_test(*extras):
         ),
         test = True,
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_junit_test_impl,
     )
 

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -96,7 +96,6 @@ def make_scala_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_library_impl,
     )
 
@@ -181,7 +180,6 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_library_for_plugin_bootstrapping_impl,
     )
 
@@ -248,7 +246,6 @@ def make_scala_macro_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_macro_library_impl,
     )
 

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -75,7 +75,6 @@ def make_scala_repl(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_repl_impl,
     )
 

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -114,7 +114,6 @@ def make_scala_test(*extras):
         ),
         test = True,
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
-        incompatible_use_toolchain_transition = True,
         implementation = _scala_test_impl,
     )
 

--- a/scala/private/toolchain_deps/toolchain_dep_rules.bzl
+++ b/scala/private/toolchain_deps/toolchain_dep_rules.bzl
@@ -14,5 +14,4 @@ common_toolchain_deps = rule(
         "deps_id": attr.string(mandatory = True),
     },
     toolchains = [_toolchain_type],
-    incompatible_use_toolchain_transition = True,
 )

--- a/scala/scalafmt/toolchain/toolchain.bzl
+++ b/scala/scalafmt/toolchain/toolchain.bzl
@@ -33,5 +33,4 @@ export_scalafmt_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//scala/scalafmt/toolchain:scalafmt_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -199,7 +199,6 @@ def make_scala_proto_aspect(*extras):
     return aspect(
         implementation = _scala_proto_aspect_impl,
         attr_aspects = ["deps"],
-        incompatible_use_toolchain_transition = True,
         attrs = dicts.add(
             attrs,
             extras_phases(extras),

--- a/scala_proto/private/toolchain_deps.bzl
+++ b/scala_proto/private/toolchain_deps.bzl
@@ -13,6 +13,5 @@ export_scalapb_toolchain_deps = rule(
             mandatory = True,
         ),
     },
-    incompatible_use_toolchain_transition = True,
     toolchains = ["@io_bazel_rules_scala//scala_proto:deps_toolchain_type"],
 )

--- a/testing/toolchain/toolchain_deps.bzl
+++ b/testing/toolchain/toolchain_deps.bzl
@@ -14,5 +14,4 @@ testing_toolchain_deps = rule(
         "deps_id": attr.string(mandatory = True),
     },
     toolchains = [_toolchain_type],
-    incompatible_use_toolchain_transition = True,
 )

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -39,5 +39,4 @@ export_scrooge_deps = rule(
         ),
     },
     toolchains = ["@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -452,7 +452,6 @@ scrooge_scala_aspect = aspect(
         "@io_bazel_rules_scala//scala:toolchain_type",
         "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
 )
 
 scrooge_java_aspect = aspect(
@@ -469,7 +468,6 @@ scrooge_java_aspect = aspect(
         "@io_bazel_rules_scala//scala:toolchain_type",
         "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
     ],
-    incompatible_use_toolchain_transition = True,
     fragments = ["java"],
 )
 
@@ -546,5 +544,4 @@ scrooge_scala_import = rule(
     },
     provides = [ThriftInfo, JavaInfo, ScroogeImport],
     toolchains = ["@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type"],
-    incompatible_use_toolchain_transition = True,
 )


### PR DESCRIPTION
… enabled by

default in Bazel 5.0.

This is a step towards removing it entirely.

Part of https://github.com/bazelbuild/bazel/issues/14127.
