### PR TITLE
Scalatest version bump to 3.2.9

### DIFF
--- a/examples/testing/multi_frameworks_toolchain/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/BUILD
@@ -36,6 +36,16 @@ declare_deps_provider(
     deps = [
         "@io_bazel_rules_scala_scalactic",
         "@io_bazel_rules_scala_scalatest",
+        "@io_bazel_rules_scala_scalatest_compatible",
+        "@io_bazel_rules_scala_scalatest_core",
+        "@io_bazel_rules_scala_scalatest_featurespec",
+        "@io_bazel_rules_scala_scalatest_flatspec",
+        "@io_bazel_rules_scala_scalatest_freespec",
+        "@io_bazel_rules_scala_scalatest_funspec",
+        "@io_bazel_rules_scala_scalatest_funsuite",
+        "@io_bazel_rules_scala_scalatest_matchers_core",
+        "@io_bazel_rules_scala_scalatest_mustmatchers",
+        "@io_bazel_rules_scala_scalatest_shouldmatchers",
     ],
 )
 

--- a/examples/testing/scalatest_repositories/example/ExampleTest.scala
+++ b/examples/testing/scalatest_repositories/example/ExampleTest.scala
@@ -3,7 +3,7 @@ package examples.testing.scalatest_repositories.example
 import org.scalatest.flatspec.AnyFlatSpec
 import org.scalatest.matchers.must.Matchers
 
