### PR TITLE
Use a public java_compile_toolchain attr instead of _java_toolchain

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -28,6 +28,10 @@ common_attrs_for_plugin_bootstrapping = {
     "resources": attr.label_list(allow_files = True),
     "resource_strip_prefix": attr.string(),
     "resource_jars": attr.label_list(allow_files = True),
+    "java_compile_toolchain": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+        providers = [java_common.JavaToolchainInfo],
+    ),
     "scalacopts": attr.string_list(),
     "javacopts": attr.string_list(),
     "scalac_jvm_flags": attr.string_list(),
@@ -88,9 +92,6 @@ implicit_deps = {
         cfg = "host",
         default = Label("@bazel_tools//tools/zip:zipper"),
         allow_files = True,
-    ),
-    "_java_toolchain": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
     ),
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -3,7 +3,6 @@
 #
 # DOCUMENT THIS
 #
-load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
 load(
     "@io_bazel_rules_scala//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
@@ -15,6 +14,7 @@ load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
     _compile_java = "compile_java",
     _compile_scala = "compile_scala",
+    "specified_java_compile_toolchain",
 )
 load(":resources.bzl", _resource_paths = "paths")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
@@ -217,7 +217,7 @@ def _compile_or_empty(
                 ctx.actions,
                 jar = ctx.outputs.jar,
                 target_label = ctx.label,
-                java_toolchain = find_java_toolchain(ctx, ctx.attr.java_compile_toolchain),
+                java_toolchain = specified_java_compile_toolchain(ctx),
             )
         else:
             #  macro code needs to be available at compile-time,
@@ -333,7 +333,7 @@ def _pack_source_jar(ctx, scala_srcs, input_srcjars):
             output_source_jar = output_source_jar,
             sources = scala_srcs,
             source_jars = input_srcjars,
-            java_toolchain = find_java_toolchain(ctx, ctx.attr.java_compile_toolchain),
+            java_toolchain = specified_java_compile_toolchain(ctx),
         )
 
 def _try_to_compile_java_jar(

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -217,7 +217,7 @@ def _compile_or_empty(
                 ctx.actions,
                 jar = ctx.outputs.jar,
                 target_label = ctx.label,
-                java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
+                java_toolchain = find_java_toolchain(ctx, ctx.attr.java_compile_toolchain),
             )
         else:
             #  macro code needs to be available at compile-time,
@@ -333,7 +333,7 @@ def _pack_source_jar(ctx, scala_srcs, input_srcjars):
             output_source_jar = output_source_jar,
             sources = scala_srcs,
             source_jars = input_srcjars,
-            java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
+            java_toolchain = find_java_toolchain(ctx, ctx.attr.java_compile_toolchain),
         )
 
 def _try_to_compile_java_jar(

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -12,9 +12,9 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "specified_java_compile_toolchain",
     _compile_java = "compile_java",
     _compile_scala = "compile_scala",
-    "specified_java_compile_toolchain",
 )
 load(":resources.bzl", _resource_paths = "paths")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -141,6 +141,9 @@ def compile_scala(
     )
 
 def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, providers_of_dependencies):
+
+    java_toolchain = find_java_toolchain(ctx, ctx.attr.java_compile_toolchain)\
+    
     return java_common.compile(
         ctx,
         source_jars = source_jars,
@@ -150,7 +153,7 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
             ctx,
             extra_javac_opts +
             java_common.default_javac_opts(
-                java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo],
+                java_toolchain = java_toolchain,
             ),
         ),
         deps = providers_of_dependencies,
@@ -159,7 +162,7 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
         #workaround until https://github.com/bazelbuild/bazel/issues/3528 is resolved
         exports = [],
         neverlink = getattr(ctx.attr, "neverlink", False),
-        java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
+        java_toolchain = java_toolchain,
         strict_deps = ctx.fragments.java.strict_java_deps,
     )
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -141,9 +141,8 @@ def compile_scala(
     )
 
 def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, providers_of_dependencies):
-
     java_toolchain = specified_java_compile_toolchain(ctx)
