### PR TITLE
Validate repository Scala version against scala_config

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,14 @@ http_archive(
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 scala_config()
 
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
-scala_repositories()
+load("//scala:scala.bzl", "rules_scala_setup", "rules_scala_toolchain_deps_repositories")
+
+# loads other rules Rules Scala depends on 
+rules_scala_setup()
+
+# loads Maven deps like Scala compiler and standard libs, on production projects you should consider 
+# defining a custom deps toolchains to use your project libs instead 
+rules_scala_toolchain_deps_repositories(fetch_sources = True)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -24,9 +24,11 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("//scala:scala.bzl", "scala_repositories")
+load("//scala:scala.bzl", "rules_scala_setup", "rules_scala_toolchain_deps_repositories")
 
-scala_repositories(fetch_sources = True)
+rules_scala_setup()
+
+rules_scala_toolchain_deps_repositories(fetch_sources = True)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -59,6 +59,18 @@ ARTIFACT_IDS = [
     "io_bazel_rules_scala_scala_library_2",
 ]
 
+def rules_scala_toolchain_deps_repositories(
+        maven_servers = _default_maven_server_urls(),
+        overriden_artifacts = {},
+        fetch_sources = False):
+    repositories(
+        for_artifact_ids = ARTIFACT_IDS,
+        maven_servers = maven_servers,
+        fetch_sources = fetch_sources,
+        overriden_artifacts = overriden_artifacts,
+        validate_scala_version = True,
+    )
+
 def scala_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {},
@@ -69,9 +81,8 @@ def scala_repositories(
         rules_scala_setup()
 
     if load_jar_deps:
-        repositories(
-            for_artifact_ids = ARTIFACT_IDS,
-            maven_servers = maven_servers,
-            fetch_sources = fetch_sources,
-            overriden_artifacts = overriden_artifacts,
+        rules_scala_toolchain_deps_repositories(
+            maven_servers,
+            overriden_artifacts,
+            fetch_sources,
         )

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -4,6 +4,8 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:macros/scala_repositories.bzl",
+    _rules_scala_setup = "rules_scala_setup",
+    _rules_scala_toolchain_deps_repositories = "rules_scala_toolchain_deps_repositories",
     _scala_repositories = "scala_repositories",
 )
 load(
@@ -65,5 +67,7 @@ scala_library_suite = _scala_library_suite
 scala_macro_library = _scala_macro_library
 scala_repl = _scala_repl
 scala_repositories = _scala_repositories
+rules_scala_setup = _rules_scala_setup
+rules_scala_toolchain_deps_repositories = _rules_scala_toolchain_deps_repositories
 scala_test = _scala_test
 scala_test_suite = _scala_test_suite

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -6,13 +6,13 @@ runner=$(get_test_runner "${1:-local}")
 
 test_classpath_contains_2_12() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION=2.12.x \
+   --repo_env=SCALA_VERSION=2.12.14 \
    | grep scala-library-2.12
 }
 
 test_classpath_contains_2_13() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION=2.13.x \
+   --repo_env=SCALA_VERSION=2.13.6 \
    | grep scala-library-2.13
 }
 

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -1,7 +1,23 @@
-load("//third_party/repositories:scala_2_11.bzl", _artifacts_2_11 = "artifacts")
-load("//third_party/repositories:scala_2_12.bzl", _artifacts_2_12 = "artifacts")
-load("//third_party/repositories:scala_2_13.bzl", _artifacts_2_13 = "artifacts")
-load("//third_party/repositories:scala_3_1.bzl", _artifacts_3_1 = "artifacts")
+load(
+    "//third_party/repositories:scala_2_11.bzl",
+    _artifacts_2_11 = "artifacts",
+    _scala_version_2_11 = "scala_version",
+)
+load(
+    "//third_party/repositories:scala_2_12.bzl",
+    _artifacts_2_12 = "artifacts",
+    _scala_version_2_12 = "scala_version",
+)
+load(
+    "//third_party/repositories:scala_2_13.bzl",
+    _artifacts_2_13 = "artifacts",
+    _scala_version_2_13 = "scala_version",
+)
+load(
+    "//third_party/repositories:scala_3_1.bzl",
+    _artifacts_3_1 = "artifacts",
+    _scala_version_3_1 = "scala_version",
+)
 load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
@@ -10,7 +26,7 @@ load(
     "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
     _scala_maven_import_external = "scala_maven_import_external",
 )
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION", "SCALA_VERSION")
 
 artifacts_by_major_scala_version = {
     "2.11": _artifacts_2_11,
@@ -19,12 +35,29 @@ artifacts_by_major_scala_version = {
     "3.1": _artifacts_3_1,
 }
 
+scala_version_by_major_scala_version = {
+    "2.11": _scala_version_2_11,
+    "2.12": _scala_version_2_12,
+    "2.13": _scala_version_2_13,
+    "3.1": _scala_version_3_1,
+}
+
 def repositories(
         for_artifact_ids = [],
         maven_servers = default_maven_server_urls(),
         overriden_artifacts = {},
-        fetch_sources = True):
+        fetch_sources = True,
+        validate_scala_version = False):
     major_scala_version = SCALA_MAJOR_VERSION
+
+    if validate_scala_version:
+        repository_scala_version = scala_version_by_major_scala_version[SCALA_MAJOR_VERSION]
+        default_version_matches = SCALA_VERSION == repository_scala_version
+
+        if not default_version_matches and len(overriden_artifacts) == 0:
+            version_message = "Scala config (%s) version does not match repository version (%s)"
+            fail(version_message % (SCALA_VERSION, repository_scala_version))
+
     default_artifacts = artifacts_by_major_scala_version[major_scala_version]
     artifacts = dict(default_artifacts.items() + overriden_artifacts.items())
     for id in for_artifact_ids:

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -1,14 +1,16 @@
+scala_version = "2.11.12"
+
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala-library:2.11.12",
+        "artifact": "org.scala-lang:scala-library:%s" % scala_version,
         "sha256": "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala-compiler:2.11.12",
+        "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
         "sha256": "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
     },
     "io_bazel_rules_scala_scala_reflect": {
-        "artifact": "org.scala-lang:scala-reflect:2.11.12",
+        "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
         "sha256": "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
     },
     "io_bazel_rules_scala_scalatest": {

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -1,14 +1,16 @@
+scala_version = "2.12.14"
+
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala-library:2.12.14",
+        "artifact": "org.scala-lang:scala-library:%s" % scala_version,
         "sha256": "0451dce8322903a6c2aa7d31232b54daa72a61ced8ade0b4c5022442a3f6cb57",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala-compiler:2.12.14",
+        "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
         "sha256": "2a1b3fbf9c956073c8c5374098a6f987e3b8d76e34756ab985fc7d2ca37ee113",
     },
     "io_bazel_rules_scala_scala_reflect": {
-        "artifact": "org.scala-lang:scala-reflect:2.12.14",
+        "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
         "sha256": "497f4603e9d19dc4fa591cd467de5e32238d240bbd955d3dac6390b270889522",
     },
     "io_bazel_rules_scala_scalatest": {

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -1,14 +1,16 @@
+scala_version = "2.13.6"
+
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala-library:2.13.6",
+        "artifact": "org.scala-lang:scala-library:%s" % scala_version,
         "sha256": "f19ed732e150d3537794fd3fe42ee18470a3f707efd499ecd05a99e727ff6c8a",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala-compiler:2.13.6",
+        "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
         "sha256": "310d263d622a3d016913e94ee00b119d270573a5ceaa6b21312d69637fd9eec1",
     },
     "io_bazel_rules_scala_scala_reflect": {
-        "artifact": "org.scala-lang:scala-reflect:2.13.6",
+        "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
         "sha256": "f713593809b387c60935bb9a940dfcea53bd0dbf8fdc8d10739a2896f8ac56fa",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -1,25 +1,27 @@
+scala_version = "3.1.0"
+
 artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.5",
         "sha256": "52aafeef8e0d104433329b1bc31463d1b4a9e2b8f24f85432c8cfaed9fad2587",
     },
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala3-library_3:3.1.0",
+        "artifact": "org.scala-lang:scala3-library_3:%s" % scala_version,
         "sha256": "5b513c97181d22c393cf32a51902fce27b9f698d246c7a92df7775f0bb04bec0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala3-compiler_3:3.1.0",
