### PR TITLE
Allow `scala_junit_tests` targets to specify test environment variables

### DIFF
--- a/scala/private/phases/phase_test_environment.bzl
+++ b/scala/private/phases/phase_test_environment.bzl
@@ -2,7 +2,7 @@
 # https://bazel.build/rules/lib/testing#TestEnvironment
 
 def phase_test_environment(ctx, p):
-    test_env = getattr(ctx.attr, "env", None)
+    test_env = ctx.attr.env
 
     if test_env:
         return struct(

--- a/scala/private/phases/phase_test_environment.bzl
+++ b/scala/private/phases/phase_test_environment.bzl
@@ -2,14 +2,13 @@
 # https://bazel.build/rules/lib/testing#TestEnvironment
 
 def phase_test_environment(ctx, p):
-
     test_env = ctx.attr.env if "env" in dir(ctx.attr) else None
 
     if test_env:
         return struct(
-          external_providers = {
-            "TestingEnvironment": testing.TestEnvironment(test_env)
-          }
+            external_providers = {
+                "TestingEnvironment": testing.TestEnvironment(test_env),
+            },
         )
 
     return struct()

--- a/scala/private/phases/phase_test_environment.bzl
+++ b/scala/private/phases/phase_test_environment.bzl
@@ -1,0 +1,15 @@
+# Adds testing.TestEnvironment provider if "env" attr is specified
+# https://bazel.build/rules/lib/testing#TestEnvironment
+
+def phase_test_environment(ctx, p):
+
+    test_env = ctx.attr.env if "env" in dir(ctx.attr) else None
+
+    if test_env:
+        return struct(
+          external_providers = {
+            "TestingEnvironment": testing.TestEnvironment(test_env)
+          }
+        )
+
+    return struct()

--- a/scala/private/phases/phase_test_environment.bzl
+++ b/scala/private/phases/phase_test_environment.bzl
@@ -2,7 +2,7 @@
 # https://bazel.build/rules/lib/testing#TestEnvironment
 
 def phase_test_environment(ctx, p):
-    test_env = ctx.attr.env if "env" in dir(ctx.attr) else None
+    test_env = getattr(ctx.attr, "env", None)
 
     if test_env:
         return struct(

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -90,6 +90,7 @@ def _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wra
         inputs = [cpfile],
         executable = ctx.attr._exe.files_to_run.executable,
         arguments = [executable.path, ctx.workspace_name, java_for_exe, main_class, cpfile.path, jvm_flags_str],
+        env = ctx.attr.env,
         mnemonic = "ExeLauncher",
         progress_message = "Creating exe launcher",
     )

--- a/scala/private/phases/phases.bzl
+++ b/scala/private/phases/phases.bzl
@@ -64,6 +64,8 @@ load("@io_bazel_rules_scala//scala/private:phases/phase_merge_jars.bzl", _phase_
 load("@io_bazel_rules_scala//scala/private:phases/phase_jvm_flags.bzl", _phase_jvm_flags = "phase_jvm_flags")
 load("@io_bazel_rules_scala//scala/private:phases/phase_coverage_runfiles.bzl", _phase_coverage_runfiles = "phase_coverage_runfiles")
 load("@io_bazel_rules_scala//scala/private:phases/phase_scalafmt.bzl", _phase_scalafmt = "phase_scalafmt")
+load("@io_bazel_rules_scala//scala/private:phases/phase_test_environment.bzl", _phase_test_environment = "phase_test_environment")
+
 
 # API
 run_phases = _run_phases
@@ -135,6 +137,9 @@ phase_runfiles_common = _phase_runfiles_common
 
 # default_info
 phase_default_info = _phase_default_info
+
+# test_environment
+phase_test_environment = _phase_test_environment
 
 # scalafmt
 phase_scalafmt = _phase_scalafmt

--- a/scala/private/phases/phases.bzl
+++ b/scala/private/phases/phases.bzl
@@ -66,7 +66,6 @@ load("@io_bazel_rules_scala//scala/private:phases/phase_coverage_runfiles.bzl", 
 load("@io_bazel_rules_scala//scala/private:phases/phase_scalafmt.bzl", _phase_scalafmt = "phase_scalafmt")
 load("@io_bazel_rules_scala//scala/private:phases/phase_test_environment.bzl", _phase_test_environment = "phase_test_environment")
 
-
 # API
 run_phases = _run_phases
 extras_phases = _extras_phases

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -23,6 +23,7 @@ load(
     "phase_merge_jars",
     "phase_runfiles_common",
     "phase_scalac_provider",
+    "phase_test_environment",
     "phase_write_executable_junit_test",
     "phase_write_manifest",
     "run_phases",
@@ -52,6 +53,7 @@ def _scala_junit_test_impl(ctx):
             ("jvm_flags", phase_jvm_flags),
             ("write_executable", phase_write_executable_junit_test),
             ("default_info", phase_default_info),
+            ("test_environment", phase_test_environment),
         ],
     )
 
@@ -75,6 +77,7 @@ _scala_junit_test_attrs = {
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
         providers = [java_common.JavaRuntimeInfo],
     ),
+    "env": attr.string_dict(default = {}),
     "_junit_classpath": attr.label(
         default = Label("@io_bazel_rules_scala//testing/toolchain:junit_classpath"),
     ),

--- a/test/BUILD
+++ b/test/BUILD
@@ -777,41 +777,23 @@ scala_junit_test(
     runtime_deps = [":JunitRuntimePlatform"],
 )
 
-scala_library(
-    name = "JunitNoTestEnvironment",
-    srcs = [
-        "src/main/scala/scalarules/test/junit/JunitNoTestEnvironmentTest.scala",
-    ],
-    deps = ["@io_bazel_rules_scala_junit_junit"],
-)
-
-scala_library(
-    name = "JunitSetTestEnvironment",
-    srcs = [
-        "src/main/scala/scalarules/test/junit/JunitSetTestEnvironmentTest.scala",
-    ],
-    deps = ["@io_bazel_rules_scala_junit_junit"],
-)
-
 scala_junit_test(
-    name = "JunitNoTestEnvironment_test_runner",
+    name = "JunitNoTestEnvironmentTest",
     size = "small",
-    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    srcs = ["src/main/scala/scalarules/test/junit/JunitNoTestEnvironmentTest.scala"],
     suffixes = ["Test"],
-    tests_from = [":JunitNoTestEnvironment"],
-    runtime_deps = [":JunitNoTestEnvironment"],
+    deps = ["@io_bazel_rules_scala_junit_junit"],
 )
 
 scala_junit_test(
-    name = "JunitSetTestEnvironment_test_runner",
+    name = "JunitSetTestEnvironmentTest",
     size = "small",
+    srcs = ["src/main/scala/scalarules/test/junit/JunitSetTestEnvironmentTest.scala"],
     env = {
         "my_env_var": "my_value",
     },
-    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
     suffixes = ["Test"],
-    tests_from = [":JunitSetTestEnvironment"],
-    runtime_deps = [":JunitSetTestEnvironment"],
+    deps = ["@io_bazel_rules_scala_junit_junit"],
 )
 
 py_binary(

--- a/test/BUILD
+++ b/test/BUILD
@@ -777,6 +777,43 @@ scala_junit_test(
     runtime_deps = [":JunitRuntimePlatform"],
 )
 
+scala_library(
+    name = "JunitNoTestEnvironment",
+    srcs = [
+        "src/main/scala/scalarules/test/junit/JunitNoTestEnvironmentTest.scala",
+    ],
+    deps = ["@io_bazel_rules_scala_junit_junit"],
+)
+
+scala_library(
+    name = "JunitSetTestEnvironment",
+    srcs = [
+        "src/main/scala/scalarules/test/junit/JunitSetTestEnvironmentTest.scala",
+    ],
+    deps = ["@io_bazel_rules_scala_junit_junit"],
+)
+
+scala_junit_test(
+    name = "JunitNoTestEnvironment_test_runner",
+    size = "small",
+    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    suffixes = ["Test"],
+    tests_from = [":JunitNoTestEnvironment"],
+    runtime_deps = [":JunitNoTestEnvironment"],
+)
+
+scala_junit_test(
+    name = "JunitSetTestEnvironment_test_runner",
+    size = "small",
+    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    suffixes = ["Test"],
+    env = {
+        "my_env_var": "my_value"
+    },
+    tests_from = [":JunitSetTestEnvironment"],
+    runtime_deps = [":JunitSetTestEnvironment"],
+)
+
 py_binary(
     name = "py_resource_binary",
     srcs = ["py_resource.py"],

--- a/test/BUILD
+++ b/test/BUILD
@@ -805,11 +805,11 @@ scala_junit_test(
 scala_junit_test(
     name = "JunitSetTestEnvironment_test_runner",
     size = "small",
+    env = {
+        "my_env_var": "my_value",
+    },
     runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
     suffixes = ["Test"],
-    env = {
-        "my_env_var": "my_value"
-    },
     tests_from = [":JunitSetTestEnvironment"],
     runtime_deps = [":JunitSetTestEnvironment"],
 )

--- a/test/src/main/scala/scalarules/test/junit/JunitNoTestEnvironmentTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/JunitNoTestEnvironmentTest.scala
@@ -1,0 +1,15 @@
+package scalarules.test.junit
+
+import org.junit.Assert.fail
+import org.junit.Test
+
+class JunitNoTestEnvironmentTest {
+
+  @Test
+  def testUnsetEnvVarIsNull: Unit = {
+    System.getenv("my_unset_env_var") match {
+      case null => ()
+      case x => fail(s"Unexpectedly obtained my_unset_env_var=$x")
+    }
+  }
+} 

--- a/test/src/main/scala/scalarules/test/junit/JunitSetTestEnvironmentTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/JunitSetTestEnvironmentTest.scala
@@ -1,0 +1,17 @@
+package scalarules.test.junit
+
+import org.junit.Assert
+import org.junit.Assert.fail
+import org.junit.Test
+
+class JunitSetTestEnvironmentTest {
+  
+  @Test
+  def testSetEnvVarEqualsValue: Unit = {
+    System.getenv("my_unset_env_var") match {
+      case null => ()
+      case x => fail(s"Unexpectedly obtained my_unset_env_var=$x")
+    }
+    Assert.assertEquals(System.getenv("my_env_var"), "my_value")  
+  }
+} 


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Add the equivalent of `java_test`'s `env` attr to `scala_junit_tests` via `TestEnvironment` provider.
Allows targets to set their own environment variables during `bazel test` runs.


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->
https://bazel.build/reference/be/common-definitions#test.env


### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
We would like to test with environment variables different from the ones defaulted to by a `bazel test` invocation, on a target-specified basis. This also brings our test rules further in line with the functionality offered by native test rules.