-    
+
     return java_common.compile(
         ctx,
         source_jars = source_jars,
@@ -175,7 +174,7 @@ def specified_java_compile_toolchain(ctx):
     java_compile_toolchain = getattr(
         ctx.attr,
         "java_compile_toolchain",
-        getattr(ctx.attr, "_java_toolchain", None)
+        getattr(ctx.attr, "_java_toolchain", None),
     )
 
     return find_java_toolchain(ctx, java_compile_toolchain)

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -142,7 +142,7 @@ def compile_scala(
 
 def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, providers_of_dependencies):
 
-    java_toolchain = find_java_toolchain(ctx, ctx.attr.java_compile_toolchain)\
+    java_toolchain = specified_java_compile_toolchain(ctx)
     
     return java_common.compile(
         ctx,
@@ -168,6 +168,17 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
 
 def runfiles_root(ctx):
     return "${TEST_SRCDIR}/%s" % ctx.workspace_name
+
+def specified_java_compile_toolchain(ctx):
+    # Aspects such as scrooge_java_aspect are not allowed public label attrs
+    # And so will still use an implicit _java_toolchain
+    java_compile_toolchain = getattr(
+        ctx.attr,
+        "java_compile_toolchain",
+        getattr(ctx.attr, "_java_toolchain", None)
+    )
+
+    return find_java_toolchain(ctx, java_compile_toolchain)
 
 def specified_java_runtime(ctx, default_runtime = None):
     use_specified_java = "runtime_jdk" in dir(ctx.attr)

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -1,5 +1,9 @@
 load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("//scala/settings:stamp_settings.bzl", "StampScalaImport")
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "specified_java_compile_toolchain",
+)
 
 def _stamp_jar(ctx, jar):
     stamped_jar_filename = "%s.stamp/%s" % (ctx.label.name, jar.basename)
@@ -9,7 +13,7 @@ def _stamp_jar(ctx, jar):
         actions = ctx.actions,
         jar = symlink_file,
         target_label = ctx.label,
-        java_toolchain = ctx.attr.java_compile_toolchain[java_common.JavaToolchainInfo],
+        java_toolchain = specified_java_compile_toolchain(ctx),
     )
 
 # intellij part is tested manually, tread lightly when changing there

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -9,7 +9,7 @@ def _stamp_jar(ctx, jar):
         actions = ctx.actions,
         jar = symlink_file,
         target_label = ctx.label,
-        java_toolchain = ctx.attr._java_toolchain[java_common.JavaToolchainInfo],
+        java_toolchain = ctx.attr.java_compile_toolchain[java_common.JavaToolchainInfo],
     )
 
 # intellij part is tested manually, tread lightly when changing there
@@ -139,7 +139,7 @@ scala_import = rule(
             doc = "Adds Target-Label attribute to MANIFEST.MF for dep tracking",
             default = Label("@io_bazel_rules_scala//scala/settings:stamp_scala_import"),
         ),
-        "_java_toolchain": attr.label(
+        "java_compile_toolchain": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
         ),
     },

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -1,12 +1,12 @@
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("//scala/private:common.bzl", "write_manifest_file")
 load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_protobuf_scrooge")
-load("//scala/private:rule_impls.bzl", "compile_scala")
-load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(
-    "@bazel_tools//tools/jdk:toolchain_utils.bzl",
-    "find_java_toolchain",
+    "//scala/private:rule_impls.bzl",
+    "compile_scala",
+    "specified_java_compile_toolchain"
 )
+load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(
     "@io_bazel_rules_scala//scala_proto/private:scala_proto_aspect_provider.bzl",
     "ScalaProtoAspectInfo",
@@ -51,7 +51,7 @@ def _pack_sources(ctx, src_jars):
         ctx.actions,
         source_jars = src_jars,
         output_source_jar = ctx.actions.declare_file(ctx.label.name + "_scalapb-src.jar"),
-        java_toolchain = find_java_toolchain(ctx, ctx.attr.compile_java_toolchain),
+        java_toolchain = specified_java_compile_toolchain(ctx),
     )
 
 def _generate_sources(ctx, toolchain, proto):

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -4,7 +4,7 @@ load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_proto
 load(
     "//scala/private:rule_impls.bzl",
     "compile_scala",
-    "specified_java_compile_toolchain"
+    "specified_java_compile_toolchain",
 )
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -51,7 +51,7 @@ def _pack_sources(ctx, src_jars):
         ctx.actions,
         source_jars = src_jars,
         output_source_jar = ctx.actions.declare_file(ctx.label.name + "_scalapb-src.jar"),
-        java_toolchain = find_java_toolchain(ctx, ctx.attr._java_toolchain),
+        java_toolchain = find_java_toolchain(ctx, ctx.attr.compile_java_toolchain),
     )
 
 def _generate_sources(ctx, toolchain, proto):

