### PR TITLE
add package_name

### DIFF
--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -18,6 +18,8 @@ def _generators_opts(ctx):
         opts.append("grpc")
     if ctx.attr.with_flat_package:
         opts.append("flat_package")
+    if ctx.attr.with_package_name:
+        opts.append("package_name")
     if ctx.attr.with_single_line_to_string:
         opts.append("single_line_to_proto_string")
     return ",".join(opts)
@@ -62,6 +64,7 @@ def _scala_proto_toolchain_impl(ctx):
 #     with_grpc: Enables generation of grpc service bindings for services
 #     with_flat_package: When true, ScalaPB will not append the protofile base name to the package name
 #     with_single_line_to_string: Enables generation of toString() methods that use the single line format
+#     with_package_name: sets the Scala base package name, if option is also not the found, then the package name from file's package statement is used.
 #     blacklisted_protos: list of protobuf targets to exclude from recursive building
 #     code_generator: what code generator to use, usually you'll want the default
 scala_proto_toolchain = rule(
@@ -70,6 +73,7 @@ scala_proto_toolchain = rule(
         "with_grpc": attr.bool(),
         "with_flat_package": attr.bool(),
         "with_single_line_to_string": attr.bool(),
+        "with_package_name": attr.bool(),
         "blacklisted_protos": attr.label_list(default = []),
         "code_generator": attr.label(
             executable = True,


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

Support `package_name` option https://scalapb.github.io/docs/customizations/

```
package_name sets the Scala base package name, if this is not defined, then it falls back to the java_package option. If the java_package option is also not the found, then the package name from file's package statement is used.
```


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

Classpath collisions... need to rename the generated classes