### PR TITLE
Take --instrumentation_filter into account in coverage phase

### DIFF
--- a/test/shell/test_coverage_scalatest_resources.sh
+++ b/test/shell/test_coverage_scalatest_resources.sh
@@ -5,7 +5,9 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 test_coverage_succeeds_resource_call() {
-    bazel coverage //test/coverage_scalatest_resources/consumer:tests
+    bazel coverage \
+          --instrumentation_filter=^//test/coverage_scalatest_resources[:/] \
+          //test/coverage_scalatest_resources/consumer:tests
     diff test/coverage_scalatest_resources/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

Previously, all Scala code would be instrumented for coverage during a
bazel coverage run instead of only those source files that belong to
targets matching the instrumentation filter.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

Fixes https://github.com/bazelbuild/bazel/issues/15167.
