### PR TITLE
Allow scala_benchmark_jmh to specify a runtime_jdk version

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -138,6 +138,25 @@ go_rules_dependencies()
 
 go_register_toolchains()
 
+# Explicitly pull in a different (newer) version of rules_java for remote jdks
+rules_java_extra_version = "5.1.0"
+
+rules_java_extra_sha = "d974a2d6e1a534856d1b60ad6a15e57f3970d8596fbb0bb17b9ee26ca209332a"
+
+rules_java_extra_url = "https://github.com/bazelbuild/rules_java/releases/download/{}/rules_java-{}.tar.gz".format(rules_java_extra_version, rules_java_extra_version)
+
+http_archive(
+    name = "rules_java_extra",
+    sha256 = rules_java_extra_sha,
+    url = rules_java_extra_url,
+)
+
+load("@rules_java//java:repositories.bzl", "remote_jdk8_repos")
+
+# We need to select based on platform when we use these
+# https://github.com/bazelbuild/bazel/issues/11655
+remote_jdk8_repos()
+
 bazel_toolchains_version = "4.1.0"
 
 http_archive(

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -67,6 +67,10 @@ scala_generate_benchmark = rule(
                 "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator",
             ),
         ),
+        "runtime_jdk": attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+            providers = [java_common.JavaRuntimeInfo],
+        ),
     },
     outputs = {
         "src_jar": "%{name}.srcjar",
@@ -85,6 +89,7 @@ def scala_benchmark_jmh(**kw):
     testonly = kw.get("testonly", False)
     scalacopts = kw.get("scalacopts", [])
     main_class = kw.get("main_class", "org.openjdk.jmh.Main")
+    runtime_jdk = kw.get("runtime_jdk", "@bazel_tools//tools/jdk:current_java_runtime")
 
     scala_library(
         name = lib,
@@ -107,6 +112,7 @@ def scala_benchmark_jmh(**kw):
         src = lib,
         generator_type = generator_type,
         testonly = testonly,
+        runtime_jdk = runtime_jdk,
     )
     compiled_lib = name + "_compiled_benchmark_lib"
     scala_library(
@@ -130,4 +136,5 @@ def scala_benchmark_jmh(**kw):
         main_class = main_class,
         testonly = testonly,
         unused_dependency_checker_mode = "off",
+        runtime_jdk = runtime_jdk,
     )

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -51,6 +51,31 @@ scala_benchmark_jmh(
 )
 
 scala_benchmark_jmh(
+    name = "test_jmh_jdk8",
+    srcs = ["TestJmhRuntimeJdk8.scala"],
+    runtime_jdk = select({
+        "@bazel_tools//src/conditions:darwin": "@remote_jdk8_macos//:jdk",
+        "@bazel_tools//src/conditions:windows": "@remote_jdk8_windows//:jdk",
+        "//conditions:default": "@remote_jdk8_linux//:jdk",
+    }),
+)
+
+scala_benchmark_jmh(
+    name = "test_jmh_jdk11",
+    srcs = ["TestJmhRuntimeJdk11.scala"],
+)
+
+[sh_test(
+    name = "Run" + "".join([binary[idx] if binary[idx].isalnum() else "_" for idx in range(len(binary))]),
+    srcs = ["test_binary.sh"],
+    args = ["$(location %s)" % binary],
+    data = [binary if (":" in binary) else (":%s" % binary)],
+) for binary in [
+    "//test/jmh:test_jmh_jdk8",
+    "//test/jmh:test_jmh_jdk11",
+]]
+
+scala_benchmark_jmh(
     name = "test_benchmark_testonly",
     testonly = True,
     srcs = ["TestBenchmark.scala"],

--- a/test/jmh/TestJmhRuntimeJdk11.scala
+++ b/test/jmh/TestJmhRuntimeJdk11.scala
@@ -1,0 +1,23 @@
+package foo
+
+import org.openjdk.jmh.annotations.{Benchmark, Warmup, Measurement, Fork}
+
+class TestJmhRuntimeJdk11 {
+  @Benchmark
+  @Fork(0) // So that System.exit affects main process
+  @Warmup(iterations = 0)
+  @Measurement(iterations = 1)
+  def isUsingJdk11: Unit = {
+    val expectedMajorVersion = "11";
+    val version = System.getProperty("java.version");
+    val majorVersionMatches = version.startsWith(expectedMajorVersion);
+    val failureMsg = "Expected major version of " + expectedMajorVersion + " but got version: " + version;
+    
+    if (!majorVersionMatches) {
+      println(failureMsg);
+      // Our JMH doesn't fail on exception; we have to manually exit
+      // Perhaps we should consider an attr on scala_benchmark_jmh for failing on exception (JMH flag -foe)
+      System.exit(1);
+    }
+  }
+}

--- a/test/jmh/TestJmhRuntimeJdk8.scala
+++ b/test/jmh/TestJmhRuntimeJdk8.scala
@@ -1,0 +1,23 @@
+package foo
+
+import org.openjdk.jmh.annotations.{Benchmark, Warmup, Measurement, Fork}
+
+class TestJmhRuntimeJdk8 {
+  @Benchmark
+  @Fork(0) // So that System.exit affects main process
+  @Warmup(iterations = 0)
+  @Measurement(iterations = 1)
+  def isUsingJdk8: Unit = {
+    val expectedMajorVersion = "1.8";
+    val version = System.getProperty("java.version");
+    val majorVersionMatches = version.startsWith(expectedMajorVersion);
+    val failureMsg = "Expected major version of " + expectedMajorVersion + " but got version: " + version;
+    
+    if (!majorVersionMatches) {
+      println(failureMsg);
+      // Our JMH doesn't fail on exception; we have to manually exit
+      // Perhaps we should consider an attr on scala_benchmark_jmh for failing on exception (JMH flag -foe)
+      System.exit(1);
+    }
+  }
+}

--- a/test/jmh/test_binary.sh
+++ b/test/jmh/test_binary.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+
+echo "Executing: " $@
+$@


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Include `runtime_jdk` as an an `attr` on `jmh_support:benchmark_generator`.
`scala_benchmark_jmh` can now specify a Java runtime to build its `scala_binary` with.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->
To test whether our changes work for different specified JDKs, we include [rules_java@5.1.0](https://github.com/bazelbuild/rules_java/tree/5.1.0) as an `http_archive`.
We don't override our Bazel's (`@.bazelversion`) `rules_java` and instead pull in the newer `rules_java` as `@rules_java_extra`.  

This allows us to use `remote_jdk8` runtimes specified [here](https://github.com/bazelbuild/rules_java/blob/5.1.0/java/repositories.bzl). 

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
We want to be able to use JMH benchmarking on different Java runtimes. 

Co-authored-by: Shane Delmore <sdelmore@twitter.com>
