### PR TITLE
Fix rules_scala JDK lookup when using --nolegacy_external_runfiles.

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -191,7 +191,7 @@ def java_bin(ctx):
         default_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo],
     )
 
-    java_path = str(java_runtime.java_executable_exec_path)
+    java_path = str(java_runtime.java_executable_runfiles_path)
 
     if paths.is_absolute(java_path):
         javabin = java_path

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -24,7 +24,7 @@ $runner bazel test "--extra_toolchains=//scala:minimal_direct_source_deps -- tes
 $runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn"
 $runner bazel build //test_expect_failure/proto_source_root/... --strict_proto_deps=off
 $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
-$runner build test:ScalaBinaryInGenrule --nolegacy_external_runfiles
+$runner bazel build test:ScalaBinaryInGenrule --nolegacy_external_runfiles
 $runner bazel build //test_statsfile:Simple_statsfile
 $runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
 . "${test_dir}"/test_build_event_protocol.sh

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -24,6 +24,7 @@ $runner bazel test "--extra_toolchains=//scala:minimal_direct_source_deps -- tes
 $runner bazel build "test_expect_failure/missing_direct_deps/internal_deps/... --strict_java_deps=warn --extra_toolchains=//test/toolchains:high_level_transitive_deps_strict_deps_warn"
 $runner bazel build //test_expect_failure/proto_source_root/... --strict_proto_deps=off
 $runner bazel test //test/... --extra_toolchains="//test_expect_failure/plus_one_deps:plus_one_deps"
+$runner build test:ScalaBinaryInGenrule --nolegacy_external_runfiles
 $runner bazel build //test_statsfile:Simple_statsfile
 $runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolchains="//test/toolchains:enable_stats_file_disabled_toolchain"
 . "${test_dir}"/test_build_event_protocol.sh


### PR DESCRIPTION
java_executable_exec_path does not look up the right path when resolving
the JDK from the runfiles directory and legacy_external_runfiles is disabled.
java_executable_runfiles_path should be used instead.

Examples of these paths when running "bazel build test:ScalaBinaryInGenrule":

java_executable_exec_path: external/remotejdk11_macos/bin/java
java_executable_runfiles_path: ../remotejdk11_macos/bin/java

The working directory appears to be
ScalaBinary.runfiles/io_bazel_rules_scala.

When legacy_external_runfiles is enabled, the JDK is present in
ScalaBinary.runfiles/remotejdk11_macos but is also linked
in ScalaBinary.runfiles/io_bazel_rules_scala/external/remotejdk11_macos,
so looking up using either exec_path or runfiles_path is correct.

When legacy_external_runfiles is disabled, the JDK only goes in
ScalaBinary.runfiles/remotejdk11_macos, so only runfiles_path will work.

Fixes #1396 