### PR TITLE
Update release workflow with a stable archive

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Prepare workspace snippet
-        run: .github/workflows/workspace_snippet.sh > release_notes.txt
+        run: .github/workflows/workspace_snippet.sh ${{ env.GITHUB_REF_NAME }} > release_notes.txt
 
       - name: Release
         uses: softprops/action-gh-release@v1
@@ -23,3 +23,5 @@ jobs:
           # Use GH feature to populate the changelog automatically
           generate_release_notes: true
           body_path: release_notes.txt
+          fail_on_unmatched_files: true
+          files: rules_scala-*.tar.gz

--- a/.github/workflows/workspace_snippet.sh
+++ b/.github/workflows/workspace_snippet.sh
@@ -6,7 +6,9 @@ set -o errexit -o nounset -o pipefail
 # https://docs.github.com/en/actions/learn-github-actions/environment-variables#default-environment-variables
 TAG=${GITHUB_REF_NAME}
 PREFIX="rules_scala-${TAG:1}"
-SHA=$(git archive --format=tar --prefix="${PREFIX}/" "${TAG}" | gzip | shasum -a 256 | awk '{print $1}')
+ARCHIVE="rules_scala-$TAG.tar.gz"
+git archive --format=tar --prefix=${PREFIX}/ ${TAG} | gzip > $ARCHIVE
+SHA=$(shasum -a 256 $ARCHIVE | awk '{print $1}')
 
 cat << EOF
 ## Using WORKSPACE
@@ -20,7 +22,7 @@ http_archive(
     name = "io_bazel_rules_scala",
     sha256 = "${SHA}",
     strip_prefix = "${PREFIX}",
-    url = "https://github.com/bazelbuild/rules_scala/archive/refs/tags/${TAG}.tar.gz",
+    url = "https://github.com/bazelbuild/rules_scala/releases/download/${TAG}/${ARCHIVE}",
 )
 \`\`\`
 


### PR DESCRIPTION
Github generated archive may not be stable - let's upload custom archive to keep stable checksum