### PR TITLE
Expose `_source_jars` output group in `scala_import`

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -57,12 +57,14 @@ def _scala_import_impl(ctx):
         # TODO(#8867): Migrate away from the placeholder jar hack when #8867 is fixed.
         current_target_providers = [_new_java_info(ctx, ctx.file._placeholder_jar, ctx.file._placeholder_jar)]
 
+    merged_providers = java_common.merge(current_target_providers)
     return [
-        java_common.merge(current_target_providers),
+        merged_providers,
         DefaultInfo(
             files = compile_jars_depset,
         ),
         JarsToLabelsInfo(jars_to_labels = jars2labels),
+        OutputGroupInfo(_source_jars = merged_providers.source_jars),
     ]
 
 def _new_java_info(ctx, jar, stamped_jar):

--- a/test/src/main/scala/scalarules/test/scala_import/srcjar/BUILD.bazel
+++ b/test/src/main/scala/scalarules/test/scala_import/srcjar/BUILD.bazel
@@ -1,0 +1,41 @@
+load("@rules_java//java:defs.bzl", "java_import")
+load("//scala:scala_import.bzl", "scala_import")
+load(":exposes_srcjar_test.bzl", "exposes_srcjar_test")
+
+scala_import(
+    name = "my-scala-import",
+    jars = [":my-jar"],
+    srcjar = ":my-src-jar",
+)
+
+java_import(
+    name = "my-java-import",
+    jars = [":my-jar"],
+    srcjar = ":my-src-jar",
+)
+
+exposes_srcjar_test(
+    name = "scala",
+    source_jar = "my-src-jar",
+    target_under_test = "my-scala-import",
+)
+
+exposes_srcjar_test(
+    name = "java",
+    source_jar = "my-src-jar",
+    target_under_test = "my-java-import",
+)
+
+genrule(
+    name = "my-jar",
+    srcs = [],
+    outs = ["my-jar.jar"],
+    cmd = "touch \"$@\"",
+)
+
+genrule(
+    name = "my-src-jar",
+    srcs = [],
+    outs = ["my-src-jar.jar"],
+    cmd = "touch \"$@\"",
+)

--- a/test/src/main/scala/scalarules/test/scala_import/srcjar/exposes_srcjar_test.bzl
+++ b/test/src/main/scala/scalarules/test/scala_import/srcjar/exposes_srcjar_test.bzl
@@ -1,0 +1,33 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _assert_exposes_srcjar(ctx):
+    env = analysistest.begin(ctx)
+    target_under_test = analysistest.target_under_test(env)
+    expected_source_jar = ctx.file.source_jar
+
+    asserts.true(
+        env,
+        OutputGroupInfo in target_under_test,
+        msg = "provider 'OutputGroupinfo' is not provided by target_under_test.",
+    )
+
+    output_group_info = target_under_test[OutputGroupInfo]
+    asserts.true(
+        env,
+        "_source_jars" in output_group_info,
+        msg = "provider 'OutputGroupInfo' doesn't contain '_source_jars' info.",
+    )
+
+    actual_source_jars = output_group_info["_source_jars"].to_list()
+    asserts.equals(
+        env,
+        [expected_source_jar],
+        actual_source_jars,
+    )
+
+    return analysistest.end(env)
+
+exposes_srcjar_test = analysistest.make(
+    _assert_exposes_srcjar,
+    attrs = {"source_jar": attr.label(allow_single_file = True)},
+)


### PR DESCRIPTION
### Description
Previously, `scala_import` rules would have no `OutputGroupInfo`, and
therefore would not expose their source jars. Java's counterpart,
`java_import`, does expose the source jars via an entry named
`_source_jars` in `OutputGroupInfo`.

This patch adds an `OutputGroupInfo` provider to `scala_import` rules
containing the source jars in an entry named `_source_jars`.

The source jars of a `scala_import` rule can now be requested by
passing `--output_groups=+_source_jars` to Bazel.

### Motivation
Querying Bazel for the source jars can be useful in a variety of situations, like IDE integration for instance.