### PR TITLE
Fix semanticdb-scalac checksums for Scala 2.12.18 and 2.13.11

### DIFF
--- a/examples/semanticdb/WORKSPACE
+++ b/examples/semanticdb/WORKSPACE
@@ -21,7 +21,7 @@ local_repository(
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "2.13.6")
+scala_config(scala_version = "2.13.11")
 
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -79,7 +79,7 @@ artifacts = {
     },
     "org_scalameta_semanticdb_scalac": {
         "artifact": "org.scalameta:semanticdb-scalac_%s:4.8.4" % scala_version,
-        "sha256": "f31614cd13b6dc5c97804aa814b6f7ad4d67124290c08d0c9296b53e46d744e0",
+        "sha256": "11d28a73d182453454451aef4768462730f8c3e369df47b224a4ff2e943f1db7",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -83,7 +83,7 @@ artifacts = {
     },
     "org_scalameta_semanticdb_scalac": {
         "artifact": "org.scalameta:semanticdb-scalac_%s:4.8.4" % scala_version,
-        "sha256": "acc1f667d4e98b42ba851309feb391cf301afeeeeddb8c172874a2184b18b057",
+        "sha256": "7edcf57254f4361085f3fb0e604c9be0bf8037dbdc63cca7f26e2425fa1b1a9b",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],


### PR DESCRIPTION
### Description
This PR addresses current build issues regarding `semanticdb-scalac` checksums and Scala `2.13.x` version used in `examples/semanticdb` that was not up-to-date

### Motivation
Builds are currently failing because of : 

```
(15:35:14) WARNING: Download from https://repo.maven.apache.org/maven2/org/scalameta/semanticdb-scalac_2.12.18/4.8.4/semanticdb-scalac_2.12.18-4.8.4.jar failed: class com.google.devtools.build.lib.bazel.repository.downloader.UnrecoverableHttpException Checksum was 11d28a73d182453454451aef4768462730f8c3e369df47b224a4ff2e943f1db7 but wanted f31614cd13b6dc5c97804aa814b6f7ad4d67124290c08d0c9296b53e46d744e0
```

and : 

```
Error in fail: Scala config (2.13.6) version does not match repository version (2.13.11)
```

cc @crt-31 
