### PR TITLE
Declare non-windows executable with .sh extension

### DIFF
--- a/docs/scala_repl.md
+++ b/docs/scala_repl.md
@@ -21,5 +21,5 @@ Instead, use `bazel build` to build the script, then run that script as normal t
 An example in this repo:
 ```
 bazel build test:HelloLibRepl
-bazel-bin/test/HelloLibRepl
+bazel-bin/test/HelloLibRepl.sh
 ```

--- a/scala/private/phases/phase_declare_executable.bzl
+++ b/scala/private/phases/phase_declare_executable.bzl
@@ -15,5 +15,5 @@ def phase_declare_executable(ctx, p):
         )
     else:
         return struct(
-            executable = ctx.actions.declare_file(ctx.label.name),
+            executable = ctx.actions.declare_file("%s.sh" % ctx.label.name),
         )

--- a/test/BUILD
+++ b/test/BUILD
@@ -472,6 +472,7 @@ scala_specs2_junit_test(
     "//test/src/main/scala/scalarules/test/large_classpath:largeClasspath",
     "//test:test_scala_proto_server",
     "//test:scala_binary_jdk_11",
+    "//test/artifact_prefix_conflict_example/example:example"
 ]]
 
 # Make sure scala_binary respects runtime_jdk on bazel run

--- a/test/BUILD
+++ b/test/BUILD
@@ -472,7 +472,7 @@ scala_specs2_junit_test(
     "//test/src/main/scala/scalarules/test/large_classpath:largeClasspath",
     "//test:test_scala_proto_server",
     "//test:scala_binary_jdk_11",
-    "//test/artifact_prefix_conflict_example/example:example"
+    "//test/artifact_prefix_conflict_example/example:example",
 ]]
 
 # Make sure scala_binary respects runtime_jdk on bazel run

--- a/test/artifact_prefix_conflict_example/example/ArtifactPrefixConflictExample.scala
+++ b/test/artifact_prefix_conflict_example/example/ArtifactPrefixConflictExample.scala
@@ -1,0 +1,8 @@
+package example
+
+import example.Somefile
+
+object ArtifactPrefixConflictExample extends App {
+  println(s"Using Somefile: $Somefile")
+  println("In ArtifactPrefixConflictExample.scala")
+}

--- a/test/artifact_prefix_conflict_example/example/BUILD
+++ b/test/artifact_prefix_conflict_example/example/BUILD
@@ -1,0 +1,9 @@
+load("//scala:scala.bzl", "scala_binary")
+
+scala_binary(
+    name = "example",
+    srcs = ["ArtifactPrefixConflictExample.scala"],
+    main_class = "example.ArtifactPrefixConflictExample",
+    deps = ["//test/artifact_prefix_conflict_example/example/example:example-lib"],
+    visibility = ["//visibility:public"]
+)

--- a/test/artifact_prefix_conflict_example/example/BUILD
+++ b/test/artifact_prefix_conflict_example/example/BUILD
@@ -4,6 +4,6 @@ scala_binary(
     name = "example",
     srcs = ["ArtifactPrefixConflictExample.scala"],
     main_class = "example.ArtifactPrefixConflictExample",
+    visibility = ["//visibility:public"],
     deps = ["//test/artifact_prefix_conflict_example/example/example:example-lib"],
-    visibility = ["//visibility:public"]
 )

--- a/test/artifact_prefix_conflict_example/example/example/BUILD
+++ b/test/artifact_prefix_conflict_example/example/example/BUILD
@@ -3,5 +3,5 @@ load("//scala:scala.bzl", "scala_library")
 scala_library(
     name = "example-lib",
     srcs = ["Somefile.scala"],
-    visibility = ["//visibility:public"]
+    visibility = ["//visibility:public"],
 )

--- a/test/artifact_prefix_conflict_example/example/example/BUILD
+++ b/test/artifact_prefix_conflict_example/example/example/BUILD
@@ -1,0 +1,7 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "example-lib",
+    srcs = ["Somefile.scala"],
+    visibility = ["//visibility:public"]
+)

--- a/test/artifact_prefix_conflict_example/example/example/Somefile.scala
+++ b/test/artifact_prefix_conflict_example/example/example/Somefile.scala
@@ -1,0 +1,3 @@
+package example.example
+
+object Somefile

--- a/test/rootpaths_binary.sh
+++ b/test/rootpaths_binary.sh
@@ -3,9 +3,9 @@
 set -eou pipefail
 
 content="$(cat $1)"
-expected=$'test/ScalaBinary\ntest/ScalaBinary.jar'
+expected=$'test/ScalaBinary.jar\ntest/ScalaBinary.sh'
 if [ "$content" != "$expected" ]; then
     echo "Unexpected rootpaths: $content"
-    echo "$expected"
+    echo "Expected rootpaths: $expected"
     exit 1
 fi

--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -51,11 +51,11 @@ test_transitive_deps() {
 
 test_repl() {
   bazel build $(bazel query 'kind(scala_repl, //test/...)')
-  echo "import scalarules.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl -Xnojline | grep "foo java" &&
-  echo "import scalarules.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl -Xnojline | grep "bar" &&
-  echo "import scalarules.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl -Xnojline | grep "A hui hou" &&
-  echo "import scalarules.test._; ResourcesStripScalaBinary.main(Array())" | bazel-bin/test/ResourcesStripScalaBinaryRepl -Xnojline | grep "More Hello"
-  echo "import scalarules.test._; A.main(Array())" | bazel-bin/test/ReplWithSources -Xnojline | grep "4 8 15"
+  echo "import scalarules.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl.sh -Xnojline | grep "foo java" &&
+  echo "import scalarules.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl.sh -Xnojline | grep "bar" &&
+  echo "import scalarules.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl.sh -Xnojline | grep "A hui hou" &&
+  echo "import scalarules.test._; ResourcesStripScalaBinary.main(Array())" | bazel-bin/test/ResourcesStripScalaBinaryRepl.sh -Xnojline | grep "More Hello"
+  echo "import scalarules.test._; A.main(Array())" | bazel-bin/test/ReplWithSources.sh -Xnojline | grep "4 8 15"
 }
 
 test_benchmark_jmh() {


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Add an extension for the executable runfile in non-Windows OS (`.sh`) to prevent an issue with `ArtifactPrefixConflictException`.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

When `foo:bar` is a binary (or test), it will generate a runfile artifact, `<bazel-out>/.../foo/bar`.
If we also have a subdirectory `foo/bar` with targets, then there will be a conflict since those targets (e.g. `foo/bar:baz`) will need the  `<bazel-out>/.../foo/bar` output path, but that is already taken by our first artifact, resulting in Bazel erroring out with `com.google.devtools.build.lib.skyframe.ArtifactConflictFinder$ConflictException: com.google.devtools.build.lib.actions.ArtifactPrefixConflictException`.

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Remove conflicts between runfile executables and directory names.
