### PR TITLE
Added windows task to CI

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -42,6 +42,11 @@ tasks:
     platform: macos
     shell_commands:
     - "./test_rules_scala.sh"
+  test_rules_scala_win:
+    name: "./test_rules_scala"
+    platform: windows
+    shell_commands:
+    - "bash test_rules_scala.sh"
   test_coverage_linux_6_3_0:
     name: "./test_coverage"
     platform: ubuntu2004


### PR DESCRIPTION
### Description
Added task on CI to run on Windows. 

### Motivation
Running the CI on Windows will help ensure this library ensure this library maintains continuous compatibility with Windows OS. (this is essentially a follow-on to #1529)
