### PR TITLE
singlejar executable from specified java compile toolchain

### DIFF
--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -81,12 +81,6 @@ common_attrs.update({
 })
 
 implicit_deps = {
-    "_singlejar": attr.label(
-        executable = True,
-        cfg = "exec",
-        default = Label("@bazel_tools//tools/jdk:singlejar"),
-        allow_files = True,
-    ),
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
     ),

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -270,7 +270,7 @@ def _build_nosrc_jar(ctx):
     ctx.actions.run(
         inputs = ctx.files.resources,
         outputs = [ctx.outputs.jar],
-        executable = ctx.executable._singlejar,
+        executable = specified_java_compile_toolchain(ctx).single_jar,
         progress_message = "scalac %s" % ctx.label,
         arguments = [args],
     )

--- a/scala/private/phases/phase_merge_jars.bzl
+++ b/scala/private/phases/phase_merge_jars.bzl
@@ -3,6 +3,10 @@
 #
 # DOCUMENT THIS
 #
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "specified_java_compile_toolchain",
+)
 
 def merge_jars_to_output(ctx, output, jars):
     """Calls Bazel's singlejar utility.
@@ -26,7 +30,7 @@ def merge_jars_to_output(ctx, output, jars):
     ctx.actions.run(
         inputs = jars,
         outputs = [output],
-        executable = ctx.executable._singlejar,
+        executable = specified_java_compile_toolchain(ctx).single_jar,
         mnemonic = "ScalaDeployJar",
         progress_message = progress_message,
         arguments = [args],


### PR DESCRIPTION
Use single jar utility from toolchains instead of private attribute.

### Motivation
* toolchain comes with precompiled singlejar from remote_java_tools
* it would allow to configure your own if needed