### PR TITLE
Fix scala toolchains link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project defines core build rules for [Scala](https://www.scala-lang.org/) t
 * [scala_test_suite](docs/scala_test_suite.md)
 * [thrift_library](docs/thrift_library.md)
 * [scala_proto_library](docs/scala_proto_library.md)
-* [scala_](docs/scala_toolchain.md)
+* [scala_toolchain](docs/scala_toolchain.md)
 * [scala_import](docs/scala_import.md)
 * [scala_doc](docs/scala_doc.md)
 
@@ -78,8 +78,7 @@ scalatest_toolchain()
 ```
 
 This will load the `rules_scala` repository at the commit sha
-`rules_scala_version` into your Bazel project and register a [Scala
-toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.14)
+`rules_scala_version` into your Bazel project and register a [scala_toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.14)
 
 Then in your BUILD file just add the following so the rules will be available:
 ```python

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This project defines core build rules for [Scala](https://www.scala-lang.org/) t
 * [scala_test_suite](docs/scala_test_suite.md)
 * [thrift_library](docs/thrift_library.md)
 * [scala_proto_library](docs/scala_proto_library.md)
-* [scala_toolchain](docs/scala_toolchain.md)
+* [scala_](docs/scala_toolchain.md)
 * [scala_import](docs/scala_import.md)
 * [scala_doc](docs/scala_doc.md)
 
@@ -79,7 +79,7 @@ scalatest_toolchain()
 
 This will load the `rules_scala` repository at the commit sha
 `rules_scala_version` into your Bazel project and register a [Scala
-toolchain](#scala_toolchain) at the default Scala version (2.12.14)
+toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.14)
 
 Then in your BUILD file just add the following so the rules will be available:
 ```python
@@ -132,7 +132,7 @@ Rules scala supports the last two released minor versions for each of Scala 2.11
 Previous minor versions may work but are supported only on a best effort basis.
 
 To configure Scala version you must call `scala_config(scala_version = "2.xx.xx")` and configure 
-dependencies by declaring [scala_toolchain](https://github.com/bazelbuild/rules_scala/blob/master/docs/scala_toolchain.md). 
+dependencies by declaring [scala_toolchain](docs/scala_toolchain.md). 
 For a quick start you can use `scala_repositories()` and `scala_register_toolchains()`, which have 
 dependency providers configured for `2.11.12`, `2.12.14` and `2.13.6` versions.
 


### PR DESCRIPTION
Fixes invalid link to scala toolchains docs and changes another url to relative