### PR TITLE
Add scalatest-wordspec 3.2.9 dependency to scalatest

### DIFF
--- a/examples/testing/multi_frameworks_toolchain/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/BUILD
@@ -46,6 +46,7 @@ declare_deps_provider(
         "@io_bazel_rules_scala_scalatest_matchers_core",
         "@io_bazel_rules_scala_scalatest_mustmatchers",
         "@io_bazel_rules_scala_scalatest_shouldmatchers",
+        "@io_bazel_rules_scala_scalatest_wordspec",
     ],
 )
 

--- a/scalatest/scalatest.bzl
+++ b/scalatest/scalatest.bzl
@@ -17,6 +17,7 @@ def scalatest_repositories(
             "io_bazel_rules_scala_scalatest_freespec",
             "io_bazel_rules_scala_scalatest_funsuite",
             "io_bazel_rules_scala_scalatest_funspec",
+            "io_bazel_rules_scala_scalatest_wordspec",
             "io_bazel_rules_scala_scalatest_matchers_core",
             "io_bazel_rules_scala_scalatest_shouldmatchers",
             "io_bazel_rules_scala_scalatest_mustmatchers",

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -93,6 +93,7 @@ declare_deps_provider(
         "@io_bazel_rules_scala_scalatest_matchers_core",
         "@io_bazel_rules_scala_scalatest_mustmatchers",
         "@io_bazel_rules_scala_scalatest_shouldmatchers",
+        "@io_bazel_rules_scala_scalatest_wordspec",
     ],
 )
 

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -45,6 +45,10 @@ artifacts = {
         "artifact": "org.scalatest:scalatest-funspec_2.11:3.2.9",
         "sha256": "6ed2de364aacafcb3390144501ed4e0d24b7ff1431e8b9e6503d3af4bc160196",
     },
+    "io_bazel_rules_scala_scalatest_wordspec": {
+        "artifact": "org.scalatest:scalatest-wordspec_2.11:3.2.9",
+        "sha256": "96b382988fbcbf1c3ff45ba4eac06a069d0f3cb3247a66ea60fd7c0be90e55ed",
+    },
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.11:3.2.9",
         "sha256": "06eb7b5f3a8e8124c3a92e5c597a75ccdfa3fae022bc037770327d8e9c0759b4",

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -45,6 +45,10 @@ artifacts = {
         "artifact": "org.scalatest:scalatest-funspec_2.12:3.2.9",
         "sha256": "3d4d5b6e79c4398d0ff71f1ad4843f7eaf2acd0d197d782ee5f2437eb214ccf1",
     },
+    "io_bazel_rules_scala_scalatest_wordspec": {
+        "artifact": "org.scalatest:scalatest-wordspec_2.12:3.2.9",
+        "sha256": "3d51d057ac4858fb38faf63035f94687a29f75492825ee8881204008a0a59a95",
+    },
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.12:3.2.9",
         "sha256": "44e6bf24fb6fd4fd9419fcaf8d7e64b20c2916659f5d062d33f2de9a48ffdf09",

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -49,6 +49,10 @@ artifacts = {
         "artifact": "org.scalatest:scalatest-funspec_2.13:3.2.9",
         "sha256": "821d13ced0bf96d1470538cbcca3109694148f2637961e5c502639e16ab7eee9",
     },
+    "io_bazel_rules_scala_scalatest_wordspec": {
+        "artifact": "org.scalatest:scalatest-wordspec_2.13:3.2.9",
+        "sha256": "c5d5424bc43f02df9720bd83c57daa982af02ad7ae468875956ebe183f836277",
+    },
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.13:3.2.9",
         "sha256": "b86ed6f0986d005f4d54af5effdb73a18fe5741533f6663631d17a0731b9616f",

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -67,6 +67,10 @@ artifacts = {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.9",
         "sha256": "a4d0b15fea0f73cc7af7f1e35ae291966f8652fbf811d6525294691fa6fb54d2",
     },
+    "io_bazel_rules_scala_scalatest_wordspec": {
+        "artifact": "org.scalatest:scalatest-wordspec_3:3.2.9",
+        "sha256": "28a649d8f73fbd7a9d02e702a5f23577b4f6e301840d002d5574728a6ba5c473",
+    },
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.9",
         "sha256": "4aee69baf7cbbd2f8c28e02fab7aead12093bf905b322a4aca9c987de58dffab",


### PR DESCRIPTION
### Description
Adding the `scalatest-wordspec` package that is currently missing from the `scalatest` stack

Note : `scalatest-propspec` and `scalatest-refspec` are also missing not sure if it´s intentional or not... I can also add them if required so that all test styles will be covered. See [ScalaTest 3.2.0 Release notes](https://www.scalatest.org/release_notes/3.2.0)

### Motivation
This will allow supporting `WordSpec`  style out of the box with `scala_test` rule

Closes #1448 
