### PR TITLE
Upgrade scala 2.12.x and 2.13.x versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ scalatest_toolchain()
 ```
 
 This will load the `rules_scala` repository at the commit sha
-`rules_scala_version` into your Bazel project and register a [scala_toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.14)
+`rules_scala_version` into your Bazel project and register a [scala_toolchain](docs/scala_toolchain.md) at the default Scala version (2.12.18)
 
 Then in your BUILD file just add the following so the rules will be available:
 ```starlark
@@ -145,7 +145,7 @@ Previous minor versions may work but are supported only on a best effort basis.
 To configure Scala version you must call `scala_config(scala_version = "2.xx.xx")` and configure 
 dependencies by declaring [scala_toolchain](docs/scala_toolchain.md). 
 For a quick start you can use `scala_repositories()` and `scala_register_toolchains()`, which have 
-dependency providers configured for `2.11.12`, `2.12.14` and `2.13.11` versions.
+dependency providers configured for `2.11.12`, `2.12.18` and `2.13.11` versions.
 
 
 ```starlark

--- a/README.md
+++ b/README.md
@@ -145,13 +145,13 @@ Previous minor versions may work but are supported only on a best effort basis.
 To configure Scala version you must call `scala_config(scala_version = "2.xx.xx")` and configure 
 dependencies by declaring [scala_toolchain](docs/scala_toolchain.md). 
 For a quick start you can use `scala_repositories()` and `scala_register_toolchains()`, which have 
-dependency providers configured for `2.11.12`, `2.12.14` and `2.13.6` versions.
+dependency providers configured for `2.11.12`, `2.12.14` and `2.13.11` versions.
 
 
 ```starlark
 # WORKSPACE
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
-scala_config(scala_version = "2.13.6")
+scala_config(scala_version = "2.13.11")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
 rules_proto_dependencies()

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -197,7 +197,7 @@ repositories(
         # validated against it
         "org_springframework_spring_core",
         "org_springframework_spring_tx",
-        "org_spire_math_kind_projector",
+        "org_typelevel_kind_projector",
         # For testing that we don't include sources jars to the classpath
         "org_typelevel__cats_core",
     ],

--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -105,6 +105,8 @@ run_test_local test_compiler_patch 2.13.5
 run_test_local test_compiler_patch 2.13.6
 run_test_local test_compiler_patch 2.13.7
 run_test_local test_compiler_patch 2.13.8
+run_test_local test_compiler_patch 2.13.10
+run_test_local test_compiler_patch 2.13.11
 
 run_test_local test_compiler_srcjar_error 2.12.11
 run_test_local test_compiler_srcjar_error 2.12.12

--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -95,6 +95,8 @@ run_test_local test_compiler_patch 2.12.13
 run_test_local test_compiler_patch 2.12.14
 run_test_local test_compiler_patch 2.12.15
 run_test_local test_compiler_patch 2.12.16
+run_test_local test_compiler_patch 2.12.17
+run_test_local test_compiler_patch 2.12.18
 
 run_test_local test_compiler_patch 2.13.0
 run_test_local test_compiler_patch 2.13.1
@@ -118,3 +120,4 @@ run_test_local test_compiler_srcjar 2.12.14
 run_test_local test_compiler_srcjar 2.12.15
 run_test_local test_compiler_srcjar 2.12.16
 run_test_local test_compiler_srcjar_nonhermetic 2.12.17
+run_test_local test_compiler_srcjar_nonhermetic 2.12.18

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -88,6 +88,9 @@ srcjars_by_version = {
     "2.12.17": {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.17/scala-compiler-2.12.17-sources.jar?foo",
     },
+    "2.12.18": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala-compiler/2.12.18/scala-compiler-2.12.18-sources.jar?foo",
+    },
 }
 
 rules_scala_setup(scala_compiler_srcjar = srcjars_by_version[SCALA_VERSION])

