### PR TITLE
Support Scala 3.3.1

### DIFF
--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -18,7 +18,7 @@ local_repository(
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "3.1.0")
+scala_config(scala_version = "3.3.1")
 
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",

--- a/test/shell/test_examples.sh
+++ b/test/shell/test_examples.sh
@@ -38,7 +38,7 @@ function scala3_2_example() {
 }
 
 function scala3_3_example() {
-  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.3.0 //..."
+  test_example examples/scala3 "bazel build --repo_env=SCALA_VERSION=3.3.1 //..."
 }
 
 function semanticdb_example() {

--- a/test/shell/test_semanticdb.sh
+++ b/test/shell/test_semanticdb.sh
@@ -30,7 +30,7 @@ test_produces_semanticdb(){
   fi
 
   if [ $scala_majver -eq 3 ]; then
-    local version_opt="--repo_env=SCALA_VERSION=3.3.0"
+    local version_opt="--repo_env=SCALA_VERSION=3.3.1"
   fi
 
 

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -1,4 +1,4 @@
-scala_version = "3.3.0"
+scala_version = "3.3.1"
 
 artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
@@ -7,22 +7,22 @@ artifacts = {
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:%s" % scala_version,
-        "sha256": "78add3aaa13701690b73fd90a13d1cae1da32565dedb379e65ade30a16973f6b",
+        "sha256": "b64c13c1f3d1ac2323457ec6cc09e9b38d7a9ef6889a1a0063601bf25d545508",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:%s" % scala_version,
-        "sha256": "783cfb049fc762ecc49fd774197d0ca9f011cfb7aca17a81a2206c4b574c31a7",
+        "sha256": "da070033d637a405a14cfe8ef8a16a792166e175f88f2c9f32b9a5cd403e5130",
     },
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:%s" % scala_version,
-        "sha256": "8bc0a975553be0a7d1e0f4dfb864553bdeb1ce03f86d0df8f6d5af09a0dba391",
+        "sha256": "da9741cc37def9111174befa2beb1672d81b9b3d7403f54ad875a5d40ae430c5",
     },
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:%s" % scala_version,
-        "sha256": "dc88fcb0fc4e766ac681e805ad2fbecfc485e6774d167e5cefdd764840d2f97c",
+        "sha256": "921027ca6a3f0cfac3b20fcadfea613558b4e6e607c1cc247ab4a05a62af3965",
     },
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.1.0-scala-1",

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -39,7 +39,7 @@ artifacts = {
     },
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:jar:3.2.16",
-        "sha256": "7e5f1193af2fd88c432c4b80ce3641e4b1d062f421d8a0fcc43af9a19bb7c2eb",
+        "sha256": "9283e684d401d821a4cbb2646f9611cbbcd7828d2499483d13a4b507775a4cd7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.16",


### PR DESCRIPTION
### Description
Update supported Scala version from 3.3.0 to 3.3.1 as it is the latest PATCH version.

### Motivation
https://github.com/bazelbuild/rules_scala/issues/1526
