### PR TITLE
scala_doc: Use param file to build scaladocs

### DIFF
--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -83,6 +83,8 @@ def _scala_doc_impl(ctx):
     # Construct scaladoc args, which also include scalac args.
     # See `scaladoc -help` for more information.
     args = ctx.actions.args()
+    args.set_param_file_format("multiline")
+    args.use_param_file(param_file_arg = "@%s", use_always = True)
     args.add("-usejavacp")
     args.add("-nowarn")  # turn off warnings for now since they can obscure actual errors for large scala_doc targets
     args.add_all(ctx.attr.scalacopts)


### PR DESCRIPTION
### Description

Generate `scaladoc` by providing arguments via param file.

### Motivation

When we have a large set of dependencies or source files, `scaladoc` generation fails with the following error,
```
error=7, Argument list too long
``` 
Scaladoc supports reading arguments from an argfile which can help avoid the above problem,
```sh
$ scaladoc -help
...
  @<file>                              A text file containing compiler arguments (options and source files)
```
We can do this by using [param file](https://bazel.build/rules/lib/Args#use_param_file).