-class ExampleTest extends FlatSpec with Matchers {
+class ExampleTest extends AnyFlatSpec with Matchers {
   "Exmaple" should "pass" in {
     1 must be(1)
   }

--- a/examples/testing/scalatest_repositories/example/ExampleTest.scala
+++ b/examples/testing/scalatest_repositories/example/ExampleTest.scala
@@ -1,8 +1,9 @@
 package examples.testing.scalatest_repositories.example
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers
 
-class ExampleTest extends FlatSpec with MustMatchers {
+class ExampleTest extends FlatSpec with Matchers {
   "Exmaple" should "pass" in {
     1 must be(1)
   }

--- a/scalatest/scalatest.bzl
+++ b/scalatest/scalatest.bzl
@@ -10,6 +10,16 @@ def scalatest_repositories(
     repositories(
         for_artifact_ids = [
             "io_bazel_rules_scala_scalatest",
+            "io_bazel_rules_scala_scalatest_compatible",
+            "io_bazel_rules_scala_scalatest_core",
+            "io_bazel_rules_scala_scalatest_featurespec",
+            "io_bazel_rules_scala_scalatest_flatspec",
+            "io_bazel_rules_scala_scalatest_freespec",
+            "io_bazel_rules_scala_scalatest_funsuite",
+            "io_bazel_rules_scala_scalatest_funspec",
+            "io_bazel_rules_scala_scalatest_matchers_core",
+            "io_bazel_rules_scala_scalatest_shouldmatchers",
+            "io_bazel_rules_scala_scalatest_mustmatchers",
             "io_bazel_rules_scala_scalactic",
         ],
         maven_servers = maven_servers,

--- a/test_version/version_specific_tests_dir/HelloLibTest.scala
+++ b/test_version/version_specific_tests_dir/HelloLibTest.scala
@@ -14,19 +14,19 @@
 
 package scalarules.test
 
-import org.scalatest._
+import org.scalatest.flatspec._
 
 object TestUtil {
   def foo: String = "bar"
 }
 
-class ScalaSuite extends FlatSpec {
+class ScalaSuite extends AnyFlatSpec {
   "HelloLib" should "call scala" in {
     assert(HelloLib.getOtherLibMessage("hello").equals("hello you all, everybody. I am Runtime"))
   }
 }
 
-class JavaSuite extends FlatSpec {
+class JavaSuite extends AnyFlatSpec {
   "HelloLib" should "call java" in {
     assert(HelloLib.getOtherJavaLibMessage("hello").equals("hello java!"))
   }

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -83,6 +83,16 @@ declare_deps_provider(
     deps = [
         "@io_bazel_rules_scala_scalactic",
         "@io_bazel_rules_scala_scalatest",
+        "@io_bazel_rules_scala_scalatest_compatible",
+        "@io_bazel_rules_scala_scalatest_core",
+        "@io_bazel_rules_scala_scalatest_featurespec",
+        "@io_bazel_rules_scala_scalatest_flatspec",
+        "@io_bazel_rules_scala_scalatest_freespec",
+        "@io_bazel_rules_scala_scalatest_funspec",
+        "@io_bazel_rules_scala_scalatest_funsuite",
+        "@io_bazel_rules_scala_scalatest_matchers_core",
+        "@io_bazel_rules_scala_scalatest_mustmatchers",
+        "@io_bazel_rules_scala_scalatest_shouldmatchers",
     ],
 )
 

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -12,12 +12,52 @@ artifacts = {
         "sha256": "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
     },
     "io_bazel_rules_scala_scalatest": {
-        "artifact": "org.scalatest:scalatest_2.11:3.1.2",
-        "sha256": "5a61de4a55b9bd1ce2b2936200c4d5b0b05d96ac9727d361ee37f7a5add5d86a",
+        "artifact": "org.scalatest:scalatest_2.11:3.2.9",
+        "sha256": "45affb34dd5b567fa943a7e155118ae6ab6c4db2fd34ca6a6c62ea129a1675be",
+    },
+    "io_bazel_rules_scala_scalatest_compatible": {
+        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.9",
+        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
+    },
+    "io_bazel_rules_scala_scalatest_core": {
+        "artifact": "org.scalatest:scalatest-core_2.11:3.2.9",
+        "sha256": "003cb40f78cbbffaf38203b09c776d06593974edf1883a933c1bbc0293a2f280",
+    },
+    "io_bazel_rules_scala_scalatest_featurespec": {
+        "artifact": "org.scalatest:scalatest-featurespec_2.11:3.2.9",
+        "sha256": "41567216bbd338625e77cd74ca669c88f59ff2da8adeb362657671bb43c4e462",
+    },
+    "io_bazel_rules_scala_scalatest_flatspec": {
+        "artifact": "org.scalatest:scalatest-flatspec_2.11:3.2.9",
+        "sha256": "3e89091214985782ff912559b7eb1ce085f6117db8cff65663e97325dc264b91",
+    },
+    "io_bazel_rules_scala_scalatest_freespec": {
+        "artifact": "org.scalatest:scalatest-freespec_2.11:3.2.9",
+        "sha256": "7c3e26ac0fa165263e4dac5dd303518660f581f0f8b0c20ba0b8b4a833ac9b9e",
+    },
+    "io_bazel_rules_scala_scalatest_funsuite": {
+        "artifact": "org.scalatest:scalatest-funsuite_2.11:3.2.9",
+        "sha256": "dc2100fe45b577c464f01933d8e605c3364dbac9ba24cd65222a5a4f3000717c",
+    },
+    "io_bazel_rules_scala_scalatest_funspec": {
+        "artifact": "org.scalatest:scalatest-funspec_2.11:3.2.9",
+        "sha256": "6ed2de364aacafcb3390144501ed4e0d24b7ff1431e8b9e6503d3af4bc160196",
+    },
+    "io_bazel_rules_scala_scalatest_matchers_core": {
+        "artifact": "org.scalatest:scalatest-matchers-core_2.11:3.2.9",
+        "sha256": "06eb7b5f3a8e8124c3a92e5c597a75ccdfa3fae022bc037770327d8e9c0759b4",
+    },
+    "io_bazel_rules_scala_scalatest_shouldmatchers": {
+        "artifact": "org.scalatest:scalatest-shouldmatchers_2.11:3.2.9",
+        "sha256": "444545c33a3af8d7a5166ea4766f376a5f2c209854c7eb630786c8cb3f48a706",
+    },
+    "io_bazel_rules_scala_scalatest_mustmatchers": {
+        "artifact": "org.scalatest:scalatest-mustmatchers_2.11:3.2.9",
+        "sha256": "b0ba6b9db7a2d1a4f7a3cf45b034b65481e31da8748abc2f2750cf22619d5a45",
     },
     "io_bazel_rules_scala_scalactic": {
-        "artifact": "org.scalactic:scalactic_2.11:3.1.2",
-        "sha256": "60642da4dcfa1e1fae02c394e9d8a1ce4c08f1b189bae86b8f3809310c12c29b",
+        "artifact": "org.scalactic:scalactic_2.11:3.2.9",
+        "sha256": "97b439fe61d1c655a8b29cdab8182b15b41b2308923786a348fc7b9f8f72b660",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.11:1.2.0",

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -12,12 +12,52 @@ artifacts = {
         "sha256": "497f4603e9d19dc4fa591cd467de5e32238d240bbd955d3dac6390b270889522",
     },
     "io_bazel_rules_scala_scalatest": {
-        "artifact": "org.scalatest:scalatest_2.12:3.1.2",
-        "sha256": "d7cb6c48e033d317dbb4a25c0514fb27538d798662f178c37235870a30da4f23",
+        "artifact": "org.scalatest:scalatest_2.12:3.2.9",
+        "sha256": "ed4a7e0a2373505ae5b9c4811fa2d2d167f5388556cdcb49bce11f27e18b90fa",
+    },
+    "io_bazel_rules_scala_scalatest_compatible": {
+        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.9",
+        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
+    },
+    "io_bazel_rules_scala_scalatest_core": {
+        "artifact": "org.scalatest:scalatest-core_2.12:3.2.9",
+        "sha256": "8d5bc6b847caaf221fa42cc214dcd1c70fd758aef384a2b6498463db0caf8e3c",
+    },
+    "io_bazel_rules_scala_scalatest_featurespec": {
+        "artifact": "org.scalatest:scalatest-featurespec_2.12:3.2.9",
+        "sha256": "f68bd68cd1f9fc5ccc3bbb004bb843bf01481886952e96e909933960a3365d00",
+    },
+    "io_bazel_rules_scala_scalatest_flatspec": {
+        "artifact": "org.scalatest:scalatest-flatspec_2.12:3.2.9",
+        "sha256": "bcec89594fda4fc4ffe3c98adaf8e9b7982011433d782b280fe54b6dc8b9f21f",
+    },
+    "io_bazel_rules_scala_scalatest_freespec": {
+        "artifact": "org.scalatest:scalatest-freespec_2.12:3.2.9",
+        "sha256": "097d551509cbb472d2367ea1b2060b0a27e36bad45ce5828ae2062867b5e8299",
+    },
+    "io_bazel_rules_scala_scalatest_funsuite": {
+        "artifact": "org.scalatest:scalatest-funsuite_2.12:3.2.9",
+        "sha256": "07b6eb20584bc684646dff58ac02019b97a74c2825644f09d514b7dd7cacf067",
+    },
+    "io_bazel_rules_scala_scalatest_funspec": {
+        "artifact": "org.scalatest:scalatest-funspec_2.12:3.2.9",
+        "sha256": "3d4d5b6e79c4398d0ff71f1ad4843f7eaf2acd0d197d782ee5f2437eb214ccf1",
+    },
+    "io_bazel_rules_scala_scalatest_matchers_core": {
+        "artifact": "org.scalatest:scalatest-matchers-core_2.12:3.2.9",
+        "sha256": "44e6bf24fb6fd4fd9419fcaf8d7e64b20c2916659f5d062d33f2de9a48ffdf09",
+    },
+    "io_bazel_rules_scala_scalatest_shouldmatchers": {
+        "artifact": "org.scalatest:scalatest-shouldmatchers_2.12:3.2.9",
+        "sha256": "2fce7f0f8cbfbc1a3bc65807cf389b01599ee78af459071e679ba5ed4884b4e2",
+    },
+    "io_bazel_rules_scala_scalatest_mustmatchers": {
+        "artifact": "org.scalatest:scalatest-mustmatchers_2.12:3.2.9",
+        "sha256": "e443fa6b4b741d1fb21c76ec204df39fec565ea817a3adb2b0b9be7c2a143041",
     },
     "io_bazel_rules_scala_scalactic": {
-        "artifact": "org.scalactic:scalactic_2.12:3.1.2",
-        "sha256": "3b32040bb6f60d8dd054746a9047ac99ee9e075dca752dde55ed72cd7915f54f",
+        "artifact": "org.scalactic:scalactic_2.12:3.2.9",
+        "sha256": "a5f01a0ecb7479b4f43e03147094279609d66fdaa04a9cb3238510d7c4dbc22a",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.12:1.2.0",

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -16,12 +16,52 @@ artifacts = {
         "sha256": "d15f22f1308b98e9ac52a3d1ac8d582d548d6d852b1116cbdf5a50f431246ed1",
     },
     "io_bazel_rules_scala_scalatest": {
-        "artifact": "org.scalatest:scalatest_2.13:3.1.2",
-        "sha256": "94b636ce8dc2caed3069069c97b94538e60e9a400833fb8086c8271978ad2c21",
+        "artifact": "org.scalatest:scalatest_2.13:3.2.9",
+        "sha256": "c5d283a5ec028bf06f83d70e2b88d70a149dd574d19e79e8389b49483914b08b",
+    },
+    "io_bazel_rules_scala_scalatest_compatible": {
+        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.9",
+        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
+    },
+    "io_bazel_rules_scala_scalatest_core": {
+        "artifact": "org.scalatest:scalatest-core_2.13:3.2.9",
+        "sha256": "b238f0e42edd471c8d066d25fa925d4c0cfae33b8db1ea79d14ff42047263e5d",
+    },
+    "io_bazel_rules_scala_scalatest_featurespec": {
+        "artifact": "org.scalatest:scalatest-featurespec_2.13:3.2.9",
+        "sha256": "f8ec83a39554c1e44f6ef5e13d9b87bf8257067b0dad8ee6012fec36e318036d",
+    },
+    "io_bazel_rules_scala_scalatest_flatspec": {
+        "artifact": "org.scalatest:scalatest-flatspec_2.13:3.2.9",
+        "sha256": "6a1bc2f522105b4eda53c225f3d5cbdabbf3e9375136dde57a5b43846369f75a",
+    },
+    "io_bazel_rules_scala_scalatest_freespec": {
+        "artifact": "org.scalatest:scalatest-freespec_2.13:3.2.9",
+        "sha256": "db3467bb0b34c1ca8d9830cf40179e2900ac01d5119f7a1b6bdcef30adb62214",
+    },
+    "io_bazel_rules_scala_scalatest_funsuite": {
+        "artifact": "org.scalatest:scalatest-funsuite_2.13:3.2.9",
+        "sha256": "d6455470fabc9f3a5a7a50770f6e1a4f4d0114122885637f3df684e5bb501f9d",
+    },
+    "io_bazel_rules_scala_scalatest_funspec": {
+        "artifact": "org.scalatest:scalatest-funspec_2.13:3.2.9",
+        "sha256": "821d13ced0bf96d1470538cbcca3109694148f2637961e5c502639e16ab7eee9",
+    },
+    "io_bazel_rules_scala_scalatest_matchers_core": {
+        "artifact": "org.scalatest:scalatest-matchers-core_2.13:3.2.9",
+        "sha256": "b86ed6f0986d005f4d54af5effdb73a18fe5741533f6663631d17a0731b9616f",
+    },
+    "io_bazel_rules_scala_scalatest_shouldmatchers": {
+        "artifact": "org.scalatest:scalatest-shouldmatchers_2.13:3.2.9",
+        "sha256": "39a4eefa409fed5a32eff3647aa4f80628202d966e3cb6a9f01e88dcfae75e4c",
+    },
+    "io_bazel_rules_scala_scalatest_mustmatchers": {
+        "artifact": "org.scalatest:scalatest-mustmatchers_2.13:3.2.9",
+        "sha256": "e170d4ff75f0e96458b7ec072accd40ff585f9e444b5831ba84287ff2da70f2c",
     },
     "io_bazel_rules_scala_scalactic": {
-        "artifact": "org.scalactic:scalactic_2.13:3.1.2",
-        "sha256": "6977c34cabeacca7c0d8f3be0c3f5644ddd922b4af7c32d5a59ca561807e728d",
+        "artifact": "org.scalactic:scalactic_2.13:3.2.9",
+        "sha256": "dcb853409202fee6f8e7216b363aab5b68edc07a51d27b61d5bf3fdf4418c9da",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.13:1.3.0",

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -34,12 +34,52 @@ artifacts = {
     },
     #
     "io_bazel_rules_scala_scalatest": {
-        "artifact": "org.scalatest:scalatest_2.13:3.1.2",
-        "sha256": "94b636ce8dc2caed3069069c97b94538e60e9a400833fb8086c8271978ad2c21",
+        "artifact": "org.scalatest:scalatest_3:3.2.9",
+        "sha256": "6a528ed38912f9c69bf2a1be157871fe801bbff590eecb1a56fa25c62570e147",
+    },
+    "io_bazel_rules_scala_scalatest_compatible": {
+        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.9",
+        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
+    },
+    "io_bazel_rules_scala_scalatest_core": {
+        "artifact": "org.scalatest:scalatest-core_3:3.2.9",
+        "sha256": "248674b6269578bc2f57d595f1e484fc02837ef567ba461eafb81294bce611a8",
+    },
+    "io_bazel_rules_scala_scalatest_featurespec": {
+        "artifact": "org.scalatest:scalatest-featurespec_3:3.2.9",
+        "sha256": "db51db398582b656cc0b90fbd1c6e5c2495125706b1f860b4cdfc5aba1832d0d",
+    },
+    "io_bazel_rules_scala_scalatest_flatspec": {
+        "artifact": "org.scalatest:scalatest-flatspec_3:3.2.9",
+        "sha256": "b558319f8b4835d25424381dc9b7dcc3b27353cf36dc2c28270dac59e8c8b827",
+    },
+    "io_bazel_rules_scala_scalatest_freespec": {
+        "artifact": "org.scalatest:scalatest-freespec_3:3.2.9",
+        "sha256": "dfcbce7d8315dca731b2829ad233893f2dec8895543267c086f7c88a618bda97",
+    },
+    "io_bazel_rules_scala_scalatest_funsuite": {
+        "artifact": "org.scalatest:scalatest-funsuite_3:3.2.9",
+        "sha256": "f3aa7a6414a6f0217ab386be38da537738239f073512a00e93967ac34ff3c9d3",
+    },
+    "io_bazel_rules_scala_scalatest_funspec": {
+        "artifact": "org.scalatest:scalatest-funspec_3:3.2.9",
+        "sha256": "a4d0b15fea0f73cc7af7f1e35ae291966f8652fbf811d6525294691fa6fb54d2",
+    },
+    "io_bazel_rules_scala_scalatest_matchers_core": {
+        "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.9",
+        "sha256": "4aee69baf7cbbd2f8c28e02fab7aead12093bf905b322a4aca9c987de58dffab",
+    },
+    "io_bazel_rules_scala_scalatest_shouldmatchers": {
+        "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.9",
+        "sha256": "5866c9f28faf5389a82d0a66f3539933325eed3a03425c9bf2f495c34f4bb370",
+    },
+    "io_bazel_rules_scala_scalatest_mustmatchers": {
+        "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.9",
+        "sha256": "2755b8558acf71603b70d10a02f9df43a216f305318dbcb442d5451f0da32c46",
     },
     "io_bazel_rules_scala_scalactic": {
-        "artifact": "org.scalactic:scalactic_2.13:3.1.2",
-        "sha256": "6977c34cabeacca7c0d8f3be0c3f5644ddd922b4af7c32d5a59ca561807e728d",
+        "artifact": "org.scalactic:scalactic_3:3.2.9",
+        "sha256": "dde6c79aeb8ca632ac9aede0a00462b6b75d0db857bf0e9f264a2ed36efcb800",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.13:1.3.0",


### PR DESCRIPTION
### Description
Updated `scalatest` to `3.2.9`.

Updated version introduces some breaking changes by [removing many of deprecated names](https://www.scalatest.org/release_notes/3.2.0#expiredDeprecations). These were used in some tests, e.g. (`FlatSpec`, `MustMatchers`).

### Motivation
Current version (`3.1.2`) does not support Scala 3, `3.2.9` is the lowest version [that does](https://index.scala-lang.org/artifacts/scalatest/scalatest). This PR updates updates to `3.2.9` across all Scala versions for sake of consistency.
