### PR TITLE
scala_doc: Include transitive runtime jars in classpath

### DIFF
--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -34,6 +34,7 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
             direct = [file for file in ctx.rule.files.deps],
             transitive = (
                 [dep[JavaInfo].compile_jars for dep in ctx.rule.attr.deps if JavaInfo in dep] +
+                [dep[JavaInfo].transitive_runtime_jars for dep in ctx.rule.attr.deps if JavaInfo in dep] +
                 [dep[_ScaladocAspectInfo].compile_jars for dep in ctx.rule.attr.deps if _ScaladocAspectInfo in dep]
             ),
         )

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -33,7 +33,6 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
         compile_jars = depset(
             direct = [file for file in ctx.rule.files.deps],
             transitive = (
-                [dep[JavaInfo].compile_jars for dep in ctx.rule.attr.deps if JavaInfo in dep] +
                 [dep[JavaInfo].transitive_runtime_jars for dep in ctx.rule.attr.deps if JavaInfo in dep] +
                 [dep[_ScaladocAspectInfo].compile_jars for dep in ctx.rule.attr.deps if _ScaladocAspectInfo in dep]
             ),


### PR DESCRIPTION
### Description

Some of our targets require additional jars on the classpath for scaladoc generation to be successful. This seems to be solved by including the `transitive_runtime_jars` on the classpath.

### Motivation

Fix compilation of some our targets which require additional jars on the classpath.