### PR TITLE
Add SemanticDB support

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -57,10 +57,13 @@ specs2_junit_repositories()
 register_toolchains("//testing:testing_toolchain")
 
 load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_default_config", "scalafmt_repositories")
+load("//scala/semanticdb:semanticdb_repositories.bzl", "semanticdb_repositories")
 
 scalafmt_default_config()
 
 scalafmt_repositories()
+
+semanticdb_repositories()
 
 MAVEN_SERVER_URLS = default_maven_server_urls()
 

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -39,3 +39,7 @@ load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "
 scalatest_repositories()
 
 scalatest_toolchain()
+
+load("@io_bazel_rules_scala//scala/semanticdb:semanticdb_repositories.bzl", "semanticdb_repositories")
+
+semanticdb_repositories()

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -105,3 +105,10 @@ declare_deps_provider(
     visibility = ["//visibility:public"],
     deps = ["@io_bazel_rules_scala_scala_parser_combinators"],
 )
+
+declare_deps_provider(
+    name = "semanticdb_scalac_provider",
+    deps_id = "semanticdb_scalac",
+    visibility = ["//visibility:public"],
+    deps = ["@org_scalameta_semanticdb_scalac"],
+)

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -54,6 +54,11 @@ common_attrs.update({
     "_dependency_analyzer_plugin": attr.label(
         default = Label(
             "@io_bazel_rules_scala//third_party/dependency_analyzer/src/main:dependency_analyzer",
+        ), allow_files = [".jar"], mandatory = False,
+    ),
+    "_semanticdb_scalac_plugin": attr.label(
+        default = Label(
+            "@io_bazel_rules_scala//scala/private/toolchain_deps:semanticdb_scalac",
         ),
         allow_files = [".jar"],
         mandatory = False,

--- a/scala/private/dependency.bzl
+++ b/scala/private/dependency.bzl
@@ -23,6 +23,7 @@ def new_dependency_info(
         unused_deps_mode = unused_deps_mode,
         strict_deps_mode = strict_deps_mode,
         use_analyzer = is_strict_deps_on or is_unused_deps_on,
+        use_semanticdb_scalac = True,
     )
 
 # TODO(https://github.com/bazelbuild/rules_scala/issues/987): Clariy the situation

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -61,6 +61,8 @@ def compile_scala(
     plugins = _collect_plugin_paths(plugins)
     if dependency_info.use_analyzer:
         plugins = depset(transitive = [plugins, ctx.attr._dependency_analyzer_plugin.files])
+    if dependency_info.use_semanticdb_scalac and False:
+        plugins = depset(transitive = [plugins, ctx.attr._semanticdb_scalac_plugin.files])
 
     toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
     compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars

--- a/scala/private/toolchain_deps/BUILD
+++ b/scala/private/toolchain_deps/BUILD
@@ -23,3 +23,9 @@ common_toolchain_deps(
     deps_id = "parser_combinators",
     visibility = ["//visibility:public"],
 )
+
+common_toolchain_deps(
+    name = "semanticdb_scalac",
+    deps_id = "semanticdb_scalac",
+    visibility = ["//visibility:public"],
+)

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -93,6 +93,7 @@ scala_toolchain = rule(
         "scalacopts": attr.string_list(),
         "dep_providers": attr.label_list(
             default = [
+                "@io_bazel_rules_scala//scala:semanticdb_scalac_provider",
                 "@io_bazel_rules_scala//scala:scala_xml_provider",
                 "@io_bazel_rules_scala//scala:parser_combinators_provider",
                 "@io_bazel_rules_scala//scala:scala_compile_classpath_provider",

--- a/scala/semanticdb/semanticdb_repositories.bzl
+++ b/scala/semanticdb/semanticdb_repositories.bzl
@@ -1,0 +1,16 @@
+load(
+    "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
+)
+load("//third_party/repositories:repositories.bzl", "repositories")
+
+
+def semanticdb_repositories(
+        maven_servers = _default_maven_server_urls(),
+        overriden_artifacts = {}):
+    repositories(
+        for_artifact_ids = ["org_scalameta_semanticdb_scalac"],
+        maven_servers = maven_servers,
+        fetch_sources = False,
+        overriden_artifacts = overriden_artifacts,
+    )

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -35,6 +35,10 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_semanticdb_scalac": {
+        "artifact": "org.scalameta:semanticdb-scalac_2.11.12:4.4.31",
+        "sha256": "d61eb07ff182173c8b30b7caa4bba2bd04fd2c921552ad1c550073f1f0262ed7",
+    },
     "org_scalameta_fastparse": {
         "artifact": "org.scalameta:fastparse_2.11:1.0.1",
         "sha256": "49ecc30a4b47efc0038099da0c97515cf8f754ea631ea9f9935b36ca7d41b733",

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -35,6 +35,10 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_semanticdb_scalac": {
+        "artifact": "org.scalameta:semanticdb-scalac_2.12.14:4.4.31",
+        "sha256": "8a6d71f1611ede0fdc435a851fdd67ccb64c68b80b2153fce4a389eb33ed7416",
+    },
     "org_scalameta_fastparse": {
         "artifact": "org.scalameta:fastparse_2.12:1.0.1",
         "sha256": "387ced762e93915c5f87fed59d8453e404273f49f812d413405696ce20273aa5",

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -40,6 +40,10 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_semanticdb_scalac": {
+        "artifact": "org.scalameta:semanticdb-scalac_2.13.6:4.4.31",
+        "sha256": "09f270c275701cfba93620ddd5c0b287a5c123cf528e837c518d5b5dd85efff0",
+    },
     "org_scalameta_fastparse": {
         "artifact": "org.scalameta:fastparse_2.13:1.0.1",
         "sha256": "b43b99244d5b51948daf1467083b3850dc2727c604de98dc426dec14244fd18e",


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
This PR adds an flag to enable the [SemanticDB](https://scalameta.org/docs/semanticdb/guide.html) compiler plugin during Scala compilation. 

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->
The SemanticDB compiler adds overhead to compilation so it should be disabled by default. The goal of this PR is to make it easy for users to dynamically enable SemanticDB in certain environments like CI via Bazel config options or system environment variables. 

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
SemanticDB is used by several tools like [Scalafix](https://scalacenter.github.io/scalafix/) and [Metals](https://scalameta.org/metals) so it would be nice to have this functionality included out-of-the-box with rules_scala. Example use-cases include

- Use Scalafix to organize imports via https://github.com/liancheng/scalafix-organize-imports
- Use Metals, the Scala language server, with Bazel workspaces (
- Run [lsif-java](https://sourcegraph.github.io/lsif-java) to generate [LSIF indexes](https://microsoft.github.io/language-server-protocol/specifications/lsif/0.4.0/specification/). This is my primary motivation to work on this PR, I'd like to integrate Bazel with precise code intelligence on [Sourcegraph](https://sourcegraph.com) (my employer). We recently [announced precise code intelligence support for Java, Scala, and Kotlin](https://about.sourcegraph.com/blog/java-scala-kotlin-code-intelligence/) that's powered by SemanticDB.