### PR TITLE
Fix checksum io_bazel_rules_scala_scala_parallel_collections in Scala3.3

### DIFF
--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -30,7 +30,7 @@ artifacts = {
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_3:jar:1.0.4",
-        "sha256": "68f266c4fa37cb20a76e905ad940e241190ce288b7e4a9877f1dd1261cd1a9a7",
+        "sha256": "c3bf0d4d057942a78389fa9675823db5e3179f1b503f2df212b74e784da57050",
     },
     #
     "io_bazel_rules_scala_scalatest": {


### PR DESCRIPTION
### Description
Fix checkum for Scala 3.3 and [dependency](https://mvnrepository.com/artifact/org.scala-lang.modules/scala-parallel-collections_3/1.0.4). Correct checksum should be c3bf0d4d057942a78389fa9675823db5e3179f1b503f2df212b74e784da57050

### Motivation
Current checksum is invalid for `scala-parallel-collections_3/1.0.4`
