### PR TITLE
Add flag for option to run run_ijar for imports

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -9,12 +9,20 @@ def _stamp_jar(ctx, jar):
     stamped_jar_filename = "%s.stamp/%s" % (ctx.label.name, jar.basename)
     symlink_file = ctx.actions.declare_file(stamped_jar_filename)
     ctx.actions.symlink(output = symlink_file, target_file = jar)
-    return java_common.stamp_jar(
-        actions = ctx.actions,
-        jar = symlink_file,
-        target_label = ctx.label,
-        java_toolchain = specified_java_compile_toolchain(ctx),
-    )
+    if ctx.attr.use_ijar:
+        return java_common.run_ijar(
+            actions = ctx.actions,
+            jar = symlink_file,
+            target_label = ctx.label,
+            java_toolchain = specified_java_compile_toolchain(ctx),
+        )
+    else:
+        return java_common.stamp_jar(
+            actions = ctx.actions,
+            jar = symlink_file,
+            target_label = ctx.label,
+            java_toolchain = specified_java_compile_toolchain(ctx),
+        )
 
 # intellij part is tested manually, tread lightly when changing there
 # if you change make sure to manually re-import an intellij project and see imports
@@ -136,6 +144,7 @@ scala_import = rule(
         "runtime_deps": attr.label_list(),
         "exports": attr.label_list(),
         "neverlink": attr.bool(),
+        "use_ijar": attr.bool(default = False),
         "srcjar": attr.label(allow_single_file = True),
         "_placeholder_jar": attr.label(
             allow_single_file = True,

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -44,7 +44,7 @@ _PASS_PROPS = (
     "runtime_deps",
     "deps",
     "tags",
-    "use_ijar"
+    "use_ijar",
 )
 
 _FETCH_SOURCES_ENV_VAR_NAME = "BAZEL_JVM_FETCH_SOURCES"

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -44,6 +44,7 @@ _PASS_PROPS = (
     "runtime_deps",
     "deps",
     "tags",
+    "use_ijar"
 )
 
 _FETCH_SOURCES_ENV_VAR_NAME = "BAZEL_JVM_FETCH_SOURCES"
@@ -55,6 +56,7 @@ def _jvm_import_external(repository_ctx):
         fail("Only use generated_linkable_rule_name if neverlink is set")
     name = repository_ctx.attr.generated_rule_name or repository_ctx.name
     urls = repository_ctx.attr.jar_urls
+    use_ijar = repository_ctx.attr.use_ijar
     if repository_ctx.attr.jar_sha256:
         print("'jar_sha256' is deprecated. Please use 'artifact_sha256'")
     sha = repository_ctx.attr.jar_sha256 or repository_ctx.attr.artifact_sha256
@@ -227,6 +229,7 @@ jvm_import_external = repository_rule(
             default = ["//visibility:public"],
         ),
         "extra_build_file_content": attr.string(),
+        "use_ijar": attr.bool(),
     },
     environ = [_FETCH_SOURCES_ENV_VAR_NAME],
 )

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -78,4 +78,5 @@ def repositories(
             runtime_deps = artifacts[id].get("runtime_deps", []),
             testonly_ = artifacts[id].get("testonly", False),
             fetch_sources = fetch_sources,
+            use_ijar = artifacts[id].get("use_ijar", False),
         )


### PR DESCRIPTION
### Description
Add flag option to use run_ijar for imports instead of stamp_jar


### Motivation
Should help reduce rebuilding of dependent jars during any recompiles consisting only of simple changes to method implementations
