### PR TITLE
Update specs2 versions to 4.15.0 which has build for Scala 3

### DIFF
--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -261,34 +261,34 @@ artifacts = {
         "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
     },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
-        "artifact": "org.specs2:specs2-common_2.12:4.4.1",
-        "sha256": "7b7d2497bfe10ad552f5ab3780537c7db9961d0ae841098d5ebd91c78d09438a",
+        "artifact": "org.specs2:specs2-common_2.12:4.15.0",
+        "sha256": "69dd6d424ce779ee66eebfb0d1b9ed5a2660e46c49b5ebef0e9f5b4fcd37b648",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_fp",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_core": {
-        "artifact": "org.specs2:specs2-core_2.12:4.4.1",
-        "sha256": "f92c3c83844aac13250acec4eb247a2a26a2b3f04e79ef1bf42c56de4e0bb2e7",
+        "artifact": "org.specs2:specs2-core_2.12:4.15.0",
+        "sha256": "b48989de02a8a09bd9540c5cbe47c45e0b13901eef5e65fe872639aec3bd5362",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
             "@io_bazel_rules_scala_org_specs2_specs2_matcher",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
-        "artifact": "org.specs2:specs2-fp_2.12:4.4.1",
-        "sha256": "834a145b28dbf57ba6d96f02a3862522e693b5aeec44d4cb2f305ef5617dc73f",
+        "artifact": "org.specs2:specs2-fp_2.12:4.15.0",
+        "sha256": "baef13ecf394a9ef847e032cfdf9087e889889e87abbf8fb55c93b7e704711cc",
     },
     "io_bazel_rules_scala_org_specs2_specs2_matcher": {
-        "artifact": "org.specs2:specs2-matcher_2.12:4.4.1",
-        "sha256": "78c699001c307dcc5dcbec8a80cd9f14e9bdaa047579c3d1010ee4bea66805fe",
+        "artifact": "org.specs2:specs2-matcher_2.12:4.15.0",
+        "sha256": "f3e35a06cd8fd5337a04f585860f0126423b39582a0f9ac00cbbe1620c9d88e0",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
-        "artifact": "org.specs2:specs2-junit_2.12:4.4.1",
-        "sha256": "c867824801da5cccf75354da6d12d406009c435865ecd08a881b799790e9ffec",
+        "artifact": "org.specs2:specs2-junit_2.12:4.15.0",
+        "sha256": "643c88092f6dc48fb27790b82201210e557ff384941f797592183939eeda1350",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_core",
         ],

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -266,34 +266,34 @@ artifacts = {
         "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
     },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
-        "artifact": "org.specs2:specs2-common_2.13:4.10.3",
-        "sha256": "51636fb6a904b3c807de0673f283a971379c9886e03aedbecbf5d787b22346b0",
+        "artifact": "org.specs2:specs2-common_2.13:4.15.0",
+        "sha256": "919d9120415d625bc276b940badc71d1655c3b0b08c5e4724de5951e979021b3",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_fp",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_core": {
-        "artifact": "org.specs2:specs2-core_2.13:4.10.3",
-        "sha256": "9cc55eb11781c9b77689cf8175795fad34b060718b04a225fffb0613a181256b",
+        "artifact": "org.specs2:specs2-core_2.13:4.15.0",
+        "sha256": "ce8c9939a63bb64bce39be9a7fbba61e13f1b56e42617478a191bd38099e15d0",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
             "@io_bazel_rules_scala_org_specs2_specs2_matcher",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
-        "artifact": "org.specs2:specs2-fp_2.13:4.10.3",
-        "sha256": "48a908b345c93a3387ddd157ab338686513f450c7dd8afe0f32b6edc7ff15239",
+        "artifact": "org.specs2:specs2-fp_2.13:4.15.0",
+        "sha256": "980101e1af0e40e27e114ce40ff3cccdda505b6b139d1012c4e668cadfb7e3a8",
     },
     "io_bazel_rules_scala_org_specs2_specs2_matcher": {
-        "artifact": "org.specs2:specs2-matcher_2.13:4.10.3",
-        "sha256": "754465f58dad8f59b3bb299d5dc127027bf0c0c9ad25250260fc95abd705363b",
+        "artifact": "org.specs2:specs2-matcher_2.13:4.15.0",
+        "sha256": "fe75efe11feea1f1378739c293f4da80bc95ff1ed57da911f8d3517af19f5182",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
-        "artifact": "org.specs2:specs2-junit_2.13:4.10.3",
-        "sha256": "49c4e7cf5483aada90852314983fc046f72092da1a4e7900ace6574444f581ea",
+        "artifact": "org.specs2:specs2-junit_2.13:4.15.0",
+        "sha256": "205898d34c1694b95ca938df9f8533cbe3107701faefc6fd9b3ee88dc31f3219",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_core",
         ],

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -282,34 +282,34 @@ artifacts = {
         "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
     },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
-        "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
-        "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
+        "artifact": "org.specs2:specs2-common_3:jar:4.15.0",
+        "sha256": "b75b4070165791978d3cbfb44fed71c24b1658edff1bfb629258cffc0f8cd048",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_fp",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_core": {
-        "artifact": "org.specs2:specs2-core_3:jar:5.0.0-RC-21",
-        "sha256": "ad4197e181c5921e685ce30b38f8a536745c8f3728172df49f7be2256e675608",
+        "artifact": "org.specs2:specs2-core_3:jar:4.15.0",
+        "sha256": "55f217ba3bb35c4bf8626b202e4d8f5b7f88ed1945dcb93a303c466252a89178",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
             "@io_bazel_rules_scala_org_specs2_specs2_matcher",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
-        "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
-        "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "artifact": "org.specs2:specs2-fp_3:jar:4.15.0",
+        "sha256": "d097320ba21322e17aca16c2e9c0aa01eca7212e1e080f148fa3b3a71850722b",
     },
     "io_bazel_rules_scala_org_specs2_specs2_matcher": {
-        "artifact": "org.specs2:specs2-matcher_3:jar:5.0.0-RC-21",
-        "sha256": "e747c4f40f3a96bfec5ac4a4af7d6b8b8f6f74b2412513752730888f75050e0b",
+        "artifact": "org.specs2:specs2-matcher_3:jar:4.15.0",
+        "sha256": "4840bd5a4cb92c3cb54b6d1241c08d54e9105fc4f6d345a8aaa2eadbd0dd0387",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_common",
         ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
-        "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",
-        "sha256": "7e8b2c8ab10e6ea1ee471fb0313ad4c81963f326aa66efc4a2f476815ac4f8d9",
+        "artifact": "org.specs2:specs2-junit_3:jar:4.15.0",
+        "sha256": "fd48b0f8294caf0396dc5e32fb0c10fa60e5b30eec5bf2fa1ee1e9c7e236b675",
         "deps": [
             "@io_bazel_rules_scala_org_specs2_specs2_core",
         ],


### PR DESCRIPTION
This change is part of Scala 3 support work.

5.0.0-RC-21 version used in Scala 3 repositories is not compatible with many features we use in Rules Scala tests.

Specs2 4.15.0 was released which has a build for Scala 3. Updating repositories for 2.12, 2.13 and 3.1 to this version. There is no release for 2.11 anymore.
