### PR TITLE
Update buildkite jobs

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -1,17 +1,6 @@
 ---
 validate_config: 1
 tasks:
-  ubuntu1804:
-    name: "bazel test //test/..."      
-    platform: ubuntu1804
-    shell_commands:
-    # Disable local disk caching on CI.
-    - mv tools/bazel.rc.buildkite tools/bazel.rc
-    - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
   ubuntu2004:
     name: "bazel test //test/..."
     platform: ubuntu2004
@@ -33,23 +22,22 @@ tasks:
     - "//test/..."
     test_targets:
     - "//test/..."
-  rbe_ubuntu1604:
-    name: "bazel test //test/..."
-    platform: rbe_ubuntu1604
-    build_targets:
-    - "//test/..."
-    test_targets:
-    - "//test/..."
   test_rules_scala_linux:
     name: "./test_rules_scala"
-    platform: ubuntu1804
+    platform: ubuntu2004
     shell_commands:
     # Install xmllint
     - sudo apt update && sudo apt install -y libxml2-utils
     - "./test_rules_scala.sh"
+   test_rules_scala_linux_Bazel5:
+    name: "./test_rules_scala (Bazel 5.0)"
+    platform: ubuntu2004
+    bazel: 5.0.0
+    shell_commands:
+    - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Optional build with latest Bazel version failed, [see here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}) (It is not mandatory but worth checking)\""
   test_rules_scala_linux_latest:
-    name: "./test_rules_scala (latest bazel)"
-    platform: ubuntu1804
+    name: "./test_rules_scala (latest Bazel)"
+    platform: ubuntu2004
     bazel: latest
     shell_commands:
     - "./test_rules_scala.sh || buildkite-agent annotate --style 'warning' \"Optional build with latest Bazel version failed, [see here](${BUILDKITE_BUILD_URL}#${BUILDKITE_JOB_ID}) (It is not mandatory but worth checking)\""
@@ -60,7 +48,7 @@ tasks:
     - "./test_rules_scala.sh"
   test_coverage_linux_4_1_0:
     name: "./test_coverage"
-    platform: ubuntu1804
+    platform: ubuntu2004
     bazel: 4.1.0
     shell_commands:
       - "./test_coverage.sh"
@@ -80,7 +68,7 @@ tasks:
     platform: macos
     shell_commands:
     - "./test_reproducibility.sh"
-  versions_ubuntu2004:
+  versions_linux:
     name: "./test_version.sh"      
     platform: ubuntu2004
     shell_commands:
@@ -90,13 +78,13 @@ tasks:
     platform: macos
     shell_commands:
     - "./test_version.sh"
-  examples_ubuntu2004:
+  examples_linux:
     name: "./test_examples"
     platform: ubuntu2004
     bazel: 4.1.0
     shell_commands:
       - "./test_examples.sh"
-  lint_ubuntu2004:
+  lint_linux:
     name: "bazel //tools:lint_check"
     platform: ubuntu2004
     run_targets:


### PR DESCRIPTION
Cleanup - removed older Linux versions build, added Bazel 5 build to ensure compatibility while we are on Bazel 4.1.0.