--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -2,7 +2,7 @@ load("//scala:scala_cross_version.bzl", "extract_major_version", "extract_minor_
 
 def _default_scala_version():
     """return the scala version for use in maven coordinates"""
-    return "2.12.14"
+    return "2.12.18"
 
 def _validate_supported_scala_version(scala_major_version, scala_minor_version):
     if scala_major_version == "2.11" and int(scala_minor_version) != 12:

--- a/test/coverage_filename_encoding/expected-coverage.dat
+++ b/test/coverage_filename_encoding/expected-coverage.dat
@@ -9,14 +9,14 @@ FNDA:1,coverage_filename_encoding/A1$::a1 (Z)Ljava/lang/String;
 FNDA:0,coverage_filename_encoding/A1::a1 (Z)Ljava/lang/String;
 FNF:4
 FNH:3
-BRDA:5,0,0,0
-BRDA:5,0,1,1
+BRDA:5,0,0,1
+BRDA:5,0,1,0
 BRF:2
 BRH:1
 DA:3,1
 DA:5,1
-DA:6,1
+DA:6,0
 DA:7,1
-LH:4
+LH:3
 LF:4
 end_of_record

--- a/test/coverage_scalatest/expected-coverage.dat
+++ b/test/coverage_scalatest/expected-coverage.dat
@@ -9,15 +9,15 @@ FNDA:1,coverage_scalatest/A1$::a1 (Z)Lcoverage_scalatest/B1$;
 FNDA:0,coverage_scalatest/A1::a1 (Z)Lcoverage_scalatest/B1$;
 FNF:4
 FNH:3
-BRDA:5,0,0,0
-BRDA:5,0,1,1
+BRDA:5,0,0,1
+BRDA:5,0,1,0
 BRF:2
 BRH:1
 DA:3,1
 DA:5,1
-DA:6,1
+DA:6,0
 DA:7,1
-LH:4
+LH:3
 LF:4
 end_of_record
 SF:test/coverage_scalatest/A2.scala

--- a/test/coverage_specs2_with_junit/expected-coverage.dat
+++ b/test/coverage_specs2_with_junit/expected-coverage.dat
@@ -9,15 +9,15 @@ FNDA:1,coverage_specs2_with_junit/A1$::a1 (Z)Lcoverage_specs2_with_junit/B1$;
 FNDA:0,coverage_specs2_with_junit/A1::a1 (Z)Lcoverage_specs2_with_junit/B1$;
 FNF:4
 FNH:3
-BRDA:5,0,0,0
-BRDA:5,0,1,1
+BRDA:5,0,0,1
+BRDA:5,0,1,0
 BRF:2
 BRH:1
 DA:3,1
 DA:5,1
-DA:6,1
+DA:6,0
 DA:7,1
-LH:4
+LH:3
 LF:4
 end_of_record
 SF:test/coverage_specs2_with_junit/A2.scala

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -12,7 +12,7 @@ test_classpath_contains_2_12() {
 
 test_classpath_contains_2_13() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION=2.13.6 \
+   --repo_env=SCALA_VERSION=2.13.11 \
    | grep scala-library-2.13
 }
 

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -6,7 +6,7 @@ runner=$(get_test_runner "${1:-local}")
 
 test_classpath_contains_2_12() {
   bazel aquery 'mnemonic("Javac", //src/java/io/bazel/rulesscala/scalac:scalac)' \
-   --repo_env=SCALA_VERSION=2.12.14 \
+   --repo_env=SCALA_VERSION=2.12.18 \
    | grep scala-library-2.12
 }
 

--- a/test/src/main/scala/scalarules/test/compiler_plugin/BUILD.bazel
+++ b/test/src/main/scala/scalarules/test/compiler_plugin/BUILD.bazel
@@ -4,6 +4,6 @@ scala_library(
     name = "compiler_plugin",
     testonly = True,
     srcs = ["KindProjected.scala"],
-    plugins = ["@org_spire_math_kind_projector//jar"],
+    plugins = ["@org_typelevel_kind_projector//jar"],
     visibility = ["//visibility:public"],
 )

--- a/test/src/main/scala/scalarules/test/compiler_plugin/KindProjected.scala
+++ b/test/src/main/scala/scalarules/test/compiler_plugin/KindProjected.scala
@@ -3,4 +3,4 @@ package scalarules.test.compiler_plugin
 import scala.language.higherKinds
 
 class HKT[F[_]]
-class KKTImpl extends HKT[Either[String, ?]]
+class KKTImpl extends HKT[Either[String, *]]

--- a/test_version.sh
+++ b/test_version.sh
@@ -4,7 +4,7 @@ set -e
 
 scala_2_11_version="2.11.12"
 scala_2_12_version="2.12.14"
-scala_2_13_version="2.13.6"
+scala_2_13_version="2.13.11"
 
 SCALA_VERSION_DEFAULT=$scala_2_11_version
 
@@ -97,8 +97,8 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat $dir/.bazelversion)}
 
-TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_11_version}"
-TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_12_version}"
+#TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_11_version}"
+#TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_12_version}"
 TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_13_version}"
 
 TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "18.6.0"

