### PR TITLE
Clean up versions tests

### DIFF
--- a/test_version.sh
+++ b/test_version.sh
@@ -7,12 +7,9 @@ scala_2_12_version="2.12.14"
 scala_2_13_version="2.13.6"
 
 SCALA_VERSION_DEFAULT=$scala_2_11_version
-TWITTER_SCROOGE_ARTIFACTS='twitter_scrooge_artifacts={}'
 
 diagnostics_reporter_toolchain="//:diagnostics_reporter_toolchain"
 no_diagnostics_reporter_toolchain="//:no_diagnostics_reporter_toolchain"
-
-SCALA_TOOLCHAIN_DEFAULT="@io_bazel_rules_scala//testing:testing_toolchain"
 
 compilation_should_fail() {
   # runs the tests locally
@@ -30,7 +27,6 @@ compilation_should_fail() {
 
 run_in_test_repo() {
   local SCALA_VERSION=${SCALA_VERSION:-$SCALA_VERSION_DEFAULT}
-  local SCALA_TOOLCHAIN=${SCALA_TOOLCHAIN:-$SCALA_TOOLCHAIN_DEFAULT}
 
   local test_command=$1
   local test_dir_prefix=$2
@@ -45,8 +41,7 @@ run_in_test_repo() {
   cp -r $test_target $NEW_TEST_DIR
 
   sed \
-      -e "s%\${twitter_scrooge_artifacts}%$TWITTER_SCROOGE_ARTIFACTS%" \
-      -e "s%\${testing_toolchain}%$SCALA_TOOLCHAIN%" \
+      -e "s%\${twitter_scrooge_repositories}%$TWITTER_SCROOGE_REPOSITORIES%" \
       WORKSPACE.template >> $NEW_TEST_DIR/WORKSPACE
 
   cd $NEW_TEST_DIR
@@ -70,64 +65,20 @@ test_reporter() {
   local SCALA_VERSION="$1"
   local SCALA_TOOLCHAIN="$2"
 
-  run_in_test_repo "compilation_should_fail build //... --repo_env=SCALA_VERSION=${SCALA_VERSION}" "reporter" "test_reporter/"
+  run_in_test_repo "compilation_should_fail build //... --repo_env=SCALA_VERSION=${SCALA_VERSION} --extra_toolchains=${SCALA_TOOLCHAIN}" "reporter" "test_reporter/"
 }
 
 test_twitter_scrooge_versions() {
   local version_under_test=$1
 
-  local TWITTER_SCROOGE_ARTIFACTS_18_6_0='twitter_scrooge_artifacts={ \
-    "io_bazel_rules_scala_scrooge_core": {\
-        "artifact": "com.twitter:scrooge-core_2.11:18.6.0",\
-        "sha256": "00351f73b555d61cfe7320ef3b1367a9641e694cfb8dfa8a733cfcf49df872e8",\
-    },\
-    "io_bazel_rules_scala_scrooge_generator": {\
-        "artifact": "com.twitter:scrooge-generator_2.11:18.6.0",\
-        "sha256": "0f0027e815e67985895a6f3caa137f02366ceeea4966498f34fb82cabb11dee6",\
-        "runtime_deps": [\
-            "@io_bazel_rules_scala_guava",\
-            "@io_bazel_rules_scala_mustache",\
-            "@io_bazel_rules_scala_scopt",\
-        ],\
-    },\
-    "io_bazel_rules_scala_util_core": {\
-        "artifact": "com.twitter:util-core_2.11:18.6.0",\
-        "sha256": "5336da4846dfc3db8ffe5ae076be1021828cfee35aa17bda9af461e203cf265c",\
-    },\
-    "io_bazel_rules_scala_util_logging": {\
-        "artifact": "com.twitter:util-logging_2.11:18.6.0",\
-        "sha256": "73ddd61cedabd4dab82b30e6c52c1be6c692b063b8ba310d716ead9e3b4e9267",\
-    },\
-}'
+  local TWITTER_SCROOGE_REPOSITORIES_18_6_0='scrooge_repositories(version = "18.6.0")'
 
-  local TWITTER_SCROOGE_ARTIFACTS_21_2_0='twitter_scrooge_artifacts={ \
-    "io_bazel_rules_scala_scrooge_core": {\
-        "artifact": "com.twitter:scrooge-core_2.11:21.2.0",\
-        "sha256": "d6cef1408e34b9989ea8bc4c567dac922db6248baffe2eeaa618a5b354edd2bb",\
-    },\
-    "io_bazel_rules_scala_scrooge_generator": {\
-        "artifact": "com.twitter:scrooge-generator_2.11:21.2.0",\
-        "sha256": "87094f01df2c0670063ab6ebe156bb1a1bcdabeb95bc45552660b030287d6acb",\
-        "runtime_deps": [\
-            "@io_bazel_rules_scala_guava",\
-            "@io_bazel_rules_scala_mustache",\
-            "@io_bazel_rules_scala_scopt",\
-        ],\
-    },\
-    "io_bazel_rules_scala_util_core": {\
-        "artifact": "com.twitter:util-core_2.11:21.2.0",\
-        "sha256": "31c33d494ca5a877c1e5b5c1f569341e1d36e7b2c8b3fb0356fb2b6d4a3907ca",\
-    },\
-    "io_bazel_rules_scala_util_logging": {\
-        "artifact": "com.twitter:util-logging_2.11:21.2.0",\
-        "sha256": "f3b62465963fbf0fe9860036e6255337996bb48a1a3f21a29503a2750d34f319",\
-    },\
-}'
+  local TWITTER_SCROOGE_REPOSITORIES_21_2_0='scrooge_repositories(version = "21.2.0")'
 
   if [ "18.6.0" = $version_under_test ]; then
-    TWITTER_SCROOGE_ARTIFACTS=$TWITTER_SCROOGE_ARTIFACTS_18_6_0
+    TWITTER_SCROOGE_REPOSITORIES=$TWITTER_SCROOGE_REPOSITORIES_18_6_0
   elif [ "20.9.0" = $version_under_test ]; then
-    TWITTER_SCROOGE_ARTIFACTS=$TWITTER_SCROOGE_ARTIFACTS_20_9_0
+    TWITTER_SCROOGE_REPOSITORIES=$TWITTER_SCROOGE_REPOSITORIES_20_9_0
   else
     echo "Unknown Twitter Scrooge version given $version_under_test"
   fi

--- a/test_version.sh
+++ b/test_version.sh
@@ -7,7 +7,6 @@ scala_2_12_version="2.12.14"
 scala_2_13_version="2.13.6"
 
 SCALA_VERSION_DEFAULT=$scala_2_11_version
-SCALA_VERSION_SHAS_DEFAULT=$scala_2_11_shas
 TWITTER_SCROOGE_ARTIFACTS='twitter_scrooge_artifacts={}'
 
 diagnostics_reporter_toolchain="//:diagnostics_reporter_toolchain"
@@ -46,7 +45,6 @@ run_in_test_repo() {
   cp -r $test_target $NEW_TEST_DIR
 
   sed \
-      -e "s/\${scala_version}/$SCALA_VERSION/" \
       -e "s%\${twitter_scrooge_artifacts}%$TWITTER_SCROOGE_ARTIFACTS%" \
       -e "s%\${testing_toolchain}%$SCALA_TOOLCHAIN%" \
       WORKSPACE.template >> $NEW_TEST_DIR/WORKSPACE
@@ -65,14 +63,14 @@ run_in_test_repo() {
 test_scala_version() {
   local SCALA_VERSION="$1"
 
-  run_in_test_repo "bazel test //..." "scala_version" "version_specific_tests_dir/"
+  run_in_test_repo "bazel test //... --repo_env=SCALA_VERSION=${SCALA_VERSION}" "scala_version" "version_specific_tests_dir/"
 }
 
 test_reporter() {
   local SCALA_VERSION="$1"
   local SCALA_TOOLCHAIN="$2"
 
-  run_in_test_repo "compilation_should_fail build //..." "reporter" "test_reporter/"
+  run_in_test_repo "compilation_should_fail build //... --repo_env=SCALA_VERSION=${SCALA_VERSION}" "reporter" "test_reporter/"
 }
 
 test_twitter_scrooge_versions() {

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -41,9 +41,11 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
 
 scala_repositories(fetch_sources = True)
 
+load(":scrooge_repositories.bzl", "scrooge_repositories")
+${twitter_scrooge_repositories}
+
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
-${twitter_scrooge_artifacts}
-twitter_scrooge(overriden_artifacts = twitter_scrooge_artifacts)
+twitter_scrooge()
 
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
 
@@ -61,7 +63,7 @@ load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "
 
 scalatest_repositories()
 
-register_toolchains("${testing_toolchain}")
+register_toolchains("@io_bazel_rules_scala//testing:testing_toolchain")
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_toolchains")
 

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -31,9 +31,9 @@ local_repository(
     name = "io_bazel_rules_scala",
     path = "../../"
 )
-scala_version = "${scala_version}"
+
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
-scala_config(scala_version = scala_version)
+scala_config()
 
 load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "extract_major_version")
 

--- a/test_version/version_specific_tests_dir/scrooge_repositories.bzl
+++ b/test_version/version_specific_tests_dir/scrooge_repositories.bzl
@@ -1,0 +1,76 @@
+load(
+    "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
+    _scala_maven_import_external = "scala_maven_import_external",
+)
+load(
+    "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
+    "default_maven_server_urls",
+)
+
+def _import_external(id, artifact, sha256, deps = [], runtime_deps = []):
+    _scala_maven_import_external(
+        name = id,
+        artifact = artifact,
+        artifact_sha256 = sha256,
+        licenses = ["notice"],
+        server_urls = default_maven_server_urls(),
+        deps = deps,
+        runtime_deps = runtime_deps,
+        testonly_ = False,
+        fetch_sources = False,
+    )
+
+def scrooge_repositories(version):
+    if version == "18.6.0":
+        _import_external(
+            id = "io_bazel_rules_scala_scrooge_core",
+            artifact = "com.twitter:scrooge-core_2.11:18.6.0",
+            sha256 = "00351f73b555d61cfe7320ef3b1367a9641e694cfb8dfa8a733cfcf49df872e8",
+        )
+        _import_external(
+            id = "io_bazel_rules_scala_scrooge_generator",
+            artifact = "com.twitter:scrooge-generator_2.11:18.6.0",
+            sha256 = "0f0027e815e67985895a6f3caa137f02366ceeea4966498f34fb82cabb11dee6",
+            runtime_deps = [
+                "@io_bazel_rules_scala_guava",
+                "@io_bazel_rules_scala_mustache",
+                "@io_bazel_rules_scala_scopt",
+            ],
+        )
+        _import_external(
+            id = "io_bazel_rules_scala_util_core",
+            artifact = "com.twitter:util-core_2.11:18.6.0",
+            sha256 = "5336da4846dfc3db8ffe5ae076be1021828cfee35aa17bda9af461e203cf265c",
+        )
+        _import_external(
+            id = "io_bazel_rules_scala_util_logging",
+            artifact = "com.twitter:util-logging_2.11:18.6.0",
+            sha256 = "73ddd61cedabd4dab82b30e6c52c1be6c692b063b8ba310d716ead9e3b4e9267",
+        )
+
+    if version == "21.2.0":
+        _import_external(
+            id = "io_bazel_rules_scala_scrooge_core",
+            artifact = "com.twitter:scrooge-core_2.11:21.2.0",
+            sha256 = "d6cef1408e34b9989ea8bc4c567dac922db6248baffe2eeaa618a5b354edd2bb",
+        )
+        _import_external(
+            id = "io_bazel_rules_scala_scrooge_generator",
+            artifact = "com.twitter:scrooge-generator_2.11:21.2.0",
+            sha256 = "87094f01df2c0670063ab6ebe156bb1a1bcdabeb95bc45552660b030287d6acb",
+            runtime_deps = [
+                "@io_bazel_rules_scala_guava",
+                "@io_bazel_rules_scala_mustache",
+                "@io_bazel_rules_scala_scopt",
+            ],
+        )
+        _import_external(
+            id = "io_bazel_rules_scala_util_core",
+            artifact = "com.twitter:util-core_2.11:21.2.0",
+            sha256 = "31c33d494ca5a877c1e5b5c1f569341e1d36e7b2c8b3fb0356fb2b6d4a3907ca",
+        )
+        _import_external(
+            id = "io_bazel_rules_scala_util_logging",
+            artifact = "com.twitter:util-logging_2.11:21.2.0",
+            sha256 = "f3b62465963fbf0fe9860036e6255337996bb48a1a3f21a29503a2750d34f319",
+        )


### PR DESCRIPTION
- pass Scala version as a command line flag
- remove uses of artifact overrides in twitter scrooge setup
- move scrooge artifacts versions to bzl file for easier setup
- pass diagnostic toolchains as command line flags

Motivation: remove tech debt to have less work for upcoming Scala 3 related changes