### PR TITLE
fix: enable to override JAVABIN of wrapper script

### DIFF
--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -103,7 +103,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
         [ctx.expand_location(f, ctx.attr.data) for f in jvm_flags],
     )
 
-    javabin = "export REAL_EXTERNAL_JAVA_BIN=${JAVABIN};JAVABIN=%s/%s" % (
+    javabin = "export REAL_EXTERNAL_JAVA_BIN=${JAVABIN};JAVABIN=${JAVABIN:-%s/%s}" % (
         runfiles_root(ctx),
         wrapper.short_path,
     )


### PR DESCRIPTION
fix https://github.com/bazelbuild/rules_scala/issues/1431

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

- This PR enables to override `JAVABIN` in the wrapper script generated by `scala_binary` rule
- This behavior aligns to the wrapper script generated by `java_binary` (sorry I couldn't find where the wrapper script for `java_binary` defined, but something like)
  - for `java_binary`: `JAVABIN=${JAVABIN:-${JAVA_RUNFILES}/local_jdk/bin/java}`

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

please see: https://github.com/bazelbuild/rules_scala/issues/1431