### PR TITLE
phase_merge_jars: add separate merged output jars for external and in…

### DIFF
--- a/scala/private/common_outputs.bzl
+++ b/scala/private/common_outputs.bzl
@@ -3,6 +3,8 @@
 common_outputs = {
     "jar": "%{name}.jar",
     "deploy_jar": "%{name}_deploy.jar",
+    "external_deps_component_jar": "%{name}_external_deps_component.jar",
+    "internal_deps_component_jar": "%{name}_internal_deps_component.jar",
     "manifest": "%{name}_MANIFEST.MF",
     "statsfile": "%{name}.statsfile",
     "diagnosticsfile": "%{name}.diagnosticsproto",

--- a/scala/private/phases/phase_merge_jars.bzl
+++ b/scala/private/phases/phase_merge_jars.bzl
@@ -34,8 +34,23 @@ def merge_jars_to_output(ctx, output, jars):
 
 def phase_merge_jars(ctx, p):
     deploy_jar = ctx.outputs.deploy_jar
+    external_deps_component_jar = ctx.outputs.external_deps_component_jar
+    internal_deps_component_jar = ctx.outputs.internal_deps_component_jar
+
     runtime_jars = p.compile.rjars
+    internal_jars = []
+    external_jars = []
+    for jar in runtime_jars.to_list():
+        if jar.short_path.startswith("../"):
+            # External dependencies go here:
+            external_jars.append(jar)
+        elif jar != ctx.outputs.jar:
+            # Internal dependencies go here (except the currently built thin jar):
+            internal_jars.append(jar)
+
     merge_jars_to_output(ctx, deploy_jar, runtime_jars)
+    merge_jars_to_output(ctx, external_deps_component_jar, external_jars)
+    merge_jars_to_output(ctx, internal_deps_component_jar, internal_jars)
 
 def _fileToPath(file):
     return file.path


### PR DESCRIPTION
…ternal dependencies

*_external_deps_component.jar includes all external dependencies merged.

*_internal_deps_component.jar includes all internal dependencies merged (excluding the current app jar).

### Description
We'd like to have new jar files produced that we can put into separate docker layers when creating docker images.
As I understand these are optional outputs. Could this be included in rules_scala?

### Motivation
External dependencies do not tend to change so frequently, so we'd like to have a more stable docker layer for them.