--- a/test/BUILD
+++ b/test/BUILD
@@ -485,13 +485,13 @@ scala_binary(
 # Make sure scala_library respects java_compile_toolchain during builds
 scala_junit_test(
     name = "CheckBytecodeMajorVersion",
+    srcs = ["CheckBytecodeMajorVersionTest.scala"],
+    suffixes = ["Test"],
     runtime_deps = [
-        "//test/src/main/resources/java_sources:CompiledWithJava8",
         "//test/src/main/resources/java_sources:CompiledWithJava11",
+        "//test/src/main/resources/java_sources:CompiledWithJava8",
     ],
     deps = ["@io_bazel_rules_scala_junit_junit"],
-    suffixes = ["Test"],
-    srcs = ["CheckBytecodeMajorVersionTest.scala"],
 )
 
 # Generate a file containing the rootpaths of a Scala binary.

--- a/test/BUILD
+++ b/test/BUILD
@@ -482,6 +482,18 @@ scala_binary(
     runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
+# Make sure scala_library respects java_compile_toolchain during builds
+scala_junit_test(
+    name = "CheckBytecodeMajorVersion",
+    runtime_deps = [
+        "//test/src/main/resources/java_sources:CompiledWithJava8",
+        "//test/src/main/resources/java_sources:CompiledWithJava11",
+    ],
+    deps = ["@io_bazel_rules_scala_junit_junit"],
+    suffixes = ["Test"],
+    srcs = ["CheckBytecodeMajorVersionTest.scala"],
+)
+
 # Generate a file containing the rootpaths of a Scala binary.
 genrule(
     name = "rootpath-script",
@@ -775,6 +787,22 @@ scala_junit_test(
     suffixes = ["Test"],
     tests_from = [":JunitRuntimePlatform"],
     runtime_deps = [":JunitRuntimePlatform"],
+)
+
+scala_junit_test(
+    name = "JunitCompilePlatformTest",
+    size = "small",
+    srcs = [
+        "src/main/scala/scalarules/test/junit/compile_platform/JunitCompilePlatformTest.java",
+        "src/main/scala/scalarules/test/junit/compile_platform/JunitCompilePlatform2Test.scala",
+    ],
+    scalacopts = [
+        "-release",
+        "11"
+    ],
+    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java9",
+    suffixes = ["Test"],
+    deps = ["@io_bazel_rules_scala_junit_junit"],
 )
 
 scala_junit_test(

--- a/test/BUILD
+++ b/test/BUILD
@@ -790,22 +790,6 @@ scala_junit_test(
 )
 
 scala_junit_test(
-    name = "JunitCompilePlatformTest",
-    size = "small",
-    srcs = [
-        "src/main/scala/scalarules/test/junit/compile_platform/JunitCompilePlatformTest.java",
-        "src/main/scala/scalarules/test/junit/compile_platform/JunitCompilePlatform2Test.scala",
-    ],
-    scalacopts = [
-        "-release",
-        "11"
-    ],
-    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java9",
-    suffixes = ["Test"],
-    deps = ["@io_bazel_rules_scala_junit_junit"],
-)
-
-scala_junit_test(
     name = "JunitNoTestEnvironmentTest",
     size = "small",
     srcs = ["src/main/scala/scalarules/test/junit/JunitNoTestEnvironmentTest.scala"],

--- a/test/CheckBytecodeMajorVersionTest.scala
+++ b/test/CheckBytecodeMajorVersionTest.scala
@@ -1,0 +1,48 @@
+package scalarules.test
+
+import java.nio.file.Files
+import java.io.InputStream
+
+import org.junit.Assert;
+import org.junit.Test;
+
+class CheckBytecodeMajorVersionTest {
+
+  // https://stackoverflow.com/questions/27065/tool-to-read-and-display-java-class-versions
+  def getBytecodeMajorVersion(classFileInput: InputStream): Int = {
+    val eighthByte = classFileInput.readNBytes(8)(7)
+    eighthByte.toInt
+  }
+
+  // https://stackoverflow.com/questions/9170832/list-of-java-class-file-format-major-version-numbers
+  val majorVersionToJdkVersion = Map(
+    52 -> 8,
+    55 -> 11
+  )
+
+  @Test
+  def someTest(): Unit = {
+
+    val expectJava8 = getBytecodeMajorVersion(
+      getClass
+        .getClassLoader
+        .getResourceAsStream("java_sources/SimpleJavaSourceFileA.class")
+    )
+
+    val expectJava11 =  getBytecodeMajorVersion(
+      getClass
+        .getClassLoader
+        .getResourceAsStream("java_sources/SimpleJavaSourceFileB.class")
+    )
+      
+    Assert.assertTrue(
+      s"Expected java 8 (major version 52) but got major version $expectJava8",
+      majorVersionToJdkVersion(expectJava8) == 8
+    )
+      
+    Assert.assertTrue(
+      s"Expected java 11 (major version 55) but got major version $expectJava8",
+      majorVersionToJdkVersion(expectJava11) == 11
+    )
+  }
+}

--- a/test/CheckBytecodeMajorVersionTest.scala
+++ b/test/CheckBytecodeMajorVersionTest.scala
@@ -35,14 +35,16 @@ class CheckBytecodeMajorVersionTest {
         .getResourceAsStream("java_sources/SimpleJavaSourceFileB.class")
     )
       
-    Assert.assertTrue(
-      s"Expected java 8 (major version 52) but got major version $expectJava8",
-      majorVersionToJdkVersion(expectJava8) == 8
+    Assert.assertEquals(
+      s"Expected Java 8 bytecode (major version 52) but got major version $expectJava8",
+      8,
+      majorVersionToJdkVersion(expectJava8)
     )
       
-    Assert.assertTrue(
-      s"Expected java 11 (major version 55) but got major version $expectJava8",
-      majorVersionToJdkVersion(expectJava11) == 11
+    Assert.assertEquals(
+      s"Expected Java 11 bytecode (major version 55) but got major version $expectJava11",
+      11,
+      majorVersionToJdkVersion(expectJava11)
     )
   }
 }

--- a/test/src/main/resources/java_sources/BUILD
+++ b/test/src/main/resources/java_sources/BUILD
@@ -1,15 +1,15 @@
 load("//scala:scala.bzl", "scala_library")
 
-package(default_visibility=["//visibility:public"])
+package(default_visibility = ["//visibility:public"])
 
 scala_library(
     name = "CompiledWithJava8",
     srcs = ["SimpleJavaSourceFileA.java"],
-    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java8"
+    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java8",
 )
 
 scala_library(
     name = "CompiledWithJava11",
     srcs = ["SimpleJavaSourceFileB.java"],
-    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java11"
+    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java11",
 )

--- a/test/src/main/resources/java_sources/BUILD
+++ b/test/src/main/resources/java_sources/BUILD
@@ -1,0 +1,15 @@
+load("//scala:scala.bzl", "scala_library")
+
+package(default_visibility=["//visibility:public"])
+
+scala_library(
+    name = "CompiledWithJava8",
+    srcs = ["SimpleJavaSourceFileA.java"],
+    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java8"
+)
+
+scala_library(
+    name = "CompiledWithJava11",
+    srcs = ["SimpleJavaSourceFileB.java"],
+    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java11"
+)

--- a/test/src/main/resources/java_sources/SimpleJavaSourceFileA.java
+++ b/test/src/main/resources/java_sources/SimpleJavaSourceFileA.java
@@ -1,0 +1,11 @@
+package java_sources;
+
+public class SimpleJavaSourceFileA {
+
+  public int someIntField;
+
+  public SimpleJavaSourceFileA() {
+    this.someIntField = 0;
+  }
+  
+}

--- a/test/src/main/resources/java_sources/SimpleJavaSourceFileB.java
+++ b/test/src/main/resources/java_sources/SimpleJavaSourceFileB.java
@@ -1,0 +1,11 @@
+package java_sources;
+
+public class SimpleJavaSourceFileB {
+
+  public int someIntField;
+
+  public SimpleJavaSourceFileB() {
+    this.someIntField = 0;
+  }
+  
+}

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -370,6 +370,8 @@ def _common_scrooge_aspect_implementation(target, ctx, language, compiler_functi
     This aspect is applied to the DAG of thrift_librarys reachable from a deps or a scrooge_scala_library.
     Each thrift_library will be one scrooge invocation, assuming it has some sources.
     """
+    print("target??")
+    print(target)
     (
         target_ti,
         transitive_ti,

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -370,8 +370,6 @@ def _common_scrooge_aspect_implementation(target, ctx, language, compiler_functi
     This aspect is applied to the DAG of thrift_librarys reachable from a deps or a scrooge_scala_library.
     Each thrift_library will be one scrooge invocation, assuming it has some sources.
     """
-    print("target??")
-    print(target)
     (
         target_ti,
         transitive_ti,


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Allow per-target selection of Java compilation toolchain.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->
Note: This change doesn't add similar functionality to `thrift_library`.

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Helps with JDK migrations by allowing targets to incrementally update.  
Also allows targets to opt into newer Java syntax.

Co-authored-by: Shane Delmore <sdelmore@twitter.com>
