### PR TITLE
Fix to close the compiler object in scalacinvoker 

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
@@ -32,7 +32,7 @@ class ScalacInvoker{
       } else {
         throw ex;
       }
-    }finally{
+    } finally {
       comp.close();
     }
 

--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
@@ -32,6 +32,8 @@ class ScalacInvoker{
       } else {
         throw ex;
       }
+    }finally{
+      comp.close();
     }
 
     results.stopTime = System.currentTimeMillis();


### PR DESCRIPTION
### Description
This fixes functionality that was accidently broken in PR #1529   (my bad).

The fix is to call close on the compiler within the scalaCWorker (originally added in PR #1504)