--- a/test_version.sh
+++ b/test_version.sh
@@ -3,7 +3,7 @@
 set -e
 
 scala_2_11_version="2.11.12"
-scala_2_12_version="2.12.14"
+scala_2_12_version="2.12.18"
 scala_2_13_version="2.13.11"
 
 SCALA_VERSION_DEFAULT=$scala_2_11_version
@@ -97,8 +97,8 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat $dir/.bazelversion)}
 
-#TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_11_version}"
-#TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_12_version}"
+TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_11_version}"
+TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_12_version}"
 TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_13_version}"
 
 TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "18.6.0"

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -504,9 +504,9 @@ artifacts = {
             "@org_springframework_spring_core",
         ],
     },
-    "org_spire_math_kind_projector": {
+    "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.spire-math:kind-projector_2.11:0.9.10",
-        "sha256": "897460d4488b7dd6ac9198937d6417b36cc6ec8ab3693fdf2c532652f26c4373",
+        "artifact": "org.typelevel:kind-projector_%s:0.13.2" % scala_version,
+        "sha256": "8f7287973f7f8fc9372b59d36120e3fac5839344f65c8f640351794e8907145c",
     },
 }

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -1,17 +1,17 @@
-scala_version = "2.12.14"
+scala_version = "2.12.18"
 
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala-library:%s" % scala_version,
-        "sha256": "0451dce8322903a6c2aa7d31232b54daa72a61ced8ade0b4c5022442a3f6cb57",
+        "sha256": "e51e6636c003359e106bea4ad99def70e613c290190c8c84f10f9560dd5b00ae",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
-        "sha256": "2a1b3fbf9c956073c8c5374098a6f987e3b8d76e34756ab985fc7d2ca37ee113",
+        "sha256": "5680cee34200e8d8ed7965c71d8b1428d3eeb889eb14fec38d40ffbc3761a0d0",
     },
     "io_bazel_rules_scala_scala_reflect": {
         "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
-        "sha256": "497f4603e9d19dc4fa591cd467de5e32238d240bbd955d3dac6390b270889522",
+        "sha256": "d6a24e175246541ffcbc965a231aa1d3bb01d61def196f91495690fabf9783bc",
     },
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_2.12:3.2.9",
@@ -152,8 +152,8 @@ artifacts = {
         "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.12.14",
-        "sha256": "52c37b4e5a37146a9ce5e48b8fb2c39aa0ec7eb867c65708a5cdac786ac79f2a",
+        "artifact": "org.scala-lang:scalap:2.12.18",
+        "sha256": "9070f22699b961ace3dc8daef1b40aab6a586e10ab2bb4febeb3886654fe0a69",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -504,9 +504,9 @@ artifacts = {
             "@org_springframework_spring_core",
         ],
     },
-    "org_spire_math_kind_projector": {
+    "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.spire-math:kind-projector_2.12:0.9.10",
-        "sha256": "36aca2493302e2c037328107a121cda1d28bf9119fbc04fb47ea1ff9bce3c03f",
+        "artifact": "org.typelevel:kind-projector_%s:0.13.2" % scala_version,
+        "sha256": "7d4e821b86647c65546c1e3667348e8168c5907e9d4b277cc2badedcd479be44",
     },
 }

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -1,17 +1,17 @@
-scala_version = "2.13.6"
+scala_version = "2.13.11"
 
 artifacts = {
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala-library:%s" % scala_version,
-        "sha256": "f19ed732e150d3537794fd3fe42ee18470a3f707efd499ecd05a99e727ff6c8a",
+        "sha256": "71853291f61bda32786a866533361cae474344f5b2772a379179b02112444ed3",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala-compiler:%s" % scala_version,
-        "sha256": "310d263d622a3d016913e94ee00b119d270573a5ceaa6b21312d69637fd9eec1",
+        "sha256": "c5a14770370e73a69367b131da1533890200b1e2aa70643b73f9ff31ef2e69ec",
     },
     "io_bazel_rules_scala_scala_reflect": {
         "artifact": "org.scala-lang:scala-reflect:%s" % scala_version,
-        "sha256": "f713593809b387c60935bb9a940dfcea53bd0dbf8fdc8d10739a2896f8ac56fa",
+        "sha256": "6a46ed9b333857e8b5ea668bb254ed8e47dacd1116bf53ade9467aa4ae8f1818",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:0.2.0",
@@ -157,8 +157,8 @@ artifacts = {
         "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.13.6",
-        "sha256": "bbfa4ab0603f510b16114371a35b9c34d20946edfc1aa8f3fd31014b9f06b5b1",
+        "artifact": "org.scala-lang:scalap:2.13.11",
+        "sha256": "ac358699f40002fb4f32ad77531765fce23425d0e83c51854d1635118ab285ea",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -509,10 +509,9 @@ artifacts = {
             "@org_springframework_spring_core",
         ],
     },
-    # TODO: fix misleading artifact group in id
-    "org_spire_math_kind_projector": {
+    "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.typelevel:kind-projector_2.13:0.10.3",
-        "sha256": "b5d60c8bc8f1333e2deac17d72d41bb59c53283a67ff3a613189746ce97ac8ad",
+        "artifact": "org.typelevel:kind-projector_%s:0.13.2" % scala_version,
+        "sha256": "c5c49245a962206d708b7c9368d9f1dd77c773250c0f7bdde9c78e994889cb19",
     },
 }

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -173,8 +173,8 @@ artifacts = {
         "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.13.6",
-        "sha256": "bbfa4ab0603f510b16114371a35b9c34d20946edfc1aa8f3fd31014b9f06b5b1",
+        "artifact": "org.scala-lang:scalap:2.13.11",
+        "sha256": "ac358699f40002fb4f32ad77531765fce23425d0e83c51854d1635118ab285ea",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -525,10 +525,9 @@ artifacts = {
             "@org_springframework_spring_core",
         ],
     },
