### PR TITLE
Move ScalaTest deps to its own repository macro

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,10 @@ load("//scala_proto:scala_proto.bzl", "scala_proto_repositories")
 
 scala_proto_repositories()
 
+load("//scalatest:scalatest.bzl", "scalatest_repositories")
+
+scalatest_repositories()
+
 load("//specs2:specs2_junit.bzl", "specs2_junit_repositories")
 
 specs2_junit_repositories()

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -46,8 +46,6 @@ ARTIFACT_IDS = [
     "io_bazel_rules_scala_scala_library",
     "io_bazel_rules_scala_scala_compiler",
     "io_bazel_rules_scala_scala_reflect",
-    "io_bazel_rules_scala_scalatest",
-    "io_bazel_rules_scala_scalactic",
     "io_bazel_rules_scala_scala_xml",
     "io_bazel_rules_scala_scala_parser_combinators",
 ] if SCALA_MAJOR_VERSION.startswith("2") else [
@@ -56,8 +54,6 @@ ARTIFACT_IDS = [
     "io_bazel_rules_scala_scala_interfaces",
     "io_bazel_rules_scala_scala_tasty_core",
     "io_bazel_rules_scala_scala_asm",
-    "io_bazel_rules_scala_scalatest",
-    "io_bazel_rules_scala_scalactic",
     "io_bazel_rules_scala_scala_xml",
     "io_bazel_rules_scala_scala_parser_combinators",
     "io_bazel_rules_scala_scala_library_2",

--- a/scala/scalatest/BUILD
+++ b/scala/scalatest/BUILD
@@ -3,4 +3,5 @@ package(default_visibility = ["//visibility:public"])
 alias(
     name = "scalatest",
     actual = "//testing/toolchain:scalatest_classpath",
+    deprecation = "Use //testing/toolchain:scalatest_classpath directly",
 )

--- a/scalatest/scalatest.bzl
+++ b/scalatest/scalatest.bzl
@@ -1,0 +1,17 @@
+load(
+    "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
+)
+load("//third_party/repositories:repositories.bzl", "repositories")
+
+def scalatest_repositories(
+        maven_servers = _default_maven_server_urls(),
+        fetch_sources = True):
+    repositories(
+        for_artifact_ids = [
+            "io_bazel_rules_scala_scalatest",
+            "io_bazel_rules_scala_scalactic",
+        ],
+        maven_servers = maven_servers,
+        fetch_sources = fetch_sources,
+    )

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -57,6 +57,10 @@ load("@io_bazel_rules_scala//specs2:specs2_junit.bzl", "specs2_junit_repositorie
 
 specs2_junit_repositories()
 
+load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
+
+scalatest_repositories()
+
 register_toolchains("${testing_toolchain}")
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_toolchains")

--- a/testing/scalatest.bzl
+++ b/testing/scalatest.bzl
@@ -1,6 +1,7 @@
+load("//scalatest:scalatest.bzl", _repositories = "scalatest_repositories")
+
 def scalatest_repositories():
-    # currently ScalaTest dependencies are already loaded via //scala:scala.bzl#scala_repositories()
-    pass
+    _repositories()
 
 def scalatest_toolchain():
     native.register_toolchains("@io_bazel_rules_scala//testing:scalatest_toolchain")

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -15,7 +15,6 @@ artifacts = {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:0.2.0",
         "sha256": "d15f22f1308b98e9ac52a3d1ac8d582d548d6d852b1116cbdf5a50f431246ed1",
     },
-    #
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_2.13:3.1.2",
         "sha256": "94b636ce8dc2caed3069069c97b94538e60e9a400833fb8086c8271978ad2c21",


### PR DESCRIPTION
Tech debt clean up. Moving loading of ScalaTest dependencies from `scala_repositories` to `scalatest_repositories`, which was an empty call to ease such migration.

Codebases, which get broken after this change, should call `scalatest_repositories() ` in their WORKSPACEs:

```
load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")

scalatest_repositories() # Loads ScalaTest dependencies

scalatest_toolchain()
```