### PR TITLE
feat: added support for inherited_environment in scala_test rule

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -62,6 +62,18 @@ tasks:
     bazel: 4.1.0
     shell_commands:
       - "./test_coverage.sh"
+  test_bazel_52_linux:
+    name: "./test_bazel_5_2"
+    platform: ubuntu2004
+    bazel: 5.2.0rc2
+    shell_commands:
+      - "./test_bazel_5_2.sh"
+  test_bazel_52_macos:
+    name: "./test_bazel_5_2"
+    platform: macos
+    bazel: 5.2.0rc2
+    shell_commands:
+      - "./test_bazel_5_2.sh "
   test_reproducibility_linux:
     name: "./test_reproducibility.sh"
     platform: ubuntu1804

--- a/docs/scala_test.md
+++ b/docs/scala_test.md
@@ -15,6 +15,7 @@ scala_test(
     scalac_jvm_flags,
     javac_jvm_flags,
     unused_dependency_checker_mode
+    env_inherit
 )
 ```
 
@@ -26,3 +27,5 @@ By default, `scala_test` runs _all_ tests in a given target.
 For backwards compatibility, it accepts a `suites` attribute which
 is ignored due to the ease with which that field is not correctly
 populated and tests are not run.
+
+Note: If you need to pass environment variables to your tests, you can use `env_inherit` with the list of environment variables names to pass. This flag require Bazel version 5.2 rc0 or higher.

--- a/scala/private/phases/phase_test_environment.bzl
+++ b/scala/private/phases/phase_test_environment.bzl
@@ -3,12 +3,36 @@
 
 def phase_test_environment(ctx, p):
     test_env = ctx.attr.env
+    inherited_environment = ctx.attr.env_inherit
 
-    if test_env:
+    if inherited_environment and test_env:
         return struct(
             external_providers = {
-                "TestingEnvironment": testing.TestEnvironment(test_env),
+                "TestingEnvironment": testing.TestEnvironment(
+                    test_env,
+                    inherited_environment,
+                ),
             },
         )
 
-    return struct()
+    elif test_env:
+        return struct(
+            external_providers = {
+                "TestingEnvironment": testing.TestEnvironment(
+                    test_env,
+                ),
+            },
+        )
+
+    elif inherited_environment:
+        return struct(
+            external_providers = {
+                "TestingEnvironment": testing.TestEnvironment(
+                    {},
+                    inherited_environment,
+                ),
+            },
+        )
+
+    else:
+        return struct()

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -78,6 +78,7 @@ _scala_junit_test_attrs = {
         providers = [java_common.JavaRuntimeInfo],
     ),
     "env": attr.string_dict(default = {}),
+    "env_inherit": attr.string_list(),
     "_junit_classpath": attr.label(
         default = Label("@io_bazel_rules_scala//testing/toolchain:junit_classpath"),
     ),

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -23,6 +23,7 @@ load(
     "phase_merge_jars",
     "phase_runfiles_scalatest",
     "phase_scalac_provider",
+    "phase_test_environment",
     "phase_write_executable_scalatest",
     "phase_write_manifest",
     "run_phases",
@@ -47,6 +48,7 @@ def _scala_test_impl(ctx):
             ("coverage_runfiles", phase_coverage_runfiles),
             ("write_executable", phase_write_executable_scalatest),
             ("default_info", phase_default_info),
+            ("test_environment", phase_test_environment),
         ],
     )
 
@@ -75,6 +77,8 @@ _scala_test_attrs = {
     "_lcov_merger": attr.label(
         default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
     ),
+    "env": attr.string_dict(default = {}),
+    "env_inherit": attr.string_list(),
 }
 
 _test_resolve_deps = {

--- a/test/shell/test_inherited_environment.sh
+++ b/test/shell/test_inherited_environment.sh
@@ -1,0 +1,11 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+function test_inherited_environment() {
+  a=b bazel test //test_bazel_5_2/inherited_environment:a
+}
+
+$runner test_inherited_environment

--- a/test_bazel_5_2.sh
+++ b/test_bazel_5_2.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+
+set -e
+
+if ! bazel_loc="$(type -p 'bazel')" || [[ -z "$bazel_loc" ]]; then
+  export PATH="$(cd "$(dirname "$0")"; pwd)"/tools:$PATH
+  echo 'Using ./tools/bazel directly for bazel calls'
+fi
+
+test_dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )/test/shell
+# shellcheck source=./test_runner.sh
+. "${test_dir}"/test_runner.sh
+runner=$(get_test_runner "${1:-local}")
+
+. "${test_dir}"/test_inherited_environment.sh

--- a/test_bazel_5_2/inherited_environment/A.scala
+++ b/test_bazel_5_2/inherited_environment/A.scala
@@ -1,0 +1,8 @@
+import org.scalatest.funsuite._
+import org.scalatest.matchers.should._
+
+class A extends AnyFunSuite with Matchers {
+  test("number is positive") {
+    sys.env("a") should equal("b")
+  }
+}

--- a/test_bazel_5_2/inherited_environment/BUILD
+++ b/test_bazel_5_2/inherited_environment/BUILD
@@ -1,0 +1,7 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+
+scala_test(
+    name = "a",
+    srcs = ["A.scala"],
+    env_inherit = ["a"],
+)


### PR DESCRIPTION
### Description
Added support for `inherited_environment` in `scala_test` rule

Follow up on this [slack thread](https://bazelbuild.slack.com/archives/CDCKJ2KFZ/p1653986701998679) I added support for the new `inherited_environment`  to `scala_test`.
This feature requires Bazel version 5.2 rc0 or higher.

### Motivation
While Bazel run tests in isolated environments, when running integration tests there is a need to pass env vars to the tested code - for example, credentials for external systems like databases. This PR added a new flag that is already supported by Bazel.

Note: I am a total noob. I got a lot of help on Slack in order to get to this point but I am not 100% understand everything I changed 🤦  I added a test so I know it is working, I will be helping to have some guidelines on how to run it only on Bazel 5.2:
* Passing a flag to `test_rules_scala` and let it know it should run this test?
* Add another shell file running only my test?
* Other option?

Also - where and how should I document it?