### PR TITLE
phase_merge_jars: refactor to separate function that merges jars to o…

### DIFF
--- a/scala/private/phases/phase_merge_jars.bzl
+++ b/scala/private/phases/phase_merge_jars.bzl
@@ -4,35 +4,38 @@
 # DOCUMENT THIS
 #
 
-def phase_merge_jars(ctx, p):
+def merge_jars_to_output(ctx, output, jars):
     """Calls Bazel's singlejar utility.
 
     For a full list of available command line options see:
     https://github.com/bazelbuild/bazel/blob/697d219526bffbecd29f29b402c9122ec5d9f2ee/src/java_tools/singlejar/java/com/google/devtools/build/singlejar/SingleJar.java#L337
     Use --compression to reduce size of deploy jars.
     """
-    deploy_jar = ctx.outputs.deploy_jar
-    runtime_jars = p.compile.rjars
     main_class = getattr(ctx.attr, "main_class", "")
-    progress_message = "Merging Scala jar: %s" % ctx.label
+    progress_message = "Merging Scala jar %s: %s" % (output, ctx.label)
     args = ctx.actions.args()
     args.add_all(["--compression", "--normalize", "--sources"])
-    args.add_all(runtime_jars, map_each = _fileToPath)
+    args.add_all(jars, map_each = _fileToPath)
 
     if main_class:
         args.add_all(["--main_class", main_class])
-    args.add_all(["--output", deploy_jar.path])
+    args.add_all(["--output", output.path])
 
     args.set_param_file_format("multiline")
     args.use_param_file("@%s")
     ctx.actions.run(
-        inputs = runtime_jars,
-        outputs = [deploy_jar],
+        inputs = jars,
+        outputs = [output],
         executable = ctx.executable._singlejar,
         mnemonic = "ScalaDeployJar",
         progress_message = progress_message,
         arguments = [args],
     )
+
+def phase_merge_jars(ctx, p):
+    deploy_jar = ctx.outputs.deploy_jar
+    runtime_jars = p.compile.rjars
+    merge_jars_to_output(ctx, deploy_jar, runtime_jars)
 
 def _fileToPath(file):
     return file.path


### PR DESCRIPTION
…utput

### Description
Add a new function that is independent of runtime jars and the specific output.

### Motivation
This is a small refactoring as an intermediate step for possible extensions for creating
custom outputs. Not sure yet how to add those extensions, but such a refactoring here may be very useful.

An example how this can be changed further:

https://github.com/gergelyfabian/rules_scala/compare/refactor_phase_merge_jars...gergelyfabian:external-and-internal-deploy-jar?expand=1
