### PR TITLE
update default `scalafmt` phase order; place before `runfiles`

### DIFF
--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -40,8 +40,11 @@ declare_deps_provider(
     visibility = ["//visibility:public"],
     deps = [
         "@com_geirsson_metaconfig_core",
+        "@org_scalameta_common",
         "@org_scalameta_parsers",
         "@org_scalameta_scalafmt_core",
+        "@org_scalameta_scalameta",
+        "@org_scalameta_trees",
     ],
 )
 

--- a/scala/scalafmt/phase_scalafmt_ext.bzl
+++ b/scala/scalafmt/phase_scalafmt_ext.bzl
@@ -45,7 +45,12 @@ def _scalafmt_singleton_implementation(ctx):
     return [
         _ScalaRulePhase(
             custom_phases = [
-                ("$", "", "scalafmt", _phase_scalafmt),
+                # Placed before `runfiles` phase so the captured outputs and sources during creation of the
+                # `TARGET.format-test` output script are made available as runfiles to other downstream
+                # targets (for instance, a wrapping `sh_test` target which invokes that `TARGET.format-test`
+                # script).  This allows them to by symlinked into the runfiles tree and thus accessible when
+                # run via `bazel test`.
+                ("-", "runfiles", "scalafmt", _phase_scalafmt),
             ],
         ),
     ]


### PR DESCRIPTION
### Description
See comments in change for detailed motivation.  TL;DR: Allow the capture of formatted sources, original sources, and manifest to be passed via `runfiles` phase to downstream dependencies, such as a wrapping `sh_test`, allowing it to
actually access those during a `bazel test` invocation and fail a build if the format is incorrect.

