### PR TITLE
Replace zipper with singlejar

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -87,12 +87,6 @@ implicit_deps = {
         default = Label("@bazel_tools//tools/jdk:singlejar"),
         allow_files = True,
     ),
-    "_zipper": attr.label(
-        executable = True,
-        cfg = "exec",
-        default = Label("@bazel_tools//tools/zip:zipper"),
-        allow_files = True,
-    ),
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
     ),

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -362,11 +362,6 @@ def _try_to_compile_java_jar(
         java_compilation_provider = provider,
     )
 
-def _add_resources_cmd(ctx):
-    paths = _resource_paths(ctx.files.resources, ctx.attr.resource_strip_prefix)
-    lines = ["{target}={source}\n".format(target = p[0], source = p[1]) for p in paths]
-    return "".join(lines)
-
 def _collect_java_providers_of(deps):
     providers = []
     for dep in deps:

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -63,6 +63,7 @@ scala_benchmark_jmh(
 scala_benchmark_jmh(
     name = "test_jmh_jdk11",
     srcs = ["TestJmhRuntimeJdk11.scala"],
+    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
 )
 
 [sh_test(


### PR DESCRIPTION
Remove zipper from common attributes, singlejar is already there and can generate jars with resources.

Looking at bazel source code `singlejar` utility is used for:
* [pack_sources](https://github.com/bazelbuild/bazel/blob/455454a56e961affb041a1d4a9214f7f313a05aa/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java#L198)
* [resources_jar](https://github.com/bazelbuild/bazel/blob/master/src/main/java/com/google/devtools/build/lib/rules/java/ResourceJarActionBuilder.java#L123)

Motivation:

* use precompiled binaries ie singlejar comes precompiled via remote_java_tools while zipper is built from sources (at least in remote execution)
* use single tool to accomplish same goal