### PR TITLE
Fix toolchain type reference

### DIFF
--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -108,7 +108,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
         wrapper.short_path,
     )
 
-    scala_toolchain = ctx.toolchains["//scala:toolchain_type"]
+    scala_toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
 
     test_runner_classpath_mode = "argsfile" if scala_toolchain.use_argument_file_in_runner else "manifest"
 


### PR DESCRIPTION
### Description
Fix toolchain type reference

### Motivation
Otherwise I am seeing the following build error

```
Traceback (most recent call last):
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/rules/scala_binary.bzl", line 32, column 22, in _scala_binary_impl
                return run_phases(
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/phases/api.bzl", line 45, column 23, in run_phases
                return _run_phases(ctx, builtin_customizable_phases, target = None)
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/phases/api.bzl", line 77, column 32, in _run_phases
                new_provider = function(ctx, current_provider)
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/phases/phase_write_executable.bzl", line 49, column 43, in phase_write_executable_common
                return _phase_write_executable_default(ctx, p)
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/phases/phase_write_executable.bzl", line 52, column 35, in _phase_write_executable_default
                return _phase_write_executable(
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/phases/phase_write_executable.bzl", line 74, column 45, in _phase_write_executable
                return _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco)
        File "/home/tgeng/.cache/bazel/_bazel_tgeng/7b03291da6ccf13fbe3c6d43388e7cbb/external/io_bazel_rules_scala/scala/private/phases/phase_write_executable.bzl", line 111, column 37, in _write_executable_non_windows
                scala_toolchain = ctx.toolchains["//scala:toolchain_type"]
Error: In scala_binary rule //bazel/test/platform_srcs:scala_binary, toolchain type //scala:toolchain_type was requested but only types [@io_bazel_rules_scala//scala:toolchain_type] are configured
```
