### PR TITLE
For Windows: Fix to enable scala_test and scala_binary outputs to be executed on Windows

### DIFF
--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -139,5 +139,4 @@ def sanitize_string_for_usage(s):
 #generates rpathlocation that should be used with the rlocation() at runtime. (rpathlocations start with repo name)
 #rootpath arg expects "rootpath" format (i.e. relative to runfilesDir/workspacename). Rootpath can be obtained by $rootpath macro or File.short_path
 def rpathlocation_from_rootpath(ctx, rootpath):
-    p = paths.normalize(ctx.workspace_name + "/" + rootpath)
-    return p
+    return paths.normalize(ctx.workspace_name + "/" + rootpath)

--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -1,5 +1,6 @@
 load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("@io_bazel_rules_scala//scala:plusone.bzl", "PlusOneDeps")
+load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def write_manifest_file(actions, output_file, main_class):
     # TODO(bazel-team): I don't think this classpath is what you want
@@ -134,3 +135,9 @@ def sanitize_string_for_usage(s):
         else:
             res_array.append("_")
     return "".join(res_array)
+
+#generates rpathlocation that should be used with the rlocation() at runtime. (rpathlocations start with repo name)
+#rootpath arg expects "rootpath" format (i.e. relative to runfilesDir/workspacename). Rootpath can be obtained by $rootpath macro or File.short_path
+def rpathlocation_from_rootpath(ctx, rootpath):
+    p = paths.normalize(ctx.workspace_name + "/" + rootpath)
+    return p

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -9,8 +9,8 @@ load(
     "first_non_empty",
     "is_windows",
     "java_bin",
-    "runfiles_root",
     "java_bin_windows",
+    "runfiles_root",
 )
 
 def phase_write_executable_scalatest(ctx, p):
@@ -79,7 +79,7 @@ def _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wra
     # TODO: tests coverage support for Windows
     #launcher expects classpaths to be in rootpath form (ie. relative to runfiles_dir, short_path does the trick)
     classpath = ";".join([j.short_path for j in rjars.to_list()])
-    
+
     jvm_flags_str = ";".join(jvm_flags)
     java_for_exe = java_bin_windows(ctx)
 

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -86,9 +86,8 @@ def _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wra
     cpfile = ctx.actions.declare_file("%s.classpath" % ctx.label.name)
     ctx.actions.write(cpfile, classpath)
 
-    specifiedEnv = {}
-    if hasattr(ctx.attr, "env"):
-        specifiedEnv = ctx.attr.env
+    #Handle fact that some scala rules add env as an attr and some don't.
+    specifiedEnv = getattr(ctx.attr, "env", {})
 
     ctx.actions.run(
         outputs = [executable],

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -10,6 +10,7 @@ load(
     "is_windows",
     "java_bin",
     "runfiles_root",
+    "java_bin_windows",
 )
 
 def phase_write_executable_scalatest(ctx, p):
@@ -76,21 +77,25 @@ def _phase_write_executable(
 def _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco):
     # NOTE: `use_jacoco` is currently ignored on Windows.
     # TODO: tests coverage support for Windows
-    classpath = ";".join(
-        [("external/%s" % (j.short_path[3:]) if j.short_path.startswith("../") else j.short_path) for j in rjars.to_list()],
-    )
+    #launcher expects classpaths to be in rootpath form (ie. relative to runfiles_dir, short_path does the trick)
+    classpath = ";".join([j.short_path for j in rjars.to_list()])
+    
     jvm_flags_str = ";".join(jvm_flags)
-    java_for_exe = str(ctx.attr._java_runtime[java_common.JavaRuntimeInfo].java_executable_exec_path)
+    java_for_exe = java_bin_windows(ctx)
 
     cpfile = ctx.actions.declare_file("%s.classpath" % ctx.label.name)
     ctx.actions.write(cpfile, classpath)
+
+    specifiedEnv = {}
+    if hasattr(ctx.attr, "env"):
+        specifiedEnv = ctx.attr.env
 
     ctx.actions.run(
         outputs = [executable],
         inputs = [cpfile],
         executable = ctx.attr._exe.files_to_run.executable,
         arguments = [executable.path, ctx.workspace_name, java_for_exe, main_class, cpfile.path, jvm_flags_str],
-        env = ctx.attr.env,
+        env = specifiedEnv,
         mnemonic = "ExeLauncher",
         progress_message = "Creating exe launcher",
     )

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -15,7 +15,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
-load(":common.bzl", _collect_plugin_paths = "collect_plugin_paths")
+load(":common.bzl", _collect_plugin_paths = "collect_plugin_paths", "rpathlocation_from_rootpath")
 load(":resources.bzl", _resource_paths = "paths")
 
 def expand_location(ctx, flags):
@@ -202,6 +202,20 @@ def java_bin(ctx):
         runfiles_root_var = runfiles_root(ctx)
         javabin = "%s/%s" % (runfiles_root_var, java_path)
     return javabin
+
+def java_bin_windows(ctx):
+    java_runtime = specified_java_runtime(
+        ctx,
+        default_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo],
+    )
+
+    
+    if paths.is_absolute(java_runtime.java_executable_runfiles_path):
+        java_bin = java_runtime.java_executable_runfiles_path
+    else:
+        java_bin = rpathlocation_from_rootpath(ctx, java_runtime.java_executable_runfiles_path)
+
+    return java_bin
 
 def is_windows(ctx):
     return ctx.configuration.host_path_separator == ";"

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -15,7 +15,7 @@
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
 load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
-load(":common.bzl", _collect_plugin_paths = "collect_plugin_paths", "rpathlocation_from_rootpath")
+load(":common.bzl", "rpathlocation_from_rootpath", _collect_plugin_paths = "collect_plugin_paths")
 load(":resources.bzl", _resource_paths = "paths")
 
 def expand_location(ctx, flags):
@@ -209,7 +209,6 @@ def java_bin_windows(ctx):
         default_runtime = ctx.attr._java_runtime[java_common.JavaRuntimeInfo],
     )
 
-    
     if paths.is_absolute(java_runtime.java_executable_runfiles_path):
         java_bin = java_runtime.java_executable_runfiles_path
     else:


### PR DESCRIPTION
### Description
For Windows, this PR fixes issue where outputs of scala_test and scala_binary are failing when ran with 'bazel run' and 'bazel test'. When trying to do run or test, Bazel shows error like:

> LAUNCHER ERROR: rlocation failed on “external\localjdk\bin\java.exe not found in MANIFEST”.

The Fix:  On Windows, Bazel’s Java Launcher was being passed paths in the wrong ‘form’. The launcher expects rpathlocation form for some paths and rootpath form for others. Fix is to pass the right forms of the paths to the LauncherFileWriter which in turn passes correct paths into the Launcher.

### Motivation
scala_test and scala_binary should work properly on Windows

Seems to have been caused by #1313
Should also fix #1497

#### Test/Reproduction
The following can be used as a demonstration test on windows (will fail before this PR):

`bazel test //test/RunScalaBinary --enable_runfiles --extra_toolchains=//scala:minimal_direct_source_deps`

Note that: 'bazel test' requires --enable_runfiles to be set on Windows. 
Also note that many other tests fail in Windows, but fixes for those are for a separate PR.
