### PR TITLE
doc: Register proto toolchain for simple usage

### DIFF
--- a/docs/scala_proto_library.md
+++ b/docs/scala_proto_library.md
@@ -5,7 +5,10 @@ which adds a few dependencies needed for ScalaPB:
 
 ```starlark
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
-scala_proto_repositories() 
+scala_proto_repositories()
+
+load("@io_bazel_rules_scala//scala_proto:toolchains.bzl", "scala_proto_register_toolchains")
+scala_proto_register_toolchains()
 ```
 
 Then you can import `scala_proto_library` in any `BUILD` file like this:


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Add default toolchains registration code to `scala_proto_library` documentation.

Closes #768

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
For a simple usage of `scala_proto_library` without customization, it seems default toolchains registration must be done, otherwise users will get error like: `ERROR: No matching toolchains found for types @io_bazel_rules_scala//scala_proto:toolchain_type.`
