### PR TITLE
Test the build for: Fix JacocoInstrumenter with JDK 13+

### DIFF
--- a/src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java
+++ b/src/java/io/bazel/rulesscala/coverage/instrumenter/JacocoInstrumenter.java
@@ -51,7 +51,7 @@ public final class JacocoInstrumenter implements Worker.Interface {
 
     JarCreator jarCreator = new JarCreator(outPath);
 
-    try (FileSystem inFS = FileSystems.newFileSystem(inPath, null)) {
+    try (FileSystem inFS = FileSystems.newFileSystem(inPath, (ClassLoader) null)) {
       FileVisitor fileVisitor =
           createInstrumenterVisitor(jacoco, instrumentedClassesDirectory, jarCreator);
       inFS.getRootDirectories()


### PR DESCRIPTION
Following
https://github.com/bazelbuild/bazel/issues/10214
https://github.com/bazelbuild/bazel/commit/0216ee54417fa1f2fef14f6eb14cbc1e8f595821

FileSystems.newFileSystem becomes ambiguous on 2nd parameter when it is null.
So adding explicit type annotation.

https://docs.oracle.com/javase/7/docs/api/java/nio/file/FileSystems.html

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
