### PR TITLE
call close() on compiler in scalacWorker after each job

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
+++ b/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
@@ -16,20 +16,20 @@ import java.lang.AutoCloseable;
 public class ReportableMainClass extends MainClass {
   private Reporter reporter;
   private final CompileOptions ops;
-  private Global _compiler = null;
+  private Global compiler = null;
 
   public ReportableMainClass(CompileOptions ops) {
     this.ops = ops;
   }
 
-  public void Close() throws Exception{
-    if(_compiler != null){
+  public void close() throws Exception{
+    if(compiler != null){
 
       //nsc.Global didn't inherit from Closeable until 2.12.9.
-      if(_compiler instanceof AutoCloseable){
-        ((AutoCloseable)_compiler).close();
+      if(compiler instanceof AutoCloseable){
+        ((AutoCloseable)compiler).close();
       }
-      _compiler = null;
+      compiler = null;
     }
   }
 
@@ -44,8 +44,8 @@ public class ReportableMainClass extends MainClass {
 
     reporter = new DepsTrackingReporter(settings, ops, reporter);
 
-    _compiler = new Global(settings, reporter);
-    return _compiler;
+    compiler = new Global(settings, reporter);
+    return compiler;
   }
 
   private void createDiagnosticsFile() {

--- a/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
+++ b/src/java/io/bazel/rulesscala/scalac/ReportableMainClass.java
@@ -11,13 +11,26 @@ import scala.tools.nsc.Global;
 import scala.tools.nsc.MainClass;
 import scala.tools.nsc.Settings;
 import scala.tools.nsc.reporters.Reporter;
+import java.lang.AutoCloseable;
 
 public class ReportableMainClass extends MainClass {
   private Reporter reporter;
   private final CompileOptions ops;
+  private Global _compiler = null;
 
   public ReportableMainClass(CompileOptions ops) {
     this.ops = ops;
+  }
+
+  public void Close() throws Exception{
+    if(_compiler != null){
+
+      //nsc.Global didn't inherit from Closeable until 2.12.9.
+      if(_compiler instanceof AutoCloseable){
+        ((AutoCloseable)_compiler).close();
+      }
+      _compiler = null;
+    }
   }
 
   @Override
@@ -31,7 +44,8 @@ public class ReportableMainClass extends MainClass {
 
     reporter = new DepsTrackingReporter(settings, ops, reporter);
 
-    return new Global(settings, reporter);
+    _compiler = new Global(settings, reporter);
+    return _compiler;
   }
 
   private void createDiagnosticsFile() {

--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -258,7 +258,7 @@ class ScalacWorker implements Worker.Interface {
   }
 
   private static void compileScalaSources(CompileOptions ops, String[] scalaSources, Path classes)
-      throws IOException {
+      throws IOException, Exception {
 
     String[] pluginArgs = buildPluginArgs(ops.plugins);
     String[] pluginParams = getPluginParamsFrom(ops);
@@ -285,7 +285,11 @@ class ScalacWorker implements Worker.Interface {
       } else {
         throw ex;
       }
+    }finally {
+      comp.Close();
     }
+
+
     long stop = System.currentTimeMillis();
     if (ops.printCompileTime) {
       System.err.println("Compiler runtime: " + (stop - start) + "ms.");

--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -286,7 +286,7 @@ class ScalacWorker implements Worker.Interface {
         throw ex;
       }
     }finally {
-      comp.Close();
+      comp.close();
     }
 
 


### PR DESCRIPTION
### Description
This PR fixes the scalacWorker so that it calls close() on the compiler object (nsc.Global) after each job is done. This allows file resources (i.e. dependent jar files, source files, etc) that the compiler uses to be properly released after each job.

Note that nsc.Global did not add the close() functionality until v2.12. This is handled in this PR.

### Motivation
This issue was noticed more on Windows since Windows will lock the file (and not allow edits) until it is released. And with scalacWorker being a persistent process, it would lock the files until you called “bazel shutdown”. 

This should resolve #1486, where this issue was causing *-ijar.jar handles not to be released.

_Aside: There is still an issue where the jars for plugins are not being released (because calling nsc.Global.close() does not release the plugins). This is probably more of a Bazel core issue where Bazel needs to stop the workers when any plugins (or other tooling used by the worker) need to be recompiled. The related issue is Bazel issue #[10498](https://github.com/bazelbuild/bazel/issues/10498)._ 
