### PR TITLE
Suppress warning and enable to use dependency_tracking with `-Werror`

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/OptionsParser.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/OptionsParser.scala
@@ -46,6 +46,6 @@ class OptionsParser private(
   }
 
   def takeStringSeqOpt(key: String): Option[Seq[String]] = {
-    takeStringOpt(key).map(_.split(":"))
+    takeStringOpt(key).map(_.split(":").toSeq)
   }
 }


### PR DESCRIPTION
fix: https://github.com/bazelbuild/rules_scala/issues/1398

### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

This PR suppresses a warning like

```
scalac failed: error executing command bazel-out/host/bin/external/io_bazel_rules_scala/src/java/io/bazel/rulesscala/scalac/scalac ... (remaining 1 argument skipped)
external/io_bazel_rules_scala/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/OptionsParser.scala:49: warning: method copyArrayToImmutableIndexedSeq in class LowPriorityImplicits2 is deprecated (since 2.13.0): Implicit conversions from Array to immutable.IndexedSeq are implemented by copying; Use the more efficient non-copying ArraySeq.unsafeWrapArray or an explicit toIndexedSeq call
    takeStringOpt(key).map(_.split(":"))
                                  ^
```

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

As described by https://github.com/bazelbuild/rules_scala/issues/1398, we couldn't use the dependency tracking feature with `-Werror` flag (and I hit the same issue), because of the warning from the rules_scala itself.

This change should enable us to use dependency tracking with `-Werror`.

### additional note

`CONTRIBUTING.md` says we should run `./dangerous_test_thirdparty_version.sh` if we change in `third_party`, but I couldn't run the script with the following error (I should fix it in another PR anyway).
Therefore, I confirmed this change fixes the issue by using the `rules_scala` with this change by `local_repository("/path/to/this/repo")` from my private repo.

```
Log:

sed: can't read : No such file or directory
Loading:
Loading: 0 packages loaded
ERROR: Traceback (most recent call last):
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/WORKSPACE", line 29, column 19, in <toplevel>
                scala_repositories(("2.12.10", { "scala_compiler": "cedc3b9c39d215a9a3ffc0cc75a1d784b51e9edc7f13051a1b4ad5ae22cfbc0c","scala_library": "0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d","scala_reflect": "56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730" }))
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/scala/private/macros/scala_repositories.bzl", line 72, column 21, in scala_repositories
                repositories(
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/third_party/repositories/repositories.bzl", line 31, column 37, in repositories
                _scala_maven_import_external(
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/scala/scala_maven_import_external.bzl", line 240, column 30, in scala_maven_import_external
                jvm_maven_import_external(
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/scala/scala_maven_import_external.bzl", line 261, column 44, in jvm_maven_import_external
                jar_urls = _convert_coordinates_to_urls(coordinates, server_urls)
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/scala/scala_maven_import_external.bzl", line 171, column 46, in _convert_coordinates_to_urls
                urls.append(_concat_with_needed_slash(server_url, url_suffix))
        File "/Users/tanishiking/src/github.com/tanishiking/rules_scala/scala/scala_maven_import_external.bzl", line 175, column 18, in _concat_with_needed_slash
                if server_url.endswith("/"):
Error: 'dict' value has no field or method 'endswith'
ERROR: error loading package '': Encountered error while reading extension file 'proto/repositories.bzl': no such package '@rules_proto//proto': error loading package 'external': Could not load //external package
INFO: Elapsed time: 0.460s
INFO: 0 processes.
FAILED: Build did NOT complete successfully (0 packages loaded)
ERROR: Couldn't start the build. Unable to run tests
FAILED: Build did NOT complete successfully (0 packages loaded)
 Test "test_scala_version 2.12.10 cedc3b9c39d215a9a3ffc0cc75a1d784b51e9edc7f13051a1b4ad5ae22cfbc0c 0a57044d10895f8d3dd66ad4286891f607169d948845ac51e17b4c1cf0ab569d 56b609e1bab9144fb51525bfa01ccd72028154fc40a58685a1e9adcbe7835730" failed  (0 sec)
```