### PR TITLE
Catch macro expansion exceptions in ScalacWorker

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -248,6 +248,15 @@ class ScalacWorker implements Worker.Interface {
     return pluginParams.toArray(new String[pluginParams.size()]);
   }
 
+  private static boolean isMacroException(Throwable ex) {
+    for (StackTraceElement elem : ex.getStackTrace()) {
+      if (elem.getMethodName().equals("macroExpand")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   private static void compileScalaSources(CompileOptions ops, String[] scalaSources, Path classes)
       throws IOException {
 
@@ -269,6 +278,8 @@ class ScalacWorker implements Worker.Interface {
     } catch (Throwable ex) {
       if (ex.toString().contains("scala.reflect.internal.Types$TypeError")) {
         throw new RuntimeException("Build failure with type error", ex);
+      } else if (isMacroException(ex)) {
+        throw new RuntimeException("Build failure during macro expansion", ex);
       } else {
         throw ex;
       }

--- a/test/shell/test_persistent_worker.sh
+++ b/test/shell/test_persistent_worker.sh
@@ -5,13 +5,29 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+PERSISTENT_WORKER_FLAGS="--strategy=Scalac=worker --worker_sandboxing"
+
+test_persistent_worker_success() {
+  # shellcheck disable=SC2086
+  bazel build //test:ScalaBinary $PERSISTENT_WORKER_FLAGS
+}
+
+test_persistent_worker_failure() {
+  action_should_fail "build //test_expect_failure/diagnostics_reporter:error_file $PERSISTENT_WORKER_FLAGS"
+}
+
 test_persistent_worker_handles_exception_in_macro_invocation() {
-  bazel build //test_expect_failure/scalac_exceptions:bad_macro_invocation --strategy=Scalac=worker --worker_sandboxing 2>&1  | grep -q -- "---8<---8<---"
+  command="bazel build //test_expect_failure/scalac_exceptions:bad_macro_invocation $PERSISTENT_WORKER_FLAGS"
+  output=$(${command} 2>&1)
+  ! (echo "$output" | grep -q -- "---8<---8<---") && (echo "$output" | grep -q "Build failure during macro expansion")
+
   RESPONSE_CODE=$?
-  if [ $RESPONSE_CODE -ne 1 ]; then
+  if [ $RESPONSE_CODE -ne 0 ]; then
     echo -e "${RED} Scalac persistent worker does not handle uncaught error in macro expansion. $NC"
     exit 1
   fi
 }
 
+$runner test_persistent_worker_success
+$runner test_persistent_worker_failure
 $runner test_persistent_worker_handles_exception_in_macro_invocation

--- a/test/shell/test_persistent_worker.sh
+++ b/test/shell/test_persistent_worker.sh
@@ -1,0 +1,17 @@
+# shellcheck source=./test_runner.sh
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_persistent_worker_handles_exception_in_macro_invocation() {
+  bazel build //test_expect_failure/scalac_exceptions:bad_macro_invocation --strategy=Scalac=worker --worker_sandboxing 2>&1  | grep -q -- "---8<---8<---"
+  RESPONSE_CODE=$?
+  if [ $RESPONSE_CODE -ne 1 ]; then
+    echo -e "${RED} Scalac persistent worker does not handle uncaught error in macro expansion. $NC"
+    exit 1
+  fi
+}
+
+$runner test_persistent_worker_handles_exception_in_macro_invocation

--- a/test_expect_failure/scalac_exceptions/BUILD
+++ b/test_expect_failure/scalac_exceptions/BUILD
@@ -1,0 +1,12 @@
+load("//scala:scala.bzl", "scala_library", "scala_macro_library")
+
+scala_macro_library(
+    name = "bad_macro",
+    srcs = ["BadMacro.scala"],
+)
+
+scala_library(
+    name = "bad_macro_invocation",
+    srcs = ["BadMacroInvocation.scala"],
+    deps = [":bad_macro"],
+)

--- a/test_expect_failure/scalac_exceptions/BadMacro.scala
+++ b/test_expect_failure/scalac_exceptions/BadMacro.scala
@@ -1,0 +1,9 @@
+import scala.language.experimental.macros
+
+object BadMacro {
+  def badMacro(): Unit = macro badMacroImpl
+
+  def badMacroImpl(c: scala.reflect.macros.blackbox.Context)(): c.Tree = {
+    throw new NoSuchMethodError()
+  }
+}

--- a/test_expect_failure/scalac_exceptions/BadMacroInvocation.scala
+++ b/test_expect_failure/scalac_exceptions/BadMacroInvocation.scala
@@ -1,0 +1,3 @@
+object BadMacroInvocation {
+  BadMacro.badMacro()
+}

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -55,3 +55,4 @@ $runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolcha
 . "${test_dir}"/test_compiler_dependency_tracking.sh
 . "${test_dir}"/test_twitter_scrooge.sh
 . "${test_dir}"/test_inherited_environment.sh
+. "${test_dir}"/test_persistent_worker.sh


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Catch scalac exceptions that occur during expansion of user macros so that the entire worker doesn't crash.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Fixes #1488
