### PR TITLE
updated stripPrefix to strip_prefix for issue #16496.

### DIFF
--- a/private/format.bzl
+++ b/private/format.bzl
@@ -26,7 +26,7 @@ load(
 def _com_github_google_yapf_repository_impl(rctx):
     rctx.download_and_extract(
         url = "https://github.com/google/yapf/archive/v0.21.0.tar.gz",
-        stripPrefix = "yapf-0.21.0",
+        strip_prefix = "yapf-0.21.0",
     )
     rctx.file("BUILD", """
 alias(


### PR DESCRIPTION
### Description
Fix naming convention inconsistencies in rctx.download_and_extract for stripPrefix in _format.bzl_ for issue #16496.

Changed stripPrefix to strip_prefix in the function argument.

## Updated code:
<img width="651" alt="image" src="https://user-images.githubusercontent.com/64241254/223678187-0d84b172-d199-490e-a57f-f7921cdd2993.png">
