### PR TITLE
Add failing test for resource name crash

### DIFF
--- a/test/src/main/scala/scalarules/test/duplicated_resources/child/BUILD
+++ b/test/src/main/scala/scalarules/test/duplicated_resources/child/BUILD
@@ -1,0 +1,12 @@
+load("//scala:scala.bzl", "scala_test")
+
+# https://github.com/bazelbuild/rules_scala/issues/1455
+scala_test(
+    name = "child",
+    size = "small",
+    srcs = ["ScalaLibResourcesDuplicatedTest.scala"],
+    resources = ["resource.txt"],
+    unused_dependency_checker_mode = "off",
+    resource_strip_prefix = "test/src/main/scala/scalarules/test/duplicated_resources/child/",
+    deps = ["//test/src/main/scala/scalarules/test/duplicated_resources/parent"],
+)

--- a/test/src/main/scala/scalarules/test/duplicated_resources/child/ScalaLibResourcesDuplicatedTest.scala
+++ b/test/src/main/scala/scalarules/test/duplicated_resources/child/ScalaLibResourcesDuplicatedTest.scala
@@ -1,0 +1,14 @@
+package scalarules.test.duplicated
+
+import org.scalatest.funsuite._
+
+class ScalaLibResourcesDuplicatedTest extends AnyFunSuite {
+
+  test("Scala library depending on resources from external resource-only jar should allow to load resources") {
+    assert(get("/resource.txt") === "I am a text resource from child!\n")
+  }
+
+  private def get(s: String): String =
+    scala.io.Source.fromInputStream(getClass.getResourceAsStream(s)).mkString
+
+}

--- a/test/src/main/scala/scalarules/test/duplicated_resources/child/resource.txt
+++ b/test/src/main/scala/scalarules/test/duplicated_resources/child/resource.txt
@@ -1,0 +1,1 @@
+I am a text resource from child!

--- a/test/src/main/scala/scalarules/test/duplicated_resources/parent/BUILD
+++ b/test/src/main/scala/scalarules/test/duplicated_resources/parent/BUILD
@@ -1,0 +1,8 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "parent",
+    resources = ["resource.txt"],
+    resource_strip_prefix = "test/src/main/scala/scalarules/test/duplicated_resources/parent/",
+    visibility = ["//test/src/main/scala/scalarules/test/duplicated_resources/child:__pkg__"],
+)

--- a/test/src/main/scala/scalarules/test/duplicated_resources/parent/resource.txt
+++ b/test/src/main/scala/scalarules/test/duplicated_resources/parent/resource.txt
@@ -1,0 +1,1 @@
+I am a text resource from parent!


### PR DESCRIPTION


### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

This PR adds a failing test for https://github.com/bazelbuild/rules_scala/issues/1455

@liucijus mentioned this issue occurs around here https://github.com/bazelbuild/rules_scala/blob/master/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java#L65-L71 but re-ordering those lines doesn't work (I guess because re-ordering them control the priority of `resource`, `resource_jars`, and `classpath_resources`. It's not about resource name crash with things in JAR files).

My hunch is, this is caused because the executable file has a "wrong" order of CLASSPATH.
For example, `bazel-bin/test/src/main/scala/scalarules/test/duplicated_resources/child/child` (generated by`$ bazel build //test/src/main/scala/scalarules/test/duplicated_resources/child`) contains the following `CLASSPATH` order.

```
CLASSPATH="
  ${RUNPATH}test/src/main/scala/scalarules/test/duplicated_resources/parent/parent.jar:
  ${RUNPATH}../io_bazel_rules_scala_scala_library/scala-library-2.12.14.jar:
  ...
  ${RUNPATH}../bazel_tools/tools/java/runfiles/librunfiles.jar
  ${RUNPATH}test/src/main/scala/scalarules/test/duplicated_resources/child/child.jar:
  "
```

`parent.jar` is first, and `child.jar` is last.

I think we can fix this by moving `child.jar` to the first of `CLASSPATH` is the fix. Actually, moving `child.jar` to the place before `parent.jar` fixed the issue.

What do you think?


<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

see https://github.com/bazelbuild/rules_scala/issues/1455