### PR TITLE
Do not prefix workspace name on absolute java path in the Windows launcher

### DIFF
--- a/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
+++ b/src/java/io/bazel/rulesscala/exe/LauncherFileWriter.java
@@ -30,7 +30,7 @@ public class LauncherFileWriter {
             .addKeyValuePair("binary_type", "Java")
             .addKeyValuePair("workspace_name", workspaceName)
             .addKeyValuePair("symlink_runfiles_enabled", "0")
-            .addKeyValuePair("java_bin_path", workspaceName + "/" + javaBinPath)
+            .addKeyValuePair("java_bin_path", fullJavaBinPath(workspaceName, Paths.get(javaBinPath)).toString())
             .addKeyValuePair("jar_bin_path", jarBinPath)
             .addKeyValuePair("java_start_class", javaStartClass)
             .addKeyValuePair("classpath", classpath)
@@ -52,6 +52,17 @@ public class LauncherFileWriter {
       out.write(buffer.array());
 
       out.flush();
+    }
+  }
+
+  private static Path fullJavaBinPath(String workspaceName, Path javaBinPath) {
+    if (javaBinPath.isAbsolute()) {
+      return javaBinPath;
+    } else if (javaBinPath.startsWith(Paths.get("external"))) {
+      // Paths under `external/` already have a workspace name.
+      return javaBinPath;
+    } else {
+      return Paths.get(workspaceName).resolve(javaBinPath);
     }
   }
 }


### PR DESCRIPTION


### Description
Do not prefix the workspace name to an absolute `javaBinPath` (or a `javaBinPath` under `external/`) in the Windows launcher.

Adding the prefix in these cases would lead to an invalid path.
<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation

This is to avoid errors of the following form when configuring a `--javabase` with an absolute `java_home` path on Windows.
```
LAUNCHER ERROR: Rlocation failed on my_workspace/C:/myjdk/bin/java.exe, path doesn't exist in MANIFEST file
```
The relevant parts in Bazel's Java launcher are [here](https://github.com/bazelbuild/bazel/blob/c4975efdd7ede7b46637bf353209d9ac371181a5/src/tools/launcher/java_launcher.cc#L304-L305) and [here](https://github.com/bazelbuild/bazel/blob/c4975efdd7ede7b46637bf353209d9ac371181a5/src/tools/launcher/launcher.cc#L149-L160).