### PR TITLE
set -e for ctx.actions.run_shell commands

### DIFF
--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -261,6 +261,7 @@ def _build_nosrc_jar(ctx):
     zipper_arg_path = ctx.actions.declare_file("%s_zipper_args" % ctx.label.name)
     ctx.actions.write(zipper_arg_path, resources)
     cmd = """
+set -e
 rm -f {jar_output}
 {zipper} c {jar_output} @{path}
 # ensures that empty src targets still emit a statsfile and a diagnosticsfile

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -261,7 +261,9 @@ def _build_nosrc_jar(ctx):
     zipper_arg_path = ctx.actions.declare_file("%s_zipper_args" % ctx.label.name)
     ctx.actions.write(zipper_arg_path, resources)
     cmd = """
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 rm -f {jar_output}
 {zipper} c {jar_output} @{path}
 # ensures that empty src targets still emit a statsfile and a diagnosticsfile

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -53,7 +53,10 @@ def _formatter(ctx, manifest, files, template, output_runner):
         inputs = [template, manifest] + files,
         outputs = [output_runner],
         # replace %workspace% and %manifest% in template and rewrite it to output_runner
-        command = "cat $1 | sed -e s#%workspace%#$2# -e s#%manifest%#$3# > $4",
+        command = """
+set -e
+cat $1 | sed -e s#%workspace%#$2# -e s#%manifest%#$3# > $4
+""",
         arguments = [
             template.path,
             ctx.workspace_name,

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -54,7 +54,9 @@ def _formatter(ctx, manifest, files, template, output_runner):
         outputs = [output_runner],
         # replace %workspace% and %manifest% in template and rewrite it to output_runner
         command = """
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 cat $1 | sed -e s#%workspace%#$2# -e s#%manifest%#$3# > $4
 """,
         arguments = [

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -77,7 +77,9 @@ def _thrift_library_impl(ctx):
         # We move the files and touch them so that the output file is a purely deterministic
         # product of the _content_ of the inputs
         cmd = """
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 rm -f {out}
 {zipper} c {out} @{path}
 """
@@ -104,7 +106,9 @@ rm -f {out}
             outputs = [ctx.outputs.libarchive],
             mnemonic = "ScalaThriftArchive",
             command = """
-set -e
+set -o errexit
+set -o nounset
+set -o pipefail
 echo "empty" > {out}.contents
 rm -f {out}
 {zipper} c {out} {out}.contents

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -77,6 +77,7 @@ def _thrift_library_impl(ctx):
         # We move the files and touch them so that the output file is a purely deterministic
         # product of the _content_ of the inputs
         cmd = """
+set -e
 rm -f {out}
 {zipper} c {out} @{path}
 """
@@ -103,6 +104,7 @@ rm -f {out}
             outputs = [ctx.outputs.libarchive],
             mnemonic = "ScalaThriftArchive",
             command = """
+set -e
 echo "empty" > {out}.contents
 rm -f {out}
 {zipper} c {out} {out}.contents


### PR DESCRIPTION
Actions might look like completed successfully even though one of the commands fail.
This might cause remote-cache poisoning.