### PR TITLE
Handle StackOverflowError in macros

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -278,6 +278,8 @@ class ScalacWorker implements Worker.Interface {
     } catch (Throwable ex) {
       if (ex.toString().contains("scala.reflect.internal.Types$TypeError")) {
         throw new RuntimeException("Build failure with type error", ex);
+      } else if (ex.toString().contains("java.lang.StackOverflowError")) {
+        throw new RuntimeException("Build failure with StackOverflowError", ex);
       } else if (isMacroException(ex)) {
         throw new RuntimeException("Build failure during macro expansion", ex);
       } else {

--- a/test/shell/test_persistent_worker.sh
+++ b/test/shell/test_persistent_worker.sh
@@ -39,7 +39,7 @@ test_persistent_worker_handles_stack_overflow_exception() {
 
   RESPONSE_CODE=$?
   if [ $RESPONSE_CODE -ne 0 ]; then
-    echo -e "${RED} Scalac persistent worker does not handle uncaught error in macro expansion. $NC"
+    echo -e "${RED} Scalac persistent worker does not handle StackOverflowError in macro expansion. $NC"
     exit 1
   fi
 }

--- a/test/shell/test_persistent_worker.sh
+++ b/test/shell/test_persistent_worker.sh
@@ -7,6 +7,12 @@ runner=$(get_test_runner "${1:-local}")
 
 PERSISTENT_WORKER_FLAGS="--strategy=Scalac=worker --worker_sandboxing"
 
+check_persistent_worker_failure() {
+  command=$1
+  output=$(bazel ${command} 2>&1)
+  ! (echo "$output" | grep -q -- "---8<---8<---") && echo "$output"
+}
+
 test_persistent_worker_success() {
   # shellcheck disable=SC2086
   bazel build //test:ScalaBinary $PERSISTENT_WORKER_FLAGS
@@ -17,9 +23,8 @@ test_persistent_worker_failure() {
 }
 
 test_persistent_worker_handles_exception_in_macro_invocation() {
-  command="bazel build //test_expect_failure/scalac_exceptions:bad_macro_invocation $PERSISTENT_WORKER_FLAGS"
-  output=$(${command} 2>&1)
-  ! (echo "$output" | grep -q -- "---8<---8<---") && (echo "$output" | grep -q "Build failure during macro expansion")
+  command="build //test_expect_failure/scalac_exceptions:bad_macro_invocation $PERSISTENT_WORKER_FLAGS"
+  check_persistent_worker_failure "$command" | grep -q "Build failure during macro expansion"
 
   RESPONSE_CODE=$?
   if [ $RESPONSE_CODE -ne 0 ]; then
@@ -28,6 +33,19 @@ test_persistent_worker_handles_exception_in_macro_invocation() {
   fi
 }
 
+test_persistent_worker_handles_stack_overflow_exception() {
+  command="build //test_expect_failure/scalac_exceptions:stack_overflow_macro_invocation $PERSISTENT_WORKER_FLAGS"
+  check_persistent_worker_failure "$command" | grep -q "Build failure with StackOverflowError"
+
+  RESPONSE_CODE=$?
+  if [ $RESPONSE_CODE -ne 0 ]; then
+    echo -e "${RED} Scalac persistent worker does not handle uncaught error in macro expansion. $NC"
+    exit 1
+  fi
+}
+
+
 $runner test_persistent_worker_success
 $runner test_persistent_worker_failure
 $runner test_persistent_worker_handles_exception_in_macro_invocation
+$runner test_persistent_worker_handles_stack_overflow_exception

--- a/test_expect_failure/scalac_exceptions/BUILD
+++ b/test_expect_failure/scalac_exceptions/BUILD
@@ -10,3 +10,9 @@ scala_library(
     srcs = ["BadMacroInvocation.scala"],
     deps = [":bad_macro"],
 )
+
+scala_library(
+    name = "stack_overflow_macro_invocation",
+    srcs = ["StackOverflowMacroInvocation.scala"],
+    deps = [":bad_macro"],
+)

--- a/test_expect_failure/scalac_exceptions/BadMacro.scala
+++ b/test_expect_failure/scalac_exceptions/BadMacro.scala
@@ -2,8 +2,17 @@ import scala.language.experimental.macros
 
 object BadMacro {
   def badMacro(): Unit = macro badMacroImpl
+  def stackOverflowMacro(): Unit = macro stackOverflowMacroImpl
 
   def badMacroImpl(c: scala.reflect.macros.blackbox.Context)(): c.Tree = {
     throw new NoSuchMethodError()
+  }
+
+  def uhOh(n: Int): Int = n + uhOh(n + 1)
+
+  def stackOverflowMacroImpl(c: scala.reflect.macros.blackbox.Context)(): c.Tree = {
+    import c.universe._
+    uhOh(1)
+    q""
   }
 }

--- a/test_expect_failure/scalac_exceptions/StackOverflowMacroInvocation.scala
+++ b/test_expect_failure/scalac_exceptions/StackOverflowMacroInvocation.scala
@@ -1,0 +1,3 @@
+object StackOverflowMacroInvocation {
+  BadMacro.stackOverflowMacro()
+}


### PR DESCRIPTION
### Description
In a similar fix to #1489, catch StackOverflowErrors in ScalacWorker so that buggy macros don't crash the persistent worker resulting in unhelpful logs.
<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
Fix a similar class of issue as #1488 
