### PR TITLE
Change SemanticdbInfo.plugin_jar from string to File

### DIFF
--- a/examples/semanticdb/aspect.bzl
+++ b/examples/semanticdb/aspect.bzl
@@ -8,7 +8,7 @@ def semanticdb_info_aspect_impl(target, ctx):
         output_struct = struct(
             target_label = str(target.label),
             semanticdb_target_root = target[SemanticdbInfo].target_root,
-            semanticdb_pluginjar = target[SemanticdbInfo].plugin_jar,
+            semanticdb_pluginjar = "" if target[SemanticdbInfo].plugin_jar.path == None else target[SemanticdbInfo].plugin_jar.path,
         )
 
         json_output_file = ctx.actions.declare_file("%s_semanticdb_info.json" % target.label.name)

--- a/scala/private/phases/phase_semanticdb.bzl
+++ b/scala/private/phases/phase_semanticdb.bzl
@@ -20,7 +20,7 @@ def phase_semanticdb(ctx, p):
         scalacopts = []
         semanticdb_deps = []
         output_files = []
-        plugin_jar_path = ""
+        plugin_jar = None
 
         target_output_path = paths.dirname(ctx.outputs.jar.path)
 
@@ -45,7 +45,7 @@ def phase_semanticdb(ctx, p):
             if len(semanticdb_deps) != 1:
                 fail("more than one semanticdb plugin jar was specified in scala_toolchain. Expect a single semanticdb plugin jar")
 
-            plugin_jar_path = semanticdb_deps[0][JavaInfo].java_outputs[0].class_jar.path
+            plugin_jar = semanticdb_deps[0][JavaInfo].java_outputs[0].class_jar
 
             scalacopts += [
                 #note: Xplugin parameter handled in scalacworker,
@@ -65,7 +65,7 @@ def phase_semanticdb(ctx, p):
             semanticdb_enabled = True,
             target_root = None if toolchain.semanticdb_bundle_in_jar else semanticdb_target_root,
             is_bundled_in_jar = toolchain.semanticdb_bundle_in_jar,
-            plugin_jar = plugin_jar_path,
+            plugin_jar = plugin_jar,
         )
 
         return struct(

--- a/scala/semanticdb_provider.bzl
+++ b/scala/semanticdb_provider.bzl
@@ -3,6 +3,6 @@ SemanticdbInfo = provider(
         "semanticdb_enabled": "boolean",
         "target_root": "directory containing the semanticdb files (relative to execroot).",
         "is_bundled_in_jar": "boolean: whether the semanticdb files are bundled inside the jar",
-        "plugin_jar": "path to semanticdb plugin jar (relative to execroot)",
+        "plugin_jar": "semanticdb plugin jar file",
     },
 )

--- a/test/semanticdb/rules.bzl
+++ b/test/semanticdb/rules.bzl
@@ -12,7 +12,7 @@ def semanticdb_vars_script_impl(ctx):
                 "%TARGETROOT%": "" if semanticdb_info.target_root == None else semanticdb_info.target_root,
                 "%ENABLED%": "1" if semanticdb_info.semanticdb_enabled else "0",
                 "%ISBUNDLED%": "1" if semanticdb_info.is_bundled_in_jar else "0",
-                "%PLUGINPATH%": semanticdb_info.plugin_jar,
+                "%PLUGINPATH%": "" if semanticdb_info.plugin_jar == None else semanticdb_info.plugin_jar.path,
             },
         )
         return [


### PR DESCRIPTION
### Description
Changed SemanticdbInfo.plugin_jar from path string to File

### Motivation
This keeps the File object available for users of SemanticdbInfo. 

Addresses #1527 

(Note, this does change the public interface a bit, but should be fine since SemanicDBInfo is very new.)
