### PR TITLE
Add exec transition to scala_test _lcov_merger

### DIFF
--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -78,6 +78,7 @@ _scala_test_attrs = {
     ),
     "_lcov_merger": attr.label(
         default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
+        cfg = "exec",
     ),
     "env": attr.string_dict(default = {}),
     "env_inherit": attr.string_list(),


### PR DESCRIPTION
### Description
Have _lcov_merger run in the exec configuration. This fixes issues when running coverage when `--java_runtime_version` is a JRE 8 on Bazel > 6.x, similar to https://github.com/bazelbuild/bazel/issues/17568.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
Fixes coverage on JRE 8.