### PR TITLE
scala_doc: Add support for building docs without transitive dependencies

### DIFF
--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -112,7 +112,7 @@ def make_scala_doc_rule(aspect = _scaladoc_transitive_aspect):
             ),
             "scalacopts": attr.string_list(),
             "_scaladoc": attr.label(
-                cfg = "host",
+                cfg = "exec",
                 executable = True,
                 default = Label("//src/scala/io/bazel/rules_scala/scaladoc_support:scaladoc_generator"),
             ),

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -16,12 +16,14 @@ def _scaladoc_aspect_impl(target, ctx):
         # Collect only Java and Scala sources enumerated in visited targets, including src_files in deps.
         direct_deps = [file for file in ctx.rule.files.srcs if file.extension.lower() in ["java", "scala"]]
         transitive_deps = []
+
         # Sometimes we only want to generate scaladocs for a single target and not all of its
         # dependencies
         if ctx.attr.transitive == "true":
             transitive_deps = [dep[_ScaladocAspectInfo].src_files for dep in ctx.rule.attr.deps if _ScaladocAspectInfo in dep]
 
         src_files = depset(direct = direct_deps, transitive = transitive_deps)
+
         # Collect compile_jars from visited targets' deps.
         compile_jars = depset(
             direct = [file for file in ctx.rule.files.deps],
@@ -47,7 +49,7 @@ _scaladoc_aspect = aspect(
     implementation = _scaladoc_aspect_impl,
     attr_aspects = ["deps"],
     attrs = {
-        "transitive": attr.string(default="true", values=["true", "false"]),
+        "transitive": attr.string(default = "true", values = ["true", "false"]),
     },
     required_aspect_providers = [
         [JavaInfo],
@@ -98,7 +100,7 @@ scala_doc = rule(
             providers = [JavaInfo],
         ),
         "scalacopts": attr.string_list(),
-        "transitive": attr.string(default="true", values=["true", "false"]),
+        "transitive": attr.string(default = "true", values = ["true", "false"]),
         "_scaladoc": attr.label(
             cfg = "host",
             executable = True,

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -19,12 +19,13 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
     if hasattr(ctx.rule.attr, "srcs"):
         # Collect only Java and Scala sources enumerated in visited targets, including src_files in deps.
         direct_deps = [file for file in ctx.rule.files.srcs if file.extension.lower() in ["java", "scala"]]
-        transitive_deps = []
 
         # Sometimes we only want to generate scaladocs for a single target and not all of its
         # dependencies
         if transitive:
             transitive_deps = [dep[_ScaladocAspectInfo].src_files for dep in ctx.rule.attr.deps if _ScaladocAspectInfo in dep]
+        else:
+            transitive_deps = []
 
         src_files = depset(direct = direct_deps, transitive = transitive_deps)
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -51,6 +51,7 @@ def scala_specs2_junit_test(name, **kwargs):
 
 # Re-export private rules for public consumption
 scala_binary = _scala_binary
+
 # These are exported for enabling users to build scaladocs without transitive dependencies.
 make_scala_doc_rule = _make_scala_doc_rule
 scaladoc_intransitive_aspect = _scaladoc_intransitive_aspect

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -12,7 +12,8 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rules/scala_doc.bzl",
-    _scala_doc = "scala_doc",
+    _make_scala_doc_rule = "make_scala_doc_rule",
+    _scaladoc_intransitive_aspect = "scaladoc_intransitive_aspect",
 )
 load(
     "@io_bazel_rules_scala//scala/private:rules/scala_junit_test.bzl",
@@ -50,7 +51,9 @@ def scala_specs2_junit_test(name, **kwargs):
 
 # Re-export private rules for public consumption
 scala_binary = _scala_binary
-scala_doc = _scala_doc
+make_scala_doc_rule = _make_scala_doc_rule
+scaladoc_intransitive_aspect = _scaladoc_intransitive_aspect
+scala_doc = _make_scala_doc_rule()
 scala_junit_test = _scala_junit_test
 scala_library = _scala_library
 scala_library_for_plugin_bootstrapping = _scala_library_for_plugin_bootstrapping

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -51,6 +51,7 @@ def scala_specs2_junit_test(name, **kwargs):
 
 # Re-export private rules for public consumption
 scala_binary = _scala_binary
+# These are exported for enabling users to build scaladocs without transitive dependencies.
 make_scala_doc_rule = _make_scala_doc_rule
 scaladoc_intransitive_aspect = _scaladoc_intransitive_aspect
 scala_doc = _make_scala_doc_rule()


### PR DESCRIPTION
### Description
Add support to build scaladocs only for the provided targets.

This enables building scaladocs without building docs all transitive dependencies (i.e 3rdparty dependencies and other dependent targets). The aim is to provide a `transitive` arg that can be set to `true`/`false` (defaults to `true`) which decides whether to build scaladocs for transitive dependencies or not.

### Motivation
We are using bazel in a big mono-repo and building scaladocs for some of our targets take a long time because of the large dependency chain and sometimes long list of 3rdparty libraries. We only want to build scaladocs for the targets we specify in the `deps` field of the `scala_doc` rule. This change adds support for that.
