### PR TITLE
Fix dead link in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Please also note, that the `overriden_artifacts` parameter is likely to be remov
 | 0.14.x | 3b9ab9be31ac217d3337c709cb6bfeb89c8dcbb1 |
 | 0.13.x | 3c987b6ae8a453886759b132f1572c0efca2eca2 |
 
-PRs are also built with highest supported bazel version (see [Travis config](https://github.com/bazelbuild/rules_scala/blob/master/.travis.yml) for the exact highest version)
+See [the configuration file](https://github.com/bazelbuild/rules_scala/blob/master/.bazelci/presubmit.yml) for the exact versions verified with the continuous-integration builds.
 
 ## Breaking changes
 


### PR DESCRIPTION

### Description
README: travis ci is no longer in use, thus the link was dead. Also it doesn't appear that "the highest supported" version is built at all.

### Motivation

Find my way around the docs as a newbie