### PR TITLE
Bazel 7.0 rc2 support

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -39,7 +39,7 @@ def _scala_generate_benchmark(ctx):
 
     # just try to take the first one and see if that works
     class_jar = outs[0].class_jar
-    classpath = info.transitive_runtime_deps
+    classpath = info.transitive_runtime_jars
     ctx.actions.run(
         outputs = [ctx.outputs.src_jar, ctx.outputs.resource_jar],
         inputs = classpath,

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -136,7 +136,10 @@ def make_scala_junit_test(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         test = True,
-        toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        toolchains = [
+            "@io_bazel_rules_scala//scala:toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
+        ],
         incompatible_use_toolchain_transition = True,
         implementation = _scala_junit_test_impl,
     )


### PR DESCRIPTION
Added `@bazel_tools//tools/jdk:toolchain_type` toolchain for scala_junit_test: https://github.com/bazelbuild/bazel/issues/18970

Changed deprecated transitive_runtime_deps to transitive_runtime_jars in jmh.bzl:
https://bazel.build/versions/6.4.0/rules/lib/JavaInfo#transitive_runtime_deps

With these changes rules_scala (for the cases I checked) started working with Bazel 7.0 rc2.

