### PR TITLE
feat(specs2): remove scope and shoulds

### DIFF
--- a/test/coverage_filename_encoding/Test.scala
+++ b/test/coverage_filename_encoding/Test.scala
@@ -1,10 +1,9 @@
 package coverage_filename_encoding
 
 import org.specs2.mutable.SpecWithJUnit
-import org.specs2.specification.Scope
 
 class Test extends SpecWithJUnit {
-  "testA1" in new Scope {
-    A1.a1(true) must_!= 1
+  "testA1" in {
+    A1.a1(true) must be_!=(1)
   }
 }

--- a/test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala
+++ b/test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala
@@ -1,22 +1,24 @@
 package coverage_specs2_with_junit
 
 import org.specs2.mutable.SpecWithJUnit
-import org.specs2.specification.Scope
 
 class TestWithSpecs2WithJUnit extends SpecWithJUnit {
-  "testA1" in new Scope {
-    A1.a1(true) must_== B1
+  "testA1" in {
+    A1.a1(true) must be_==(B1)
   }
 
-  "testA2" in new Scope {
+  "testA2" in {
     A2.a2()
+    success
   }
 
-  "testD1" in new Scope {
+  "testD1" in {
     D1.veryLongFunctionNameIsHereAaaaaaaaa()
+    success
   }
 
-  "testE1" in new Scope {
+  "testE1" in {
     E1.e1("test")
+    success
   }
 }

--- a/test/shell/test_scala_specs2.sh
+++ b/test/shell/test_scala_specs2.sh
@@ -39,7 +39,7 @@ scala_specs2_junit_test_test_filter_one_test(){
   local output=$(bazel test \
     --nocache_test_results \
     --test_output=streamed \
-    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#specs2 tests should::run smoothly in bazel$' \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#specs2 tests::run smoothly in bazel$' \
     test:Specs2Tests)
   local expected="+ run smoothly in bazel"
   local unexpected="+ not run smoothly in bazel"
@@ -90,7 +90,7 @@ scala_specs2_junit_test_test_filter_exact_match(){
   local output=$(bazel test \
     --nocache_test_results \
     --test_output=streamed \
-    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2AnotherTest#other specs2 tests should::run from another test$' \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2AnotherTest#other specs2 tests::run from another test$' \
     test:Specs2Tests)
   local expected="+ run from another test"
   local unexpected="+ run from another test 2"
@@ -112,7 +112,7 @@ scala_specs2_junit_test_test_filter_exact_match_unsafe_characters(){
   local output=$(bazel test \
     --nocache_test_results \
     --test_output=streamed \
-    '--test_filter=scalarules.test.junit.specs2.JunitSpec2RegexTest#\Qtests with unsafe characters should::2 + 2 != 5\E$' \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpec2RegexTest#\Qtests with unsafe characters::2 + 2 != 5\E$' \
     test:Specs2Tests)
   local expected="+ 2 + 2 != 5"
   local unexpected="+ work escaped (with regex)"
@@ -134,7 +134,7 @@ scala_specs2_junit_test_test_filter_exact_match_escaped_and_sanitized(){
   local output=$(bazel test \
     --nocache_test_results \
     --test_output=streamed \
-    '--test_filter=scalarules.test.junit.specs2.JunitSpec2RegexTest#\Qtests with unsafe characters should::work escaped [with regex]\E$' \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpec2RegexTest#\Qtests with unsafe characters::work escaped [with regex]\E$' \
     test:Specs2Tests)
   local expected="+ work escaped (with regex)"
   local unexpected="+ 2 + 2 != 5"
@@ -156,7 +156,7 @@ scala_specs2_junit_test_test_filter_match_multiple_methods(){
   local output=$(bazel test \
     --nocache_test_results \
     --test_output=streamed \
-    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2AnotherTest#other specs2 tests should::(\Qrun from another test\E|\Qrun from another test 2\E)$' \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2AnotherTest#other specs2 tests::(\Qrun from another test\E|\Qrun from another test 2\E)$' \
     test:Specs2Tests)
   local expected=(
       "+ run from another test"
@@ -222,7 +222,7 @@ scala_specs2_all_tests_show_in_the_xml(){
     --test_output=streamed \
     '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#' \
     test:Specs2Tests
-  matches=$(grep -c -e "testcase name='specs2 tests should::run smoothly in bazel'" -e "testcase name='specs2 tests should::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
+  matches=$(grep -c -e "testcase name='specs2 tests::run smoothly in bazel'" -e "testcase name='specs2 tests should::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
   if [ $matches -eq 2 ]; then
     return 0
   else
@@ -236,9 +236,9 @@ scala_specs2_only_filtered_test_shows_in_the_xml(){
   bazel test \
     --nocache_test_results \
     --test_output=streamed \
-    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#specs2 tests should::run smoothly in bazel$' \
+    '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#specs2 tests::run smoothly in bazel$' \
     test:Specs2Tests
-  matches=$(grep -c -e "testcase name='specs2 tests should::run smoothly in bazel'" -e "testcase name='specs2 tests should::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
+  matches=$(grep -c -e "testcase name='specs2 tests::run smoothly in bazel'" -e "testcase name='specs2 tests::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
   if [ $matches -eq 1 ]; then
     return 0
   else

--- a/test/shell/test_scala_specs2.sh
+++ b/test/shell/test_scala_specs2.sh
@@ -222,7 +222,7 @@ scala_specs2_all_tests_show_in_the_xml(){
     --test_output=streamed \
     '--test_filter=scalarules.test.junit.specs2.JunitSpecs2Test#' \
     test:Specs2Tests
-  matches=$(grep -c -e "testcase name='specs2 tests::run smoothly in bazel'" -e "testcase name='specs2 tests should::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
+  matches=$(grep -c -e "testcase name='specs2 tests::run smoothly in bazel'" -e "testcase name='specs2 tests::not run smoothly in bazel'" ./bazel-testlogs/test/Specs2Tests/test.xml)
   if [ $matches -eq 2 ]; then
     return 0
   else
@@ -253,10 +253,10 @@ scala_specs2_only_failed_test_shows_in_the_xml(){
   bazel test \
   --nocache_test_results \
   --test_output=streamed \
-  '--test_filter=scalarules.test.junit.specs2.SuiteWithOneFailingTest#specs2 tests should::fail$' \
+  '--test_filter=scalarules.test.junit.specs2.SuiteWithOneFailingTest#specs2 tests::fail$' \
   test_expect_failure/scala_junit_test:specs2_failing_test
   echo "got results"
-  matches=$(grep -c -e "testcase name='specs2 tests should::fail'" -e "testcase name='specs2 tests should::succeed'" ./bazel-testlogs/test_expect_failure/scala_junit_test/specs2_failing_test/test.xml)
+  matches=$(grep -c -e "testcase name='specs2 tests::fail'" -e "testcase name='specs2 tests::succeed'" ./bazel-testlogs/test_expect_failure/scala_junit_test/specs2_failing_test/test.xml)
   if [ $matches -eq 1 ]; then
     return 0
   else

--- a/test/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
+++ b/test/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
@@ -5,7 +5,7 @@ import scalarules.test.junit.support.JUnitCompileTimeDep
 
 class JunitSpecs2Test extends SpecWithJUnit {
 
-  "specs2 tests" should {
+  "specs2 tests" >> {
     "run smoothly in bazel" in {
       println(JUnitCompileTimeDep.hello)
       success
@@ -19,7 +19,7 @@ class JunitSpecs2Test extends SpecWithJUnit {
 
 class JunitSpecs2AnotherTest extends SpecWithJUnit {
 
-  "other specs2 tests" should {
+  "other specs2 tests" >> {
     "run from another test" >> {
       println(JUnitCompileTimeDep.hello)
       success
@@ -30,7 +30,7 @@ class JunitSpecs2AnotherTest extends SpecWithJUnit {
     }
   }
 
-  "unrelated test" should {
+  "unrelated test" >> {
     "not run" in {
       success
     }
@@ -39,7 +39,7 @@ class JunitSpecs2AnotherTest extends SpecWithJUnit {
 
 class JunitSpec2RegexTest extends SpecWithJUnit {
 
-  "tests with unsafe characters" should {
+  "tests with unsafe characters" >> {
     "2 + 2 != 5" in {
       2 + 2 must be_!=(5)
     }

--- a/test/src/main/scala/scalarules/test/location_expansion/LocationExpansionTest.scala
+++ b/test/src/main/scala/scalarules/test/location_expansion/LocationExpansionTest.scala
@@ -3,7 +3,7 @@ package scalarules.test.location_expansion
 import org.specs2.mutable.SpecWithJUnit
 class LocationExpansionTest extends SpecWithJUnit {
 
-  "tests" should {
+  "tests" >> {
     "support location expansion" >> {
       sys.props.get("location.expanded") must beSome(contain("worker"))
 

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesFilegroupTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesFilegroupTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.SpecWithJUnit
 
 class ScalaLibOnlyResourcesFilegroupTest extends SpecWithJUnit {
 
-  "Scala library with no srcs and only filegroup resources" should {
+  "Scala library with no srcs and only filegroup resources" >> {
     "allow to load resources" >> {
       get("/resource.txt") must beEqualTo("I am a text resource!")
       get("/subdir/resource.txt") must beEqualTo("I am a text resource in a subdir!")

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.SpecWithJUnit
 
 class ScalaLibOnlyResourcesTest extends SpecWithJUnit {
 
-  "Scala library with no srcs and only resources" should {
+  "Scala library with no srcs and only resources" >> {
     "allow to load resources" >> {
       get("/resource.txt") must beEqualTo("I am a text resource!")
     }

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.SpecWithJUnit
 
 class ScalaLibResourcesFromExternalDepTest extends SpecWithJUnit {
 
-  "Scala library depending on resources from external resource-only jar" should {
+  "Scala library depending on resources from external resource-only jar" >> {
     "allow to load resources" >> {
       get("/external/test_new_local_repo/resource.txt") must beEqualTo("A resource\n")
     }

--- a/test/src/main/scala/scalarules/test/resources/strip/ResourceStripPrefixTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/strip/ResourceStripPrefixTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.SpecificationWithJUnit
 
 class ResourceStripPrefixTest extends SpecificationWithJUnit {
 
-  "resource_strip_prefix" should {
+  "resource_strip_prefix" >> {
     "strip the prefix on nosrc jar" in {
       val resource = getClass.getResourceAsStream("/nosrc_jar_resource.txt")
       resource must not beNull

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesFileJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesFileJarsTest.scala
@@ -5,7 +5,7 @@ import com.lucidchart.relate.SqlRow
 
 class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
 
-  "scala_import" should {
+  "scala_import" >> {
     "enable importing jars from files" in {
       println(classOf[SqlRow])
       success

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -5,7 +5,7 @@ import org.apache.commons.lang3.ArrayUtils
 import org.specs2.mutable.SpecWithJUnit
 
 class ScalaImportExposesJarsTest extends SpecWithJUnit {
-  "scala_import" should {
+  "scala_import" >> {
     "enable using the jars it exposes" in {
       println(classOf[Cache[String, String]])
       println(classOf[ArrayUtils])

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportPropagatesRuntimeDepsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportPropagatesRuntimeDepsTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.SpecificationWithJUnit
 
 class ScalaImportPropagatesRuntimeDepsTest extends SpecificationWithJUnit {
 
-  "scala_import" should {
+  "scala_import" >> {
     "propagate runtime deps" in {
       println(Class.forName("com.google.common.cache.Cache"))
       println(Class.forName("org.apache.commons.lang3.ArrayUtils"))

--- a/test/src/main/scala/scalarules/test/scala_import/nl/ScalaImportNeverLinkTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/nl/ScalaImportNeverLinkTest.scala
@@ -4,7 +4,7 @@ import org.specs2.mutable.SpecificationWithJUnit
 import scala.util.control.NonFatal
 
 class ScalaImportNeverLinkTest extends SpecificationWithJUnit {
-  "neverlinked scala_import" should {
+  "neverlinked scala_import" >> {
     "not be available in runtime" in {
       //ScalaImportNeverLink class is packaged in scala_import_never_link.jar. Since the scala_import target
       //is marked as "neverlink" - this test class/target will be built successfully but will fail on runtime with

--- a/test_expect_failure/scala_import/ScalaImportPropagatesCompileDepsTest.scala
+++ b/test_expect_failure/scala_import/ScalaImportPropagatesCompileDepsTest.scala
@@ -6,7 +6,7 @@ import org.specs2.mutable.SpecificationWithJUnit
 
 class ScalaImportPropagatesCompileDepsTest extends SpecificationWithJUnit {
 
-  "scala_import" should {
+  "scala_import" >> {
     "propagate compile time deps" in {
       println(classOf[Cache[String, String]])
       println(classOf[ArrayUtils])

--- a/test_expect_failure/scala_junit_test/specs2/SuiteWithOneFailingTest.scala
+++ b/test_expect_failure/scala_junit_test/specs2/SuiteWithOneFailingTest.scala
@@ -4,12 +4,12 @@ import org.specs2.mutable.SpecWithJUnit
 
 class SuiteWithOneFailingTest extends SpecWithJUnit {
 
-  "specs2 tests" should {
+  "specs2 tests" >> {
     "succeed" >> success
     "fail" >> failure("boom")
   }
 
-  "some other suite" should {
+  "some other suite" >> {
     "do stuff" >> success
   }
 }

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
@@ -5,7 +5,7 @@ import scalarules.test.junit.support.JUnitCompileTimeDep
 
 class JunitSpecs2Test extends SpecWithJUnit {
 
-  "specs2 tests" should {
+  "specs2 tests" >> {
     "run smoothly in bazel" in {
       println(JUnitCompileTimeDep.hello)
       success
@@ -19,7 +19,7 @@ class JunitSpecs2Test extends SpecWithJUnit {
 
 class JunitSpecs2AnotherTest extends SpecWithJUnit {
 
-  "other specs2 tests" should {
+  "other specs2 tests" >> {
     "run from another test" >> {
       println(JUnitCompileTimeDep.hello)
       success
@@ -30,7 +30,7 @@ class JunitSpecs2AnotherTest extends SpecWithJUnit {
     }
   }
 
-  "unrelated test" should {
+  "unrelated test" >> {
     "not run" in {
       success
     }
@@ -39,7 +39,7 @@ class JunitSpecs2AnotherTest extends SpecWithJUnit {
 
 class JunitSpec2RegexTest extends SpecWithJUnit {
 
-  "tests with unsafe characters" should {
+  "tests with unsafe characters" >> {
     "2 + 2 != 5" in {
       2 + 2 must be_!=(5)
     }


### PR DESCRIPTION
### Description
Removed usage of `should` and `new Scope` from specs2 tests.
`should` clashes with an expectation in Specs2 v5.
`Scope` is [no longer available](https://medium.com/@etorreborre_99063/specs2-the-next-10-years-8c15e85cb9fe) in Specs2 v5.


`should` can be used in specs2 v5, however in test classes must extend `ExtendedBlockDsl`, which is not available in v4. Making it cross-compatible for v4 and v5 would require to write a custom 'should' in the rules_scala repo, which is not great.

I understand it is not great in terms of spec formulation, but I do not see a cleaner way for now.

### Motivation
Prerequisite for scala3 support. Scala3 build requires specs2 v5.