-    # TODO: fix misleading artifact group in id
-    "org_spire_math_kind_projector": {
+    "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.typelevel:kind-projector_2.13:0.10.3",
-        "sha256": "b5d60c8bc8f1333e2deac17d72d41bb59c53283a67ff3a613189746ce97ac8ad",
+        "artifact": "org.typelevel:kind-projector_2.13.11:0.13.2",
+        "sha256": "c5c49245a962206d708b7c9368d9f1dd77c773250c0f7bdde9c78e994889cb19",
     },
 }

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -173,8 +173,8 @@ artifacts = {
         "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.13.6",
-        "sha256": "bbfa4ab0603f510b16114371a35b9c34d20946edfc1aa8f3fd31014b9f06b5b1",
+        "artifact": "org.scala-lang:scalap:2.13.11",
+        "sha256": "ac358699f40002fb4f32ad77531765fce23425d0e83c51854d1635118ab285ea",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -525,10 +525,9 @@ artifacts = {
             "@org_springframework_spring_core",
         ],
     },
-    # TODO: fix misleading artifact group in id
-    "org_spire_math_kind_projector": {
+    "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.typelevel:kind-projector_2.13:0.10.3",
-        "sha256": "b5d60c8bc8f1333e2deac17d72d41bb59c53283a67ff3a613189746ce97ac8ad",
+        "artifact": "org.typelevel:kind-projector_2.13.11:0.13.2",
+        "sha256": "c5c49245a962206d708b7c9368d9f1dd77c773250c0f7bdde9c78e994889cb19",
     },
 }

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -171,8 +171,8 @@ artifacts = {
         "sha256": "b5f1d6071f1548d05be82f59f9039c7d37a1787bd8e3c677e31ee275af4a4621",
     },
     "org_scala_lang_scalap": {
-        "artifact": "org.scala-lang:scalap:2.13.6",
-        "sha256": "bbfa4ab0603f510b16114371a35b9c34d20946edfc1aa8f3fd31014b9f06b5b1",
+        "artifact": "org.scala-lang:scalap:2.13.11",
+        "sha256": "ac358699f40002fb4f32ad77531765fce23425d0e83c51854d1635118ab285ea",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -523,10 +523,9 @@ artifacts = {
             "@org_springframework_spring_core",
         ],
     },
-    # TODO: fix misleading artifact group in id
-    "org_spire_math_kind_projector": {
+    "org_typelevel_kind_projector": {
         "testonly": True,
-        "artifact": "org.typelevel:kind-projector_2.13:0.10.3",
-        "sha256": "b5d60c8bc8f1333e2deac17d72d41bb59c53283a67ff3a613189746ce97ac8ad",
+        "artifact": "org.typelevel:kind-projector_2.13.11:0.13.2",
+        "sha256": "c5c49245a962206d708b7c9368d9f1dd77c773250c0f7bdde9c78e994889cb19",
     },
 }


### PR DESCRIPTION
### Description
Bumping supported Scala 2.12 and 2.13 minor versions

Found a compilation issue related to `kind_projector` so updated to latest artifacts as well for all Scala major versions.

### Motivation
I wanted to level up minor Scala versions before trying to tackle #1514 that has breaking changes related to Scala `2.13.12`