### PR TITLE
Register Java Toolchain

### DIFF
--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -81,7 +81,10 @@ def make_scala_binary(*extras):
             common_outputs,
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
-        toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        toolchains = [
+            "@io_bazel_rules_scala//scala:toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
+        ],
         incompatible_use_toolchain_transition = True,
         implementation = _scala_binary_impl,
     )

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -97,7 +97,10 @@ def make_scala_library(*extras):
             common_outputs,
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
-        toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        toolchains = [
+            "@io_bazel_rules_scala//scala:toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
+        ],
         incompatible_use_toolchain_transition = True,
         implementation = _scala_library_impl,
     )
@@ -191,7 +194,10 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
             common_outputs,
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
-        toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        toolchains = [
+            "@io_bazel_rules_scala//scala:toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
+        ],
         incompatible_use_toolchain_transition = True,
         implementation = _scala_library_for_plugin_bootstrapping_impl,
     )
@@ -259,7 +265,10 @@ def make_scala_macro_library(*extras):
             common_outputs,
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
-        toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        toolchains = [
+            "@io_bazel_rules_scala//scala:toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
+        ],
         incompatible_use_toolchain_transition = True,
         implementation = _scala_macro_library_impl,
     )

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -120,7 +120,10 @@ def make_scala_test(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         test = True,
-        toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        toolchains = [
+            "@io_bazel_rules_scala//scala:toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
+        ],
         incompatible_use_toolchain_transition = True,
         implementation = _scala_test_impl,
     )


### PR DESCRIPTION
Description
Any rule which uses java_common should register java toolchain_type.

Fixes: https://github.com/bazelbuild/rules_scala/issues/1507