### PR TITLE
Register java toolchain inside rules_scala

### DIFF
--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -149,4 +149,5 @@ scala_import = rule(
             default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
         ),
     },
+    toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
 )


### PR DESCRIPTION
### Description
Any rule which uses java_common should register java toolchain_type.

