### PR TITLE
feat(specs2): modify runner suite to support scala3

### DIFF
--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -148,7 +148,7 @@ object PrefixSuffixTestDiscoveringSuite {
 
   private def hasTestAnnotatedMethodsInCurrentClass(testClass: Class[_]): Boolean =
     testClass.getDeclaredMethods.exists { method =>
-      method.getAnnotations.exists { annotation: Annotation =>
+      method.getAnnotations.exists { (annotation: Annotation) =>
         testAnnotation.isAssignableFrom(annotation.annotationType)
       }
     }

--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -1,10 +1,10 @@
 package io.bazel.rulesscala.test_discovery
 
+import FilteredRunnerBuilder.FilteringRunnerBuilder
+
 import java.lang.annotation.Annotation
 import java.util
 import java.util.regex.Pattern
-
-import io.bazel.rulesscala.test_discovery.FilteredRunnerBuilder.FilteringRunnerBuilder
 import org.junit.Test
 import org.junit.runner.Runner
 import org.junit.runners.BlockJUnit4ClassRunner


### PR DESCRIPTION
### Description
Modification of the specs2 test runner suite to support scala3.

This includes:
- Copying `bottomUp` implementation from specs2 v4 package, as it no longer exists on v5
- Minor refactoring (thanks to @liucijus for doing this part)

### Motivation
A prerequisite for scala3 support
