### PR TITLE
Add jdk toolchain type to proto rules

### DIFF
--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -217,6 +217,7 @@ def make_scala_proto_aspect(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@io_bazel_rules_scala//scala_proto:toolchain_type",
             "@io_bazel_rules_scala//scala_proto:deps_toolchain_type",
+            "@bazel_tools//tools/jdk:toolchain_type",
         ],
     )
 


### PR DESCRIPTION
Adds missing dependency on `@bazel_tools//tools/jdk:toolchain_type` to `scala_proto_aspect` as required since Bazel 7