### PR TITLE
Use java_common.stamp_jar to stamp scala_import jar

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -2,7 +2,7 @@ load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("//scala/settings:stamp_settings.bzl", "StampScalaImport")
 
 def _stamp_jar(ctx, jar):
-    stamped_jar_filename = "%s.stamp/%s.jar" % (ctx.label.name, jar.basename.rstrip(".jar"))
+    stamped_jar_filename = "%s.stamp/%s" % (ctx.label.name, jar.basename)
     symlink_file = ctx.actions.declare_file(stamped_jar_filename)
     ctx.actions.symlink(output = symlink_file, target_file = jar)
     return java_common.stamp_jar(

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -2,7 +2,7 @@ load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("//scala/settings:stamp_settings.bzl", "StampScalaImport")
 
 def _stamp_jar(ctx, jar):
-    stamped_jar_filename = "%s.stamp/%s-stamped.jar" % (ctx.label.name, jar.basename.rstrip(".jar"))
+    stamped_jar_filename = "%s.stamp/%s.jar" % (ctx.label.name, jar.basename.rstrip(".jar"))
     symlink_file = ctx.actions.declare_file(stamped_jar_filename)
     ctx.actions.symlink(output = symlink_file, target_file = jar)
     return java_common.stamp_jar(

--- a/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/scala_import_stamp_test.bzl
@@ -6,14 +6,14 @@ def _assert_compile_dep_stamped(ctx):
     env = analysistest.begin(ctx)
     stamping_enabled = ctx.attr.stamp
     jar = ctx.attr.jar.files.to_list()[0].basename
-    expected_action_mnemonic = "StampWithIjar"
+    expected_action_mnemonic = "JavaIjar"
     expected_input = jar
     expected_stamped_output = jar.rstrip(".jar") + "-stamped.jar"
 
     target_under_test = analysistest.target_under_test(env)
 
     if stamping_enabled:
-        stamp_action = analysistest.target_actions(env)[0]
+        stamp_action = analysistest.target_actions(env)[1]
 
         actual_action_mnemonic = stamp_action.mnemonic
         asserts.equals(env, expected_action_mnemonic, actual_action_mnemonic)


### PR DESCRIPTION
Let's see if we can use ijar via java_common.stamp_jar

Fixes #1371 