### PR TITLE
Allow overriding jmh_repositories artifact versions

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -20,7 +20,7 @@ def jmh_repositories(
         ],
         fetch_sources = False,
         maven_servers = maven_servers,
-        overriden_artifacts = {},
+        overriden_artifacts = overriden_artifacts,
     )
 
     native.register_toolchains("@io_bazel_rules_scala//jmh:jmh_toolchain")


### PR DESCRIPTION
### Description

Pass along the `overriden_artifacts` argument from `jmh_repositories` so that JMH artifact versions can be customized.

The `jmh_repositories` macro, which sets up JMH benchmarking dependencies, has an `overriden_artifacts` argument for replacing dependencies. However, it doesn't pass the overrides to the underlying `repositories` call, so overrides are ignored.

### Motivation

I'd like to use a more recent version of JMH (1.35) than the current default of 1.20. Because of the benchmark code generation step, I can't do this without overriding the `jmh_repositories` versions.