### PR TITLE
Add support for Scala 3.2

### DIFF
--- a/scala/support/BUILD
+++ b/scala/support/BUILD
@@ -5,6 +5,17 @@ scala_library(
     name = "test_reporter",
     srcs = ["JUnitXmlReporter.scala"],
     scalacopts = {
+        "3.2": [
+            "-deprecation:true",
+            "-encoding",
+            "UTF-8",
+            "-feature",
+            "-language:existentials",
+            "-language:higherKinds",
+            "-language:implicitConversions",
+            "-unchecked",
+            "-Xfatal-warnings",
+        ],
         "3.1": [
             "-deprecation:true",
             "-encoding",

--- a/test/shell/test_examples.sh
+++ b/test/shell/test_examples.sh
@@ -16,11 +16,16 @@ function multi_framework_toolchain_example() {
   (cd examples/testing/multi_frameworks_toolchain; bazel test //...)
 }
 
-function scala3_example() {
-  (cd examples/scala3; bazel build //...)
+function scala3_1_example() {
+  (cd examples/scala3; bazel build --repo_env=SCALA_VERSION=3.1.0 //...)
+}
+
+function scala3_2_example() {
+  (cd examples/scala3; bazel build --repo_env=SCALA_VERSION=3.2.1 //...)
 }
 
 $runner scalatest_repositories_example
 $runner specs2_junit_repositories_example
 $runner multi_framework_toolchain_example
-$runner scala3_example
+$runner scala3_1_example
+$runner scala3_2_example

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -19,6 +19,11 @@ load(
     _scala_version_3_1 = "scala_version",
 )
 load(
+    "//third_party/repositories:scala_3_2.bzl",
+    _artifacts_3_2 = "artifacts",
+    _scala_version_3_2 = "scala_version",
+)
+load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
 )
@@ -33,6 +38,7 @@ artifacts_by_major_scala_version = {
     "2.12": _artifacts_2_12,
     "2.13": _artifacts_2_13,
     "3.1": _artifacts_3_1,
+    "3.2": _artifacts_3_2,
 }
 
 scala_version_by_major_scala_version = {
@@ -40,6 +46,7 @@ scala_version_by_major_scala_version = {
     "2.12": _scala_version_2_12,
     "2.13": _scala_version_2_13,
     "3.1": _scala_version_3_1,
+    "3.2": _scala_version_3_2,
 }
 
 def repositories(

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -1,0 +1,534 @@
+scala_version = "3.2.1"
+
+artifacts = {
+    "io_bazel_rules_scala_scala_library_2": {
+        "artifact": "org.scala-lang:scala-library:2.13.5",
+        "sha256": "52aafeef8e0d104433329b1bc31463d1b4a9e2b8f24f85432c8cfaed9fad2587",
+    },
+    "io_bazel_rules_scala_scala_library": {
+        "artifact": "org.scala-lang:scala3-library_3:%s" % scala_version,
+        "sha256": "509669b30249e2b34a8488c9d1de7b978c9524c71712f1e2c8db2a516bc71266",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
+    "io_bazel_rules_scala_scala_compiler": {
+        "artifact": "org.scala-lang:scala3-compiler_3:%s" % scala_version,
+        "sha256": "bde05ca98bd7b681806eeda39524638d5cf0403254ca089d96a6d666eec5e66d",
+    },
+    "io_bazel_rules_scala_scala_interfaces": {
+        "artifact": "org.scala-lang:scala3-interfaces:%s" % scala_version,
+        "sha256": "5ceb45f9e2a2c56e4759cd96c9f4d097c3f07c1f9f6409990731f85733bbbef3",
+    },
+    "io_bazel_rules_scala_scala_tasty_core": {
+        "artifact": "org.scala-lang:tasty-core_3:%s" % scala_version,
+        "sha256": "2a7745396ba0ad90344f2dc9645123c6e2d568666668be7af9de0bee9898b933",
+    },
+    "io_bazel_rules_scala_scala_asm": {
+        "artifact": "org.scala-lang.modules:scala-asm:9.1.0-scala-1",
+        "sha256": "b85af6cbbd6075c4960177c2c3aa03d53b5221fa58b0bc74a31b72f25595e39f",
+    },
+
+    # todo: update to Scala 3.1 versions
+    "io_bazel_rules_scala_scala_parallel_collections": {
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:jar:1.0.4",
+        "sha256": "68f266c4fa37cb20a76e905ad940e241190ce288b7e4a9877f1dd1261cd1a9a7",
+    },
+    #
+    "io_bazel_rules_scala_scalatest": {
+        "artifact": "org.scalatest:scalatest_3:3.2.9",
+        "sha256": "6a528ed38912f9c69bf2a1be157871fe801bbff590eecb1a56fa25c62570e147",
+    },
+    "io_bazel_rules_scala_scalatest_compatible": {
+        "artifact": "org.scalatest:scalatest-compatible:jar:3.2.9",
+        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
+    },
+    "io_bazel_rules_scala_scalatest_core": {
+        "artifact": "org.scalatest:scalatest-core_3:3.2.9",
+        "sha256": "248674b6269578bc2f57d595f1e484fc02837ef567ba461eafb81294bce611a8",
+    },
+    "io_bazel_rules_scala_scalatest_featurespec": {
+        "artifact": "org.scalatest:scalatest-featurespec_3:3.2.9",
+        "sha256": "db51db398582b656cc0b90fbd1c6e5c2495125706b1f860b4cdfc5aba1832d0d",
+    },
+    "io_bazel_rules_scala_scalatest_flatspec": {
+        "artifact": "org.scalatest:scalatest-flatspec_3:3.2.9",
+        "sha256": "b558319f8b4835d25424381dc9b7dcc3b27353cf36dc2c28270dac59e8c8b827",
+    },
+    "io_bazel_rules_scala_scalatest_freespec": {
+        "artifact": "org.scalatest:scalatest-freespec_3:3.2.9",
+        "sha256": "dfcbce7d8315dca731b2829ad233893f2dec8895543267c086f7c88a618bda97",
+    },
+    "io_bazel_rules_scala_scalatest_funsuite": {
+        "artifact": "org.scalatest:scalatest-funsuite_3:3.2.9",
+        "sha256": "f3aa7a6414a6f0217ab386be38da537738239f073512a00e93967ac34ff3c9d3",
+    },
+    "io_bazel_rules_scala_scalatest_funspec": {
+        "artifact": "org.scalatest:scalatest-funspec_3:3.2.9",
+        "sha256": "a4d0b15fea0f73cc7af7f1e35ae291966f8652fbf811d6525294691fa6fb54d2",
+    },
+    "io_bazel_rules_scala_scalatest_matchers_core": {
+        "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.9",
+        "sha256": "4aee69baf7cbbd2f8c28e02fab7aead12093bf905b322a4aca9c987de58dffab",
+    },
+    "io_bazel_rules_scala_scalatest_shouldmatchers": {
+        "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.9",
+        "sha256": "5866c9f28faf5389a82d0a66f3539933325eed3a03425c9bf2f495c34f4bb370",
+    },
+    "io_bazel_rules_scala_scalatest_mustmatchers": {
+        "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.9",
+        "sha256": "2755b8558acf71603b70d10a02f9df43a216f305318dbcb442d5451f0da32c46",
+    },
+    "io_bazel_rules_scala_scalactic": {
+        "artifact": "org.scalactic:scalactic_3:3.2.9",
+        "sha256": "dde6c79aeb8ca632ac9aede0a00462b6b75d0db857bf0e9f264a2ed36efcb800",
+    },
+    "io_bazel_rules_scala_scala_xml": {
+        "artifact": "org.scala-lang.modules:scala-xml_2.13:1.3.0",
+        "sha256": "6d96d45a7fc6fc7ab69bdbac841b48cf67ab109f048c8db375ae4effae524f39",
+    },
+    "io_bazel_rules_scala_scala_parser_combinators": {
+        "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:1.1.2",
+        "sha256": "5c285b72e6dc0a98e99ae0a1ceeb4027dab9adfa441844046bd3f19e0efdcb54",
+    },
+    "org_scalameta_common": {
+        "artifact": "org.scalameta:common_2.13:4.3.24",
+        "sha256": "bb8ffbca69b42417aa5d3c73d4434b73dbbeb66748abc44a024090ff3aa38bd3",
+        "deps": [
+            "@com_lihaoyi_sourcecode",
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "org_scalameta_fastparse": {
+        "artifact": "org.scalameta:fastparse_2.13:1.0.1",
+        "sha256": "b43b99244d5b51948daf1467083b3850dc2727c604de98dc426dec14244fd18e",
+        "deps": [
+            "@com_lihaoyi_sourcecode",
+            "@io_bazel_rules_scala_scala_library",
+            "@org_scalameta_fastparse_utils",
+        ],
+    },
+    "org_scalameta_fastparse_utils": {
+        "artifact": "org.scalameta:fastparse-utils_2.13:1.0.1",
+        "sha256": "9d650543903836684a808bb4c5ff775a4cae4b38c3a47ce946b572237fde340f",
+        "deps": [
+            "@com_lihaoyi_sourcecode",
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "org_scala_lang_modules_scala_collection_compat": {
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.2.0",
+        "sha256": "7f601d3a6d699433ddaf549ffa1441dcbe00bc95f4035add9776772053e9f93f",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "org_scalameta_parsers": {
+        "artifact": "org.scalameta:parsers_2.13:4.3.24",
+        "sha256": "5faebb22a064f38a4be19fdadb288dc771c1e362d0c4d2f46546f08e4f43c091",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@org_scalameta_trees",
+        ],
+    },
+    "org_scalameta_scalafmt_core": {
+        "artifact": "org.scalameta:scalafmt-core_2.13:2.7.4",
+        "sha256": "873d98275f75b67c1e01094a24bafb29a588b7d05fdc508d3b1ba02f08d0c0d8",
+        "deps": [
+            "@com_geirsson_metaconfig_core",
+            "@com_geirsson_metaconfig_typesafe_config",
+            "@org_scalameta_scalameta",
+            "@org_scala_lang_modules_scala_collection_compat",
+            "@io_bazel_rules_scala_scala_parallel_collections",
+        ],
+    },
+    "org_scalameta_scalameta": {
+        "artifact": "org.scalameta:scalameta_2.13:4.3.24",
+        "sha256": "d73eaf491eb588a2bd78aeba443e62bc95f1a368051d9e81607192c88fa4c61c",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+            "@org_scala_lang_scalap",
+            "@org_scalameta_parsers",
+        ],
+    },
+    "org_scalameta_trees": {
+        "artifact": "org.scalameta:trees_2.13:4.3.24",
+        "sha256": "d49d2b085ae62e9317dd2a4e8b14be5b1ecbec2db392fa81cab86ad2bd7c2c68",
+        "deps": [
+            "@com_thesamet_scalapb_scalapb_runtime",
+            "@io_bazel_rules_scala_scala_library",
+            "@org_scalameta_common",
+            "@org_scalameta_fastparse",
+        ],
+    },
+    "org_typelevel_paiges_core": {
+        "artifact": "org.typelevel:paiges-core_2.13:0.2.4",
+        "sha256": "1f55b6f90e370a1c18f7350f6925626b5cde69b17560bd2e2a33137780b210df",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "com_typesafe_config": {
+        "artifact": "com.typesafe:config:1.3.3",
+        "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
+    },
+    "org_scala_lang_scalap": {
+        "artifact": "org.scala-lang:scalap:2.13.6",
+        "sha256": "bbfa4ab0603f510b16114371a35b9c34d20946edfc1aa8f3fd31014b9f06b5b1",
+        "deps": [
+            "@io_bazel_rules_scala_scala_compiler",
+        ],
+    },
+    "com_thesamet_scalapb_lenses": {
+        "artifact": "com.thesamet.scalapb:lenses_2.13:0.9.0",
+        "sha256": "10830d6511fc21b997c4acdde6f6700e87ee6791cbe6278f5acd7b352670a88f",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "com_thesamet_scalapb_scalapb_runtime": {
+        "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:0.9.0",
+        "sha256": "10830d6511fc21b997c4acdde6f6700e87ee6791cbe6278f5acd7b352670a88f",
+        "deps": [
+            "@com_google_protobuf_protobuf_java",
+            "@com_lihaoyi_fastparse",
+            "@com_thesamet_scalapb_lenses",
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "com_lihaoyi_fansi": {
+        "artifact": "com.lihaoyi:fansi_2.13:0.2.9",
+        "sha256": "c347b6452152cf55d401090d3d3c230d96a5f9b6792d1bdb9b760e0d5187ed30",
+        "deps": [
+            "@com_lihaoyi_sourcecode",
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "com_lihaoyi_fastparse": {
+        "artifact": "com.lihaoyi:fastparse_2.13:2.1.3",
+        "sha256": "5064d3984aab8c48d2dbd6285787ac5c6d84a6bebfc02c6d431ce153cf91dec1",
+        "deps": [
+            "@com_lihaoyi_sourcecode",
+        ],
+    },
+    "com_lihaoyi_pprint": {
+        "artifact": "com.lihaoyi:pprint_2.13:0.6.0",
+        "sha256": "6bc908b7acb825bc0ce1148a1a417ab1b75335c98749e6e2d2ad3d09604e3701",
+        "deps": [
+            "@com_lihaoyi_fansi",
+            "@com_lihaoyi_sourcecode",
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "com_lihaoyi_sourcecode": {
+        "artifact": "com.lihaoyi:sourcecode_2.13:0.1.7",
+        "sha256": "6371a79bfd1125ccf0dbf3278c178f3554a50507975f4a182abb973044f24945",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
+    "com_google_protobuf_protobuf_java": {
+        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
+        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+    },
+    "com_geirsson_metaconfig_core": {
+        "artifact": "com.geirsson:metaconfig-core_2.13:0.9.10",
+        "sha256": "2ee1f3ee60e4c5e3de63ab9bfe52be2c4f319552b7afedbc20c5097fc26fdc8c",
+        "deps": [
+            "@com_lihaoyi_pprint",
+            "@io_bazel_rules_scala_scala_library",
+            "@org_typelevel_paiges_core",
+            "@org_scala_lang_modules_scala_collection_compat",
+        ],
+    },
+    "com_geirsson_metaconfig_typesafe_config": {
+        "artifact": "com.geirsson:metaconfig-typesafe-config_2.13:0.9.10",
+        "sha256": "bd3698fed4af61d03b9b70783dfaa457e664eae234ca1b83f2580552d1306e39",
+        "deps": [
+            "@com_geirsson_metaconfig_core",
+            "@com_typesafe_config",
+            "@io_bazel_rules_scala_scala_library",
+            "@org_scala_lang_modules_scala_collection_compat",
+        ],
+    },
+    "io_bazel_rules_scala_org_openjdk_jmh_jmh_core": {
+        "artifact": "org.openjdk.jmh:jmh-core:1.20",
+        "sha256": "1688db5110ea6413bf63662113ed38084106ab1149e020c58c5ac22b91b842ca",
+    },
+    "io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_asm": {
+        "artifact": "org.openjdk.jmh:jmh-generator-asm:1.20",
+        "sha256": "2dd4798b0c9120326310cda3864cc2e0035b8476346713d54a28d1adab1414a5",
+    },
+    "io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_reflection": {
+        "artifact": "org.openjdk.jmh:jmh-generator-reflection:1.20",
+        "sha256": "57706f7c8278272594a9afc42753aaf9ba0ba05980bae0673b8195908d21204e",
+    },
+    "io_bazel_rules_scala_org_ows2_asm_asm": {
+        "artifact": "org.ow2.asm:asm:6.1.1",
+        "sha256": "dd3b546415dd4bade2ebe3b47c7828ab0623ee2336604068e2d81023f9f8d833",
+    },
+    "io_bazel_rules_scala_net_sf_jopt_simple_jopt_simple": {
+        "artifact": "net.sf.jopt-simple:jopt-simple:4.6",
+        "sha256": "3fcfbe3203c2ea521bf7640484fd35d6303186ea2e08e72f032d640ca067ffda",
+    },
+    "io_bazel_rules_scala_org_apache_commons_commons_math3": {
+        "artifact": "org.apache.commons:commons-math3:3.6.1",
+        "sha256": "1e56d7b058d28b65abd256b8458e3885b674c1d588fa43cd7d1cbb9c7ef2b308",
+    },
+    "io_bazel_rules_scala_junit_junit": {
+        "artifact": "junit:junit:4.12",
+        "sha256": "59721f0805e223d84b90677887d9ff567dc534d7c502ca903c0c2b17f05c116a",
+    },
+    "io_bazel_rules_scala_org_hamcrest_hamcrest_core": {
+        "artifact": "org.hamcrest:hamcrest-core:1.3",
+        "sha256": "66fdef91e9739348df7a096aa384a5685f4e875584cce89386a7a47251c4d8e9",
+    },
+    "io_bazel_rules_scala_org_specs2_specs2_common": {
+        "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
+        "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
+        "deps": [
+            "@io_bazel_rules_scala_org_specs2_specs2_fp",
+        ],
+    },
+    "io_bazel_rules_scala_org_specs2_specs2_core": {
+        "artifact": "org.specs2:specs2-core_3:jar:5.0.0-RC-21",
+        "sha256": "ad4197e181c5921e685ce30b38f8a536745c8f3728172df49f7be2256e675608",
+        "deps": [
+            "@io_bazel_rules_scala_org_specs2_specs2_common",
+            "@io_bazel_rules_scala_org_specs2_specs2_matcher",
+        ],
+    },
+    "io_bazel_rules_scala_org_specs2_specs2_fp": {
+        "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
+        "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+    },
+    "io_bazel_rules_scala_org_specs2_specs2_matcher": {
+        "artifact": "org.specs2:specs2-matcher_3:jar:5.0.0-RC-21",
+        "sha256": "e747c4f40f3a96bfec5ac4a4af7d6b8b8f6f74b2412513752730888f75050e0b",
+        "deps": [
+            "@io_bazel_rules_scala_org_specs2_specs2_common",
+        ],
+    },
+    "io_bazel_rules_scala_org_specs2_specs2_junit": {
+        "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",
+        "sha256": "7e8b2c8ab10e6ea1ee471fb0313ad4c81963f326aa66efc4a2f476815ac4f8d9",
+        "deps": [
+            "@io_bazel_rules_scala_org_specs2_specs2_core",
+        ],
+    },
+    "scala_proto_rules_scalapb_plugin": {
+        "artifact": "com.thesamet.scalapb:compilerplugin_2.13:0.9.7",
+        "sha256": "ac29c2f01b0b1e39c4226915000505643d586234d586247e1fd97133e20bcc60",
+    },
+    "scala_proto_rules_protoc_bridge": {
+        "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.7.14",
+        "sha256": "0704f2379374205e7130018e3df6b3d50a4d330c3e447ca39b5075ecb4c93cd1",
+    },
+    "scala_proto_rules_scalapb_runtime": {
+        "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:0.9.7",
+        "sha256": "8026485011c53d35eb427ac5c09ed34c283b355d8a6363eae68b3f165bee34a0",
+    },
+    "scala_proto_rules_scalapb_runtime_grpc": {
+        "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:0.9.7",
+        "sha256": "950984d4a3b21925d3156dd98cddb4e7c2f429aad81aa25bb5a3792d41fd7c76",
+    },
+    "scala_proto_rules_scalapb_lenses": {
+        "artifact": "com.thesamet.scalapb:lenses_2.13:0.9.7",
+        "sha256": "5f43b371b2738a81eff129fd2071ce3e5b3aa30909de90e6bb6e25c3de6c312d",
+    },
+    "scala_proto_rules_scalapb_fastparse": {
+        "artifact": "com.lihaoyi:fastparse_2.13:2.1.3",
+        "sha256": "5064d3984aab8c48d2dbd6285787ac5c6d84a6bebfc02c6d431ce153cf91dec1",
+    },
+    "scala_proto_rules_grpc_core": {
+        "artifact": "io.grpc:grpc-core:1.24.0",
+        "sha256": "8fc900625a9330b1c155b5423844d21be0a5574fe218a63170a16796c6f7880e",
+    },
+    "scala_proto_rules_grpc_api": {
+        "artifact": "io.grpc:grpc-api:1.24.0",
+        "sha256": "553978366e04ee8ddba64afde3b3cf2ac021a2f3c2db2831b6491d742b558598",
+    },
+    "scala_proto_rules_grpc_stub": {
+        "artifact": "io.grpc:grpc-stub:1.24.0",
+        "sha256": "eaa9201896a77a0822e26621b538c7154f00441a51c9b14dc9e1ec1f2acfb815",
+    },
+    "scala_proto_rules_grpc_protobuf": {
+        "artifact": "io.grpc:grpc-protobuf:1.24.0",
+        "sha256": "88cd0838ea32893d92cb214ea58908351854ed8de7730be07d5f7d19025dd0bc",
+    },
+    "scala_proto_rules_grpc_netty": {
+        "artifact": "io.grpc:grpc-netty:1.24.0",
+        "sha256": "8478333706ba442a354c2ddb8832d80a5aef71016e8a9cf07e7bf6e8c298f042",
+    },
+    "scala_proto_rules_grpc_context": {
+        "artifact": "io.grpc:grpc-context:1.24.0",
+        "sha256": "1f0546e18789f7445d1c5a157010a11bc038bbb31544cdb60d9da3848efcfeea",
+    },
+    "scala_proto_rules_perfmark_api": {
+        "artifact": "io.perfmark:perfmark-api:0.17.0",
+        "sha256": "816c11409b8a0c6c9ce1cda14bed526e7b4da0e772da67c5b7b88eefd41520f9",
+    },
+    "scala_proto_rules_guava": {
+        "artifact": "com.google.guava:guava:26.0-android",
+        "sha256": "1d044ebb866ef08b7d04e998b4260c9b52fab6e6d6b68d207859486bb3686cd5",
+    },
+    "scala_proto_rules_google_instrumentation": {
+        "artifact": "com.google.instrumentation:instrumentation-api:0.3.0",
+        "sha256": "671f7147487877f606af2c7e39399c8d178c492982827305d3b1c7f5b04f1145",
+    },
+    "scala_proto_rules_netty_codec": {
+        "artifact": "io.netty:netty-codec:4.1.32.Final",
+        "sha256": "dbd6cea7d7bf5a2604e87337cb67c9468730d599be56511ed0979aacb309f879",
+    },
+    "scala_proto_rules_netty_codec_http": {
+        "artifact": "io.netty:netty-codec-http:4.1.32.Final",
+        "sha256": "db2c22744f6a4950d1817e4e1a26692e53052c5d54abe6cceecd7df33f4eaac3",
+    },
+    "scala_proto_rules_netty_codec_socks": {
+        "artifact": "io.netty:netty-codec-socks:4.1.32.Final",
+        "sha256": "fe2f2e97d6c65dc280623dcfd24337d8a5c7377049c120842f2c59fb83d7408a",
+    },
+    "scala_proto_rules_netty_codec_http2": {
+        "artifact": "io.netty:netty-codec-http2:4.1.32.Final",
+        "sha256": "4d4c6cfc1f19efb969b9b0ae6cc977462d202867f7dcfee6e9069977e623a2f5",
+    },
+    "scala_proto_rules_netty_handler": {
+        "artifact": "io.netty:netty-handler:4.1.32.Final",
+        "sha256": "07d9756e48b5f6edc756e33e8b848fb27ff0b1ae087dab5addca6c6bf17cac2d",
+    },
+    "scala_proto_rules_netty_buffer": {
+        "artifact": "io.netty:netty-buffer:4.1.32.Final",
+        "sha256": "8ac0e30048636bd79ae205c4f9f5d7544290abd3a7ed39d8b6d97dfe3795afc1",
+    },
+    "scala_proto_rules_netty_transport": {
+        "artifact": "io.netty:netty-transport:4.1.32.Final",
+        "sha256": "175bae0d227d7932c0c965c983efbb3cf01f39abe934f5c4071d0319784715fb",
+    },
+    "scala_proto_rules_netty_resolver": {
+        "artifact": "io.netty:netty-resolver:4.1.32.Final",
+        "sha256": "9b4a19982047a95ea4791a7ad7ad385c7a08c2ac75f0a3509cc213cb32a726ae",
+    },
+    "scala_proto_rules_netty_common": {
+        "artifact": "io.netty:netty-common:4.1.32.Final",
+        "sha256": "cc993e660f8f8e3b033f1d25a9e2f70151666bdf878d460a6508cb23daa696dc",
+    },
+    "scala_proto_rules_netty_handler_proxy": {
+        "artifact": "io.netty:netty-handler-proxy:4.1.32.Final",
+        "sha256": "10d1081ed114bb0e76ebbb5331b66a6c3189cbdefdba232733fc9ca308a6ea34",
+    },
+    "scala_proto_rules_opencensus_api": {
+        "artifact": "io.opencensus:opencensus-api:0.22.1",
+        "sha256": "62a0503ee81856ba66e3cde65dee3132facb723a4fa5191609c84ce4cad36127",
+    },
+    "scala_proto_rules_opencensus_impl": {
+        "artifact": "io.opencensus:opencensus-impl:0.22.1",
+        "sha256": "9e8b209da08d1f5db2b355e781b9b969b2e0dab934cc806e33f1ab3baed4f25a",
+    },
+    "scala_proto_rules_disruptor": {
+        "artifact": "com.lmax:disruptor:3.4.2",
+        "sha256": "f412ecbb235c2460b45e63584109723dea8d94b819c78c9bfc38f50cba8546c0",
+    },
+    "scala_proto_rules_opencensus_impl_core": {
+        "artifact": "io.opencensus:opencensus-impl-core:0.22.1",
+        "sha256": "04607d100e34bacdb38f93c571c5b7c642a1a6d873191e25d49899668514db68",
+    },
+    "scala_proto_rules_opencensus_contrib_grpc_metrics": {
+        "artifact": "io.opencensus:opencensus-contrib-grpc-metrics:0.22.1",
+        "sha256": "3f6f4d5bd332c516282583a01a7c940702608a49ed6e62eb87ef3b1d320d144b",
+    },
+    "io_bazel_rules_scala_mustache": {
+        "artifact": "com.github.spullara.mustache.java:compiler:0.8.18",
+        "sha256": "ddabc1ef897fd72319a761d29525fd61be57dc25d04d825f863f83cc89000e66",
+    },
+    "io_bazel_rules_scala_guava": {
+        "artifact": "com.google.guava:guava:21.0",
+        "sha256": "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    },
+    "libthrift": {
+        "artifact": "org.apache.thrift:libthrift:0.8.0",
+        "sha256": "adea029247c3f16e55e29c1708b897812fd1fe335ac55fe3903e5d2f428ef4b3",
+    },
+    "io_bazel_rules_scala_scrooge_core": {
+        "artifact": "com.twitter:scrooge-core_2.13:21.2.0",
+        "sha256": "a93f179b96e13bd172e5164c587a3645122f45f6d6370304e06d52e2ab0e456f",
+    },
+    "io_bazel_rules_scala_scrooge_generator": {
+        "artifact": "com.twitter:scrooge-generator_2.13:21.2.0",
+        "sha256": "1293391da7df25497cad7c56cf8ecaeb672496a548d144d7a2a1cfcf748bed6c",
+        "runtime_deps": [
+            "@io_bazel_rules_scala_guava",
+            "@io_bazel_rules_scala_mustache",
+            "@io_bazel_rules_scala_scopt",
+        ],
+    },
+    "io_bazel_rules_scala_util_core": {
+        "artifact": "com.twitter:util-core_2.13:21.2.0",
+        "sha256": "da8e149b8f0646316787b29f6e254250da10b4b31d9a96c32e42f613574678cd",
+    },
+    "io_bazel_rules_scala_util_logging": {
+        "artifact": "com.twitter:util-logging_2.13:21.2.0",
+        "sha256": "90bd8318329907dcf7e161287473e27272b38ee6857e9d56ee8a1958608cc49d",
+    },
+    "io_bazel_rules_scala_javax_annotation_api": {
+        "artifact": "javax.annotation:javax.annotation-api:1.3.2",
+        "sha256": "e04ba5195bcd555dc95650f7cc614d151e4bcd52d29a10b8aa2197f3ab89ab9b",
+    },
+    "io_bazel_rules_scala_scopt": {
+        "artifact": "com.github.scopt:scopt_2.13:4.0.0-RC2",
+        "sha256": "07c1937cba53f7509d2ac62a0fc375943a3e0fef346625414c15d41b5a6cfb34",
+    },
+
+    # test only
+    "com_twitter__scalding_date": {
+        "testonly": True,
+        "artifact": "com.twitter:scalding-date_2.13:0.17.0",
+        "sha256": "973a7198121cc8dac9eeb3f325c93c497fe3b682f68ba56e34c1b210af7b15b4",
+    },
+    "org_typelevel__cats_core": {
+        "testonly": True,
+        "artifact": "org.typelevel:cats-core_3:jar:2.7.0",
+        "sha256": "6f3e17cb666886b7f21998e981ebf45966fe951898f851437a518a93cab667bd",
+    },
+    "com_google_guava_guava_21_0_with_file": {
+        "testonly": True,
+        "artifact": "com.google.guava:guava:21.0",
+        "sha256": "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+    },
+    "com_github_jnr_jffi_native": {
+        "testonly": True,
+        "artifact": "com.github.jnr:jffi:jar:native:1.2.17",
+        "sha256": "4eb582bc99d96c8df92fc6f0f608fd123d278223982555ba16219bf8be9f75a9",
+    },
+    "org_apache_commons_commons_lang_3_5": {
+        "testonly": True,
+        "artifact": "org.apache.commons:commons-lang3:3.5",
+        "sha256": "8ac96fc686512d777fca85e144f196cd7cfe0c0aec23127229497d1a38ff651c",
+    },
+    "org_springframework_spring_core": {
+        "testonly": True,
+        "artifact": "org.springframework:spring-core:5.1.5.RELEASE",
+        "sha256": "f771b605019eb9d2cf8f60c25c050233e39487ff54d74c93d687ea8de8b7285a",
+    },
+    "org_springframework_spring_tx": {
+        "testonly": True,
+        "artifact": "org.springframework:spring-tx:5.1.5.RELEASE",
+        "sha256": "666f72b73c7e6b34e5bb92a0d77a14cdeef491c00fcb07a1e89eb62b08500135",
+        "deps": [
+            "@org_springframework_spring_core",
+        ],
+    },
+    "com_google_guava_guava_21_0": {
+        "testonly": True,
+        "artifact": "com.google.guava:guava:21.0",
+        "sha256": "972139718abc8a4893fa78cba8cf7b2c903f35c97aaf44fa3031b0669948b480",
+        "deps": [
+            "@org_springframework_spring_core",
+        ],
+    },
+    # TODO: fix misleading artifact group in id
+    "org_spire_math_kind_projector": {
+        "testonly": True,
+        "artifact": "org.typelevel:kind-projector_2.13:0.10.3",
+        "sha256": "b5d60c8bc8f1333e2deac17d72d41bb59c53283a67ff3a613189746ce97ac8ad",
+    },
+}


### PR DESCRIPTION
### Description
Add support of Scala 3.2

- Add the build and repository definitions for Scala 3.2.1
- Add an extra set of tests for Scala 3.2.1

### Motivation
- To stay as close as possible to the head of Scala.
-  To make new features in Scala 3.2 available to developers.

Fixes #1464