+        "artifact": "org.scala-lang:scala3-compiler_3:%s" % scala_version,
         "sha256": "9a76c166c97db534afb51861d234430a732158bdb413d8e12425e8c72457db60",
     },
     "io_bazel_rules_scala_scala_interfaces": {
-        "artifact": "org.scala-lang:scala3-interfaces:3.1.0",
+        "artifact": "org.scala-lang:scala3-interfaces:%s" % scala_version,
         "sha256": "0e344029ace7b1a846aa77e5cd452b7c8a28726b12b7c2baec0a70a038a686e9",
     },
     "io_bazel_rules_scala_scala_tasty_core": {
-        "artifact": "org.scala-lang:tasty-core_3:3.1.0",
+        "artifact": "org.scala-lang:tasty-core_3:%s" % scala_version,
         "sha256": "80c9d1ac1630a22b3b62e0d482f91552397be22eac3ea0e61104c5ca67287647",
     },
     "io_bazel_rules_scala_scala_asm": {


### PR DESCRIPTION
### Description
Add validation to prevent Scala version mismatch between `scala_config` and default repositories.

In case there are no overrides, we fail the build if Scala version in scala_config does not match available version in default repositories.

Additionally, macros `rules_scala_toolchain_deps_repositories` and `rules_scala_setup` are exported for easier setup of Rules Scala dependencies.

### Motivation
Without validation it is easy to get wrong version loaded under the impression that `scala_config` controls dependency versions.

For example, such maintenance as in #1434 would get better feedback when Scala version is not properly configured
