### PR TITLE
Simplify setup of scala_toolchain and its deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "rules_scala_setup", "rules_scala
 # loads other rules Rules Scala depends on 
 rules_scala_setup()
 
-# loads Maven deps like Scala compiler and standard libs, on production projects you should consider 
+# Loads Maven deps like Scala compiler and standard libs. On production projects you should consider 
 # defining a custom deps toolchains to use your project libs instead 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
 
@@ -87,7 +87,7 @@ This will load the `rules_scala` repository at the commit sha
 `rules_scala_version` into your Bazel project and register a [scala_toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.14)
 
 Then in your BUILD file just add the following so the rules will be available:
-```python
+```starlark
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library", "scala_binary", "scala_test")
 ```
 You may wish to have these rules loaded by default using bazel's prelude. You can add the above to the file `tools/build_rules/prelude_bazel` in your repo (don't forget to have a, possibly empty, BUILD file there) and then it will be automatically prepended to every BUILD file in the workspace.
@@ -147,39 +147,12 @@ dependency providers configured for `2.11.12`, `2.12.14` and `2.13.6` versions.
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 scala_config(scala_version = "2.13.6")
 
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
-scala_repositories()
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+rules_proto_dependencies()
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 scala_register_toolchains()
-```
-
-If you're using any of the rules `twitter_scrooge`, `scala_proto_repositories`
-or `specs2_junit_repositories` you also need to specify `scala_version` for them. See `./test_version/WORKSPACE.template`
-for an example workspace using another scala version.
-
-### As an option for `scala_repositories()`
-
-It's also possible to override the scala artifacts while calling `scala_repositories()`:
-
-```starlark
-scala_repositories(
-  overriden_artifacts = {
-    # Change both the artifact names and sha256s.
-    "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala-library:2.12.14",
-        "sha256": "0451dce8322903a6c2aa7d31232b54daa72a61ced8ade0b4c5022442a3f6cb57",
-    },
-    "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala-compiler:2.12.14",
-        "sha256": "2a1b3fbf9c956073c8c5374098a6f987e3b8d76e34756ab985fc7d2ca37ee113",
-    },
-    "io_bazel_rules_scala_scala_reflect": {
-        "artifact": "org.scala-lang:scala-reflect:2.12.14",
-        "sha256": "497f4603e9d19dc4fa591cd467de5e32238d240bbd955d3dac6390b270889522",
-    }
-  }
-)
 ```
 
 Note: Toolchains are a more flexible way to configure dependencies, so you should prefer that way.

--- a/docs/scala_toolchain.md
+++ b/docs/scala_toolchain.md
@@ -10,7 +10,7 @@
 
 In your workspace file add the following lines:
 
-```python
+```starlark
 # WORKSPACE
 # register default scala toolchain
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
@@ -20,71 +20,37 @@ scala_register_toolchains()
 #### B) Defining your own `scala_toolchain` requires 2 steps:
 
 1. Add your own definition of `scala_toolchain` to a `BUILD` file:
-    ```python
+   Example assumes external libraries are resolved with [rules_jvm_external](https://github.com/bazelbuild/rules_jvm_external)
+    ```starlark
     # //toolchains/BUILD
