### PR TITLE
Use stable file paths in scalac actions

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -112,7 +112,9 @@ class ScalacWorker implements Worker.Interface {
 
     for (String jarPath : opts.sourceJars) {
       if (jarPath.length() > 0) {
-        String sourceJarFileName = Paths.get(jarPath).toFile().getName();
+        // Use full path as dest directory to handle duplicate file names
+        // TODO: might cause extremely long directory names, maybe replace with hash
+        String sourceJarFileName = jarPath.replace('/', '_');
         Path sourceJarDestination = Files.createDirectories(sources.resolve(sourceJarFileName));
         sourceFiles.addAll(extractJar(jarPath, sourceJarDestination.toString(), sourceExtensions));
       }

--- a/test/scalac/srcjars/BUILD.bazel
+++ b/test/scalac/srcjars/BUILD.bazel
@@ -1,0 +1,23 @@
+load("//scala:scala.bzl", "scala_library", "scala_test")
+load("//test/scalac/srcjars:setup.bzl", "single_scala_file_srcjar")
+
+single_scala_file_srcjar(content = "package test {class A}")
+
+# Check case when two srcjars with identical file names
+# but different content are handled properly
+# shouldn't be common case but plausible with generated code
+scala_library(
+    name = "duplicates",
+    testonly = True,
+    srcs = [
+        "//test/scalac/srcjars:single_srcjar",
+        "//test/scalac/srcjars/duplicate:single_srcjar",
+    ],
+    expect_java_output = False,
+)
+
+scala_test(
+    name = "duplicates_test",
+    srcs = ["DuplicatesTest.scala"],
+    deps = [":duplicates"],
+)

--- a/test/scalac/srcjars/DuplicatesTest.scala
+++ b/test/scalac/srcjars/DuplicatesTest.scala
@@ -1,0 +1,12 @@
+package scalarules.test.scalac.srcjars
+
+import org.scalatest.funsuite.AnyFunSuite
+import org.scalatest.matchers.must.Matchers._
+import test.{A, ADuplicate}
+
+class DuplicatesTest extends AnyFunSuite {
+  test("all classes from duplicated files are available") {
+    noException should be thrownBy classOf[A]
+    noException should be thrownBy classOf[ADuplicate]
+  }
+}

--- a/test/scalac/srcjars/duplicate/BUILD.bazel
+++ b/test/scalac/srcjars/duplicate/BUILD.bazel
@@ -1,0 +1,3 @@
+load("//test/scalac/srcjars:setup.bzl", "single_scala_file_srcjar")
+
+single_scala_file_srcjar(content = "package test {class ADuplicate}")

--- a/test/scalac/srcjars/setup.bzl
+++ b/test/scalac/srcjars/setup.bzl
@@ -1,0 +1,18 @@
+def single_scala_file_srcjar(content):
+    native.genrule(
+        name = "single_scala",
+        testonly = True,
+        cmd = "echo '%s' > $@" % content,
+        outs = ["single.scala"],
+        visibility = ["//test/scalac/srcjars:__pkg__"],
+    )
+
+    native.genrule(
+        name = "single_srcjar",
+        testonly = True,
+        srcs = [":single_scala"],
+        outs = ["single.srcjar"],
+        cmd = "$(location @bazel_tools//tools/zip:zipper) cf $@ $<",
+        tools = ["@bazel_tools//tools/zip:zipper"],
+        visibility = ["//test/scalac/srcjars:__pkg__"],
+    )


### PR DESCRIPTION
### Description

This PR follows similar pattern for temp files as java_library does when it compiles sources.
For each target create a working directory _target-bazel-out_/_scalac/_target-name_ containing:
* classes - this is where compiled scala code and resources goes before packaging into jar
* sources - this is where srcjars are extracted and each one has it's own directory named as srcjar file
            eg. _target-bazel-out_/_scalac/_target-name_/sources/_srcjar-file-name_

Working directory is deleted if it exists and new one is created.

### Motivation

Solves https://github.com/bazelbuild/rules_scala/issues/1311

Thought we don't know when and why scalac embeds source file paths into class files.

Also fixes minor annoyance when tmp folders keep accumulating when srcjars are used.
This is not a big issue but sometimes makes debugging harder.
