### PR TITLE
scala_doc: Export ScaladocAspectInfo to allow users to build custom scaladoc aspects

### DIFF
--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -2,7 +2,7 @@
 
 load("@io_bazel_rules_scala//scala/private:common.bzl", "collect_plugin_paths")
 
-_ScaladocAspectInfo = provider(fields = [
+ScaladocAspectInfo = provider(fields = [
     "src_files",
     "compile_jars",
     "plugins",
@@ -23,7 +23,7 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
         # Sometimes we only want to generate scaladocs for a single target and not all of its
         # dependencies
         if transitive:
-            transitive_deps = [dep[_ScaladocAspectInfo].src_files for dep in ctx.rule.attr.deps if _ScaladocAspectInfo in dep]
+            transitive_deps = [dep[ScaladocAspectInfo].src_files for dep in ctx.rule.attr.deps if ScaladocAspectInfo in dep]
         else:
             transitive_deps = []
 
@@ -34,7 +34,7 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
             direct = [file for file in ctx.rule.files.deps],
             transitive = (
                 [dep[JavaInfo].compile_jars for dep in ctx.rule.attr.deps if JavaInfo in dep] +
-                [dep[_ScaladocAspectInfo].compile_jars for dep in ctx.rule.attr.deps if _ScaladocAspectInfo in dep]
+                [dep[ScaladocAspectInfo].compile_jars for dep in ctx.rule.attr.deps if ScaladocAspectInfo in dep]
             ),
         )
 
@@ -42,7 +42,7 @@ def _scaladoc_aspect_impl(target, ctx, transitive = True):
         if hasattr(ctx.rule.attr, "plugins"):
             plugins = depset(direct = ctx.rule.attr.plugins)
 
-        return [_ScaladocAspectInfo(
+        return [ScaladocAspectInfo(
             src_files = src_files,
             compile_jars = compile_jars,
             plugins = plugins,
@@ -71,11 +71,11 @@ def _scala_doc_impl(ctx):
     output_path = ctx.actions.declare_directory("{}.html".format(ctx.attr.name))
 
     # Collect all source files and compile_jars to pass to scaladoc by way of an aspect.
-    src_files = depset(transitive = [dep[_ScaladocAspectInfo].src_files for dep in ctx.attr.deps])
-    compile_jars = depset(transitive = [dep[_ScaladocAspectInfo].compile_jars for dep in ctx.attr.deps])
+    src_files = depset(transitive = [dep[ScaladocAspectInfo].src_files for dep in ctx.attr.deps])
+    compile_jars = depset(transitive = [dep[ScaladocAspectInfo].compile_jars for dep in ctx.attr.deps])
 
     # Get the 'real' paths to the plugin jars.
-    plugins = collect_plugin_paths(depset(transitive = [dep[_ScaladocAspectInfo].plugins for dep in ctx.attr.deps]).to_list())
+    plugins = collect_plugin_paths(depset(transitive = [dep[ScaladocAspectInfo].plugins for dep in ctx.attr.deps]).to_list())
 
     # Construct the full classpath depset since we need to add compiler plugins too.
     classpath = depset(transitive = [plugins, compile_jars])

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -12,6 +12,7 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:rules/scala_doc.bzl",
+    _ScaladocAspectInfo = "ScaladocAspectInfo",
     _make_scala_doc_rule = "make_scala_doc_rule",
     _scaladoc_intransitive_aspect = "scaladoc_intransitive_aspect",
 )
@@ -56,6 +57,7 @@ scala_binary = _scala_binary
 make_scala_doc_rule = _make_scala_doc_rule
 scaladoc_intransitive_aspect = _scaladoc_intransitive_aspect
 scala_doc = _make_scala_doc_rule()
+ScaladocAspectInfo = _ScaladocAspectInfo
 scala_junit_test = _scala_junit_test
 scala_library = _scala_library
 scala_library_for_plugin_bootstrapping = _scala_library_for_plugin_bootstrapping


### PR DESCRIPTION
### Description
Export `ScaladocAspectInfo` to allow users to provide custom aspect implementation to `make_scala_doc_rule`

### Motivation
Some of our scala rules require extra jars to be present on the classpath because of custom rules present in our repo. Its hard to replicate this requirement in tests (#1393 for more information). Exporting the `ScaladocAspectInfo` helps us build a custom aspect implementation for `make_scala_doc_rule` based on some of the custom rules in our repo.
