### PR TITLE
Consistent argsfile parsing

### DIFF
--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -81,7 +81,14 @@ public final class Worker {
           int code = 0;
 
           try {
-            workerInterface.work(stringListToArray(request.getArgumentsList()));
+            String[] workerArgs = stringListToArray(request.getArgumentsList());
+            String[] args;
+            if (workerArgs.length == 1) {
+              args = expandArgsfile(workerArgs[0]);
+            } else {
+              args = workerArgs;
+            }
+            workerInterface.work(args);
           } catch (ExitTrapped e) {
             code = e.code;
           } catch (Exception e) {
@@ -116,14 +123,21 @@ public final class Worker {
   private static void ephemeralWorkerMain(String workerArgs[], Interface workerInterface)
       throws Exception {
     String[] args;
-    if (workerArgs.length == 1 && workerArgs[0].startsWith("@")) {
-      args =
-          stringListToArray(
-              Files.readAllLines(Paths.get(workerArgs[0].substring(1)), StandardCharsets.UTF_8));
+    if (workerArgs.length == 1) {
+      args = expandArgsfile(workerArgs[0]);
     } else {
       args = workerArgs;
     }
     workerInterface.work(args);
+  }
+
+  private static String[] expandArgsfile(String filepath) throws IOException {
+    if (filepath.startsWith("@")) {
+      return stringListToArray(
+              Files.readAllLines(Paths.get(filepath.substring(1)), StandardCharsets.UTF_8));
+    } else {
+      return new String[] { filepath };
+    }
   }
 
   /**

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -82,12 +82,7 @@ public final class Worker {
 
           try {
             String[] workerArgs = stringListToArray(request.getArgumentsList());
-            String[] args;
-            if (workerArgs.length == 1) {
-              args = expandArgsfile(workerArgs[0]);
-            } else {
-              args = workerArgs;
-            }
+            String[] args = expandArgsIfArgsfile(workerArgs);
             workerInterface.work(args);
           } catch (ExitTrapped e) {
             code = e.code;
@@ -122,21 +117,20 @@ public final class Worker {
   /** The single pass runner for ephemeral (non-persistent) worker processes */
   private static void ephemeralWorkerMain(String workerArgs[], Interface workerInterface)
       throws Exception {
-    String[] args;
-    if (workerArgs.length == 1) {
-      args = expandArgsfile(workerArgs[0]);
-    } else {
-      args = workerArgs;
-    }
+    String[] args = expandArgsIfArgsfile(workerArgs);
     workerInterface.work(args);
   }
 
-  private static String[] expandArgsfile(String filepath) throws IOException {
-    if (filepath.startsWith("@")) {
-      return stringListToArray(
-              Files.readAllLines(Paths.get(filepath.substring(1)), StandardCharsets.UTF_8));
+  private static String[] expandArgsIfArgsfile(String[] allArgs) throws IOException {
+    if (allArgs.length == 1 && allArgs[0].startsWith("@")) {
+        return stringListToArray(
+                Files.readAllLines(
+                  Paths.get(allArgs[0].substring(1)),
+                  StandardCharsets.UTF_8)
+                );
+      
     } else {
-      return new String[] { filepath };
+      return allArgs;
     }
   }
 


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
`Worker`s should parse argsfiles/flagfiles regardless of being persistent or ephemeral.  
This doesn't change the behavior of only allowing argsfiles when called with a single argument.


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Our functionality will be more in line with Bazel's `JavaBuilder`.  
This is also helpful for persistent workers outside of Bazel itself (e.g. on remote executors).  
Instead of expanding argsfiles, remote executors can pass in the argsfile as if it were an ephemeral invocation.

