### PR TITLE
Revert "Declare non-windows executable with .sh extension"

### DIFF
--- a/docs/scala_repl.md
+++ b/docs/scala_repl.md
@@ -21,5 +21,5 @@ Instead, use `bazel build` to build the script, then run that script as normal t
 An example in this repo:
 ```
 bazel build test:HelloLibRepl
-bazel-bin/test/HelloLibRepl.sh
+bazel-bin/test/HelloLibRepl
 ```

--- a/scala/private/phases/phase_declare_executable.bzl
+++ b/scala/private/phases/phase_declare_executable.bzl
@@ -15,5 +15,5 @@ def phase_declare_executable(ctx, p):
         )
     else:
         return struct(
-            executable = ctx.actions.declare_file("%s.sh" % ctx.label.name),
+            executable = ctx.actions.declare_file(ctx.label.name),
         )

--- a/test/BUILD
+++ b/test/BUILD
@@ -472,7 +472,6 @@ scala_specs2_junit_test(
     "//test/src/main/scala/scalarules/test/large_classpath:largeClasspath",
     "//test:test_scala_proto_server",
     "//test:scala_binary_jdk_11",
-    "//test/artifact_prefix_conflict_example/example:example",
 ]]
 
 # Make sure scala_binary respects runtime_jdk on bazel run

--- a/test/artifact_prefix_conflict_example/example/ArtifactPrefixConflictExample.scala
+++ b/test/artifact_prefix_conflict_example/example/ArtifactPrefixConflictExample.scala
@@ -1,8 +1,0 @@
-package example
-
-import example.Somefile
-
-object ArtifactPrefixConflictExample extends App {
-  println(s"Using Somefile: $Somefile")
-  println("In ArtifactPrefixConflictExample.scala")
-}

--- a/test/artifact_prefix_conflict_example/example/BUILD
+++ b/test/artifact_prefix_conflict_example/example/BUILD
@@ -1,9 +1,0 @@
-load("//scala:scala.bzl", "scala_binary")
-
-scala_binary(
-    name = "example",
-    srcs = ["ArtifactPrefixConflictExample.scala"],
-    main_class = "example.ArtifactPrefixConflictExample",
-    visibility = ["//visibility:public"],
-    deps = ["//test/artifact_prefix_conflict_example/example/example:example-lib"],
-)

--- a/test/artifact_prefix_conflict_example/example/example/BUILD
+++ b/test/artifact_prefix_conflict_example/example/example/BUILD
@@ -1,7 +1,0 @@
-load("//scala:scala.bzl", "scala_library")
-
-scala_library(
-    name = "example-lib",
-    srcs = ["Somefile.scala"],
-    visibility = ["//visibility:public"],
-)

--- a/test/artifact_prefix_conflict_example/example/example/Somefile.scala
+++ b/test/artifact_prefix_conflict_example/example/example/Somefile.scala
@@ -1,3 +1,0 @@
-package example.example
-
-object Somefile

--- a/test/rootpaths_binary.sh
+++ b/test/rootpaths_binary.sh
@@ -3,9 +3,9 @@
 set -eou pipefail
 
 content="$(cat $1)"
-expected=$'test/ScalaBinary.jar\ntest/ScalaBinary.sh'
+expected=$'test/ScalaBinary\ntest/ScalaBinary.jar'
 if [ "$content" != "$expected" ]; then
     echo "Unexpected rootpaths: $content"
-    echo "Expected rootpaths: $expected"
+    echo "$expected"
     exit 1
 fi

--- a/test/shell/test_misc.sh
+++ b/test/shell/test_misc.sh
@@ -51,11 +51,11 @@ test_transitive_deps() {
 
 test_repl() {
   bazel build $(bazel query 'kind(scala_repl, //test/...)')
-  echo "import scalarules.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl.sh -Xnojline | grep "foo java" &&
-  echo "import scalarules.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl.sh -Xnojline | grep "bar" &&
-  echo "import scalarules.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl.sh -Xnojline | grep "A hui hou" &&
-  echo "import scalarules.test._; ResourcesStripScalaBinary.main(Array())" | bazel-bin/test/ResourcesStripScalaBinaryRepl.sh -Xnojline | grep "More Hello"
-  echo "import scalarules.test._; A.main(Array())" | bazel-bin/test/ReplWithSources.sh -Xnojline | grep "4 8 15"
+  echo "import scalarules.test._; HelloLib.printMessage(\"foo\")" | bazel-bin/test/HelloLibRepl -Xnojline | grep "foo java" &&
+  echo "import scalarules.test._; TestUtil.foo" | bazel-bin/test/HelloLibTestRepl -Xnojline | grep "bar" &&
+  echo "import scalarules.test._; ScalaLibBinary.main(Array())" | bazel-bin/test/ScalaLibBinaryRepl -Xnojline | grep "A hui hou" &&
+  echo "import scalarules.test._; ResourcesStripScalaBinary.main(Array())" | bazel-bin/test/ResourcesStripScalaBinaryRepl -Xnojline | grep "More Hello"
+  echo "import scalarules.test._; A.main(Array())" | bazel-bin/test/ReplWithSources -Xnojline | grep "4 8 15"
 }
 
 test_benchmark_jmh() {


### PR DESCRIPTION
Reverts bazelbuild/rules_scala#1407
1407 was a breaking change.
The issue was that IJWB [assumes](https://github.com/bazelbuild/intellij/blob/a5522a0f1787b667a3a966e927da773cb4ec51a2/java/src/com/google/idea/blaze/java/run/fastbuild/FastBuildTestEnvironmentCreator.java#L90) the runfiles and executable are the same name as the target (java convention) and #1407 broke this convention/assumption by having the executable named `<target>.sh` and runfiles `<target>.sh.runfiles` directory.