-    load("@io_bazel_rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
-    load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
+    load("//scala:scala.bzl", "setup_scala_toolchain")
 
-    scala_toolchain(
-        name = "my_toolchain_impl",
-        dep_providers = [
-            ":my_scala_compile_classpath_provider",
-            ":my_scala_library_classpath_provider",
-            ":my_scala_macro_classpath_provider",
-            ":my_scala_xml_provider",
-            ":my_parser_combinators_provider",
+    setup_scala_toolchain(
+        name = "my_toolchain",
+        # configure toolchain dependecies
+        parser_combinators_deps = [
+            "@maven//:org_scala_lang_modules_scala_parser_combinators_2_12",
         ],
+        scala_compile_classpath = [
+            "@maven//:org_scala_lang_scala_compiler",
+            "@maven//:org_scala_lang_scala_library",
+            "@maven//:org_scala_lang_scala_reflect",
+        ],
+        scala_library_classpath = [
+            "@maven//:org_scala_lang_scala_library",
+            "@maven//:org_scala_lang_scala_reflect",
+        ],
+        scala_macro_classpath = [
+            "@maven//:org_scala_lang_scala_library",
+            "@maven//:org_scala_lang_scala_reflect",
+        ],
+        scala_xml_deps = [
+            "@maven//:org_scala_lang_modules_scala_xml_2_12",
+        ],
+        # example of setting attribute values
         scalacopts = ["-Ywarn-unused"],
         unused_dependency_checker_mode = "off",
         visibility = ["//visibility:public"]
-    )
-
-    toolchain(
-        name = "my_scala_toolchain",
-        toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-        toolchain = "my_toolchain_impl",
-        visibility = ["//visibility:public"]
-    )
-   
-    declare_deps_provider(
-        name = "my_scala_compile_classpath_provider",
-        deps_id = "scala_compile_classpath",
-        visibility = ["//visibility:public"],
-        deps = [
-            "@io_bazel_rules_scala_scala_compiler",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
-        ],
-    )
-    
-    declare_deps_provider(
-        name = "my_scala_library_classpath_provider",
-        deps_id = "scala_library_classpath",
-        deps = [
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
-        ],
-    )
-    
-    declare_deps_provider(
-        name = "my_scala_macro_classpath_provider",
-        deps_id = "scala_macro_classpath",
-        deps = [
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
-        ],
-    )
-     
-    declare_deps_provider(
-        name = "my_scala_xml_provider",
-        deps_id = "scala_xml",
-        deps = ["@scala_xml_dep"],
-    )
-    
-    declare_deps_provider(
-        name = "my_parser_combinators_provider",
-        deps_id = "parser_combinators",
-        deps = ["@parser_combinators_dep"],
     )
     ```
 
@@ -111,7 +77,7 @@ scala_register_toolchains()
         <p><code>List of labels; optional</code></p>
         <p>
           Allows to configure dependencies lists by configuring <code>DepInfo</code> provider targets. 
-          Currently supported depset ids: <code>scala_compile_classpath</code>, 
+          Currently supported dep ids: <code>scala_compile_classpath</code>, 
           <code>scala_library_classpath</code>, <code>scala_macro_classpath</code>, <code>scala_xml</code>, 
           <code>parser_combinators</code>.     
         </p>

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,4 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
+load("//scala:providers.bzl", "declare_deps_provider")
 load("//scala:scala.bzl", "setup_scala_toolchain")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
 
@@ -78,4 +79,39 @@ java_library(
     name = "PlaceHolderClassToCreateEmptyJarForScalaImport",
     srcs = ["PlaceHolderClassToCreateEmptyJarForScalaImport.java"],
     visibility = ["//visibility:public"],
+)
+
+declare_deps_provider(
+    name = "scala_compile_classpath_provider",
+    deps_id = "scala_compile_classpath",
+    visibility = ["//visibility:public"],
+    deps = _SCALA_COMPILE_CLASSPATH_DEPS,
+)
+
+declare_deps_provider(
+    name = "scala_library_classpath_provider",
+    deps_id = "scala_library_classpath",
+    visibility = ["//visibility:public"],
+    deps = _SCALA_LIBRARY_CLASSPATH_DEPS,
+)
+
+declare_deps_provider(
+    name = "scala_macro_classpath_provider",
+    deps_id = "scala_macro_classpath",
+    visibility = ["//visibility:public"],
+    deps = _SCALA_MACRO_CLASSPATH_DEPS,
+)
+
+declare_deps_provider(
+    name = "scala_xml_provider",
+    deps_id = "scala_xml",
+    visibility = ["//visibility:public"],
+    deps = _SCALA_XML_DEPS,
+)
+
+declare_deps_provider(
+    name = "parser_combinators_provider",
+    deps_id = "parser_combinators",
+    visibility = ["//visibility:public"],
+    deps = _PARSER_COMBINATORS_DEPS,
 )

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -48,7 +48,6 @@ setup_scala_toolchain(
     scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
     scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
     unused_dependency_checker_mode = "error",
-    use_argument_file_in_runner = True,
 )
 
 setup_scala_toolchain(
@@ -60,7 +59,6 @@ setup_scala_toolchain(
     scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
     strict_deps_mode = "error",
     unused_dependency_checker_mode = "error",
-    use_argument_file_in_runner = True,
 )
 
 java_import(

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,6 +1,5 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
-load("//scala:scala_toolchain.bzl", "scala_toolchain")
-load("//scala:providers.bzl", "declare_deps_provider")
+load("//scala:scala.bzl", "setup_scala_toolchain")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
 
 toolchain_type(
@@ -8,47 +7,65 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
-scala_toolchain(
-    name = "default_toolchain_impl",
-    scalacopts = [],
-    use_argument_file_in_runner = True,
-    visibility = ["//visibility:public"],
-)
+_SCALA_COMPILE_CLASSPATH_DEPS = [
+    "@io_bazel_rules_scala_scala_compiler",
+    "@io_bazel_rules_scala_scala_library",
+] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
+    "@io_bazel_rules_scala_scala_interfaces",
+    "@io_bazel_rules_scala_scala_tasty_core",
+    "@io_bazel_rules_scala_scala_asm",
+    "@io_bazel_rules_scala_scala_library_2",
+])
 
-toolchain(
+_SCALA_LIBRARY_CLASSPATH_DEPS = [
+    "@io_bazel_rules_scala_scala_library",
+] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
+    "@io_bazel_rules_scala_scala_library_2",
+])
+
+_SCALA_MACRO_CLASSPATH_DEPS = [
+    "@io_bazel_rules_scala_scala_library",
+] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
+    "@io_bazel_rules_scala_scala_library_2",
+])
+
+_PARSER_COMBINATORS_DEPS = ["@io_bazel_rules_scala_scala_parser_combinators"]
+
+_SCALA_XML_DEPS = ["@io_bazel_rules_scala_scala_xml"]
+
+setup_scala_toolchain(
     name = "default_toolchain",
-    toolchain = ":default_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-    visibility = ["//visibility:public"],
+    parser_combinators_deps = _PARSER_COMBINATORS_DEPS,
+    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
+    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
+    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
+    scala_xml_deps = _SCALA_XML_DEPS,
+    use_argument_file_in_runner = True,
 )
 
-scala_toolchain(
-    name = "unused_dependency_checker_error_toolchain_impl",
-    unused_dependency_checker_mode = "error",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
+setup_scala_toolchain(
     name = "unused_dependency_checker_error_toolchain",
-    toolchain = ":unused_dependency_checker_error_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-    visibility = ["//visibility:public"],
+    parser_combinators_deps = _PARSER_COMBINATORS_DEPS,
+    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
+    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
+    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
+    scala_xml_deps = _SCALA_XML_DEPS,
+    unused_dependency_checker_mode = "error",
+    use_argument_file_in_runner = True,
 )
 
-scala_toolchain(
-    name = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
+setup_scala_toolchain(
+    name = "minimal_direct_source_deps",
     dependency_mode = "plus-one",
     dependency_tracking_method = "ast",
+    parser_combinators_deps = _PARSER_COMBINATORS_DEPS,
+    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
+    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
+    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
+    scala_xml_deps = _SCALA_XML_DEPS,
     strict_deps_mode = "error",
     unused_dependency_checker_mode = "error",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "minimal_direct_source_deps",
-    toolchain = "ast_plus_one_deps_strict_deps_unused_deps_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-    visibility = ["//visibility:public"],
+    use_argument_file_in_runner = True,
 )
 
 java_import(
@@ -61,55 +78,4 @@ java_library(
     name = "PlaceHolderClassToCreateEmptyJarForScalaImport",
     srcs = ["PlaceHolderClassToCreateEmptyJarForScalaImport.java"],
     visibility = ["//visibility:public"],
-)
-
-declare_deps_provider(
-    name = "scala_compile_classpath_provider",
-    deps_id = "scala_compile_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "@io_bazel_rules_scala_scala_compiler",
-        "@io_bazel_rules_scala_scala_library",
-    ] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-        "@io_bazel_rules_scala_scala_interfaces",
-        "@io_bazel_rules_scala_scala_tasty_core",
-        "@io_bazel_rules_scala_scala_asm",
-        "@io_bazel_rules_scala_scala_library_2",
-    ]),
-)
-
-declare_deps_provider(
-    name = "scala_library_classpath_provider",
-    deps_id = "scala_library_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "@io_bazel_rules_scala_scala_library",
-    ] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-        "@io_bazel_rules_scala_scala_library_2",
-    ]),
-)
-
-declare_deps_provider(
-    name = "scala_macro_classpath_provider",
-    deps_id = "scala_macro_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "@io_bazel_rules_scala_scala_library",
-    ] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-        "@io_bazel_rules_scala_scala_library_2",
-    ]),
-)
-
-declare_deps_provider(
-    name = "scala_xml_provider",
-    deps_id = "scala_xml",
-    visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_scala_scala_xml"],
-)
-
-declare_deps_provider(
-    name = "parser_combinators_provider",
-    deps_id = "parser_combinators",
-    visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_scala_scala_parser_combinators"],
 )

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -36,21 +36,17 @@ _SCALA_XML_DEPS = ["@io_bazel_rules_scala_scala_xml"]
 
 setup_scala_toolchain(
     name = "default_toolchain",
-    parser_combinators_deps = _PARSER_COMBINATORS_DEPS,
     scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
     scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
     scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
-    scala_xml_deps = _SCALA_XML_DEPS,
     use_argument_file_in_runner = True,
 )
 
 setup_scala_toolchain(
     name = "unused_dependency_checker_error_toolchain",
-    parser_combinators_deps = _PARSER_COMBINATORS_DEPS,
     scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
     scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
     scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
-    scala_xml_deps = _SCALA_XML_DEPS,
     unused_dependency_checker_mode = "error",
     use_argument_file_in_runner = True,
 )
@@ -59,11 +55,9 @@ setup_scala_toolchain(
     name = "minimal_direct_source_deps",
     dependency_mode = "plus-one",
     dependency_tracking_method = "ast",
-    parser_combinators_deps = _PARSER_COMBINATORS_DEPS,
     scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
     scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
     scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
-    scala_xml_deps = _SCALA_XML_DEPS,
     strict_deps_mode = "error",
     unused_dependency_checker_mode = "error",
     use_argument_file_in_runner = True,

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -16,8 +16,6 @@ def setup_scala_toolchain(
     scala_library_classpath_provider = "%s_scala_library_classpath_provider" % name
     scala_macro_classpath_provider = "%s_scala_macro_classpath_provider" % name
 
-    print("XML", scala_xml_provider)
-
     declare_deps_provider(
         name = scala_compile_classpath_provider,
         deps_id = "scala_compile_classpath",

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -16,6 +16,8 @@ def setup_scala_toolchain(
     scala_library_classpath_provider = "%s_scala_library_classpath_provider" % name
     scala_macro_classpath_provider = "%s_scala_macro_classpath_provider" % name
 
+    print("XML", scala_xml_provider)
+
     declare_deps_provider(
         name = scala_compile_classpath_provider,
         deps_id = "scala_compile_classpath",

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -3,11 +3,11 @@ load("//scala:providers.bzl", "declare_deps_provider")
 
 def setup_scala_toolchain(
         name,
-        scala_xml_deps,
-        parser_combinators_deps,
         scala_compile_classpath,
         scala_library_classpath,
         scala_macro_classpath,
+        scala_xml_deps = None,
+        parser_combinators_deps = None,
         visibility = ["//visibility:public"],
         **kwargs):
     scala_xml_provider = "%s_scala_xml_provider" % name
@@ -37,19 +37,25 @@ def setup_scala_toolchain(
         deps = scala_macro_classpath,
     )
 
-    declare_deps_provider(
-        name = scala_xml_provider,
-        deps_id = "scala_xml",
-        visibility = visibility,
-        deps = scala_xml_deps,
-    )
+    if scala_xml_deps != None:
+        declare_deps_provider(
+            name = scala_xml_provider,
+            deps_id = "scala_xml",
+            visibility = visibility,
+            deps = scala_xml_deps,
+        )
+    else:
+        scala_xml_provider = "@io_bazel_rules_scala//scala:scala_xml_provider"
 
-    declare_deps_provider(
-        name = parser_combinators_provider,
-        deps_id = "parser_combinators",
-        visibility = visibility,
-        deps = parser_combinators_deps,
-    )
+    if parser_combinators_deps != None:
+        declare_deps_provider(
+            name = parser_combinators_provider,
+            deps_id = "parser_combinators",
+            visibility = visibility,
+            deps = parser_combinators_deps,
+        )
+    else:
+        parser_combinators_provider = "@io_bazel_rules_scala//scala:parser_combinators_provider"
 
     scala_toolchain(
         name = "%s_impl" % name,

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -1,0 +1,72 @@
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("//scala:providers.bzl", "declare_deps_provider")
+
+def setup_scala_toolchain(
+        name,
+        scala_xml_deps,
+        parser_combinators_deps,
+        scala_compile_classpath,
+        scala_library_classpath,
+        scala_macro_classpath,
+        visibility = ["//visibility:public"],
+        **kwargs):
+    scala_xml_provider = "%s_scala_xml_provider" % name
+    parser_combinators_provider = "%s_parser_combinators_provider" % name
+    scala_compile_classpath_provider = "%s_scala_compile_classpath_provider" % name
+    scala_library_classpath_provider = "%s_scala_library_classpath_provider" % name
+    scala_macro_classpath_provider = "%s_scala_macro_classpath_provider" % name
+
+    declare_deps_provider(
+        name = scala_compile_classpath_provider,
+        deps_id = "scala_compile_classpath",
+        visibility = visibility,
+        deps = scala_compile_classpath,
+    )
+
+    declare_deps_provider(
+        name = scala_library_classpath_provider,
+        deps_id = "scala_library_classpath",
+        visibility = visibility,
+        deps = scala_library_classpath,
+    )
+
+    declare_deps_provider(
+        name = scala_macro_classpath_provider,
+        deps_id = "scala_macro_classpath",
+        visibility = visibility,
+        deps = scala_macro_classpath,
+    )
+
+    declare_deps_provider(
+        name = scala_xml_provider,
+        deps_id = "scala_xml",
+        visibility = visibility,
+        deps = scala_xml_deps,
+    )
+
+    declare_deps_provider(
+        name = parser_combinators_provider,
+        deps_id = "parser_combinators",
+        visibility = visibility,
+        deps = parser_combinators_deps,
+    )
+
+    scala_toolchain(
+        name = "%s_impl" % name,
+        dep_providers = [
+            scala_xml_provider,
+            parser_combinators_provider,
+            scala_compile_classpath_provider,
+            scala_library_classpath_provider,
+            scala_macro_classpath_provider,
+        ],
+        visibility = visibility,
+        **kwargs
+    )
+
+    native.toolchain(
+        name = name,
+        toolchain = ":%s_impl" % name,
+        toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+        visibility = visibility,
+    )

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -9,6 +9,10 @@ load(
     _scala_repositories = "scala_repositories",
 )
 load(
+    "@io_bazel_rules_scala//scala/private:macros/setup_scala_toolchain.bzl",
+    _setup_scala_toolchain = "setup_scala_toolchain",
+)
+load(
     "@io_bazel_rules_scala//scala/private:rules/scala_binary.bzl",
     _scala_binary = "scala_binary",
 )
@@ -71,3 +75,4 @@ rules_scala_setup = _rules_scala_setup
 rules_scala_toolchain_deps_repositories = _rules_scala_toolchain_deps_repositories
 scala_test = _scala_test
 scala_test_suite = _scala_test_suite
+setup_scala_toolchain = _setup_scala_toolchain


### PR DESCRIPTION
### Description
Added `setup_scala_toolchain` macro to simplify scala toolchain setup.

### Motivation
To configuration of custom scala toolchain one needs to understand implementation details like dependency provider ids, which makes it a complicated task. We can encapsulate those details under a macro.
