### PR TITLE
Make DepsTrackingReporter handle Windows path separators

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/reporter/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/reporter/DepsTrackingReporter.java
@@ -17,9 +17,6 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
-
-import javax.print.attribute.standard.Severity;
-
 import scala.reflect.internal.util.NoPosition$;
 import scala.reflect.internal.util.Position;
 import scala.tools.nsc.Settings;

--- a/src/java/io/bazel/rulesscala/scalac/reporter/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/reporter/DepsTrackingReporter.java
@@ -17,6 +17,9 @@ import java.util.Map;
 import java.util.Set;
 import java.util.jar.JarFile;
 import java.util.stream.Collectors;
+
+import javax.print.attribute.standard.Severity;
+
 import scala.reflect.internal.util.NoPosition$;
 import scala.reflect.internal.util.Position;
 import scala.tools.nsc.Settings;
@@ -90,6 +93,9 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
   private void parseOpenedJar(String msg) {
     String jar = msg.split(":")[1];
+
+    //normalize path separators (scalac passes os-specific path separators.)
+    jar = jar.replace("\\", "/");
 
     // track only jars from dependency targets
     // this should exclude things like rt.jar which come from JDK


### PR DESCRIPTION
### Description
This fixes issue where the ‘compiler-dependency-analyzer’ was not handling Windows path separator and failed with false negatives. 
* Added one-liner in DepsTrackingReporter.java that replaces ‘\\’ with ‘/’ in the paths it receives from the scalac compiler.

### Motivation
Makes the new compiler-dependency-analyzer work on Windows. 

Before this PR, on Windows, compiling would report a bunch of erroneous 'unused deps' errors.

This fixes #1487 
