### PR TITLE
Fix org_typelevel__cats_core checksum for 2.13

### DIFF
--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -430,7 +430,7 @@ artifacts = {
     "org_typelevel__cats_core": {
         "testonly": True,
         "artifact": "org.typelevel:cats-core_2.13:2.2.0",
-        "sha256": "6058d02418e4eb5f1919a1156d63d2d1b93f2c6190b1a1806ee2b73f8726a923",
+        "sha256": "6058d02418e4eb5f1919a1156d63d2d1b93f2c6190b1a1806ee2b73f8726a92f",
     },
     "com_google_guava_guava_21_0_with_file": {
         "testonly": True,


### PR DESCRIPTION
Discovered invalid checksum for `org_typelevel__cats_core` while testing Scala 2.13 locally.

Since we can pass Scala version on the command line, I think we need a follow up improvement on how version based tests run on CI.

Also it's probably good time to update default version to 2.13.