### PR TITLE
Cross build support

### DIFF
--- a/examples/crossbuild/BUILD
+++ b/examples/crossbuild/BUILD
@@ -2,14 +2,14 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 
 scala_library(
     name = "hello211",
-    scala_version = "2.11.12",
     srcs = ["Hello211.scala"],
+    scala_version = "2.11.12",
 )
 
 scala_library(
     name = "hello213",
-    scala_version = "2.13.12",
     srcs = ["Hello213.scala"],
+    scala_version = "2.13.12",
 )
 
 # scala 3.3.1 is default for this workspace
@@ -17,5 +17,8 @@ scala_binary(
     name = "main",
     srcs = ["Main.scala"],
     main_class = "hello",
-    deps = [":hello211", ":hello213"],
+    deps = [
+        ":hello211",
+        ":hello213",
+    ],
 )

--- a/examples/crossbuild/BUILD
+++ b/examples/crossbuild/BUILD
@@ -1,0 +1,21 @@
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+
+scala_library(
+    name = "hello211",
+    scala_version = "2.11.12",
+    srcs = ["Hello211.scala"],
+)
+
+scala_library(
+    name = "hello213",
+    scala_version = "2.13.12",
+    srcs = ["Hello213.scala"],
+)
+
+# scala 3.3.1 is default for this workspace
+scala_binary(
+    name = "main",
+    srcs = ["Main.scala"],
+    main_class = "hello",
+    deps = [":hello211", ":hello213"],
+)

--- a/examples/crossbuild/Hello211.scala
+++ b/examples/crossbuild/Hello211.scala
@@ -1,0 +1,5 @@
+package examples.crossbuild
+
+class Hello211 {
+  def hello = "Hello"
+}

--- a/examples/crossbuild/Hello213.scala
+++ b/examples/crossbuild/Hello213.scala
@@ -1,0 +1,5 @@
+package examples.crossbuild
+
+class Hello213 {
+  def hello = "Hello"
+}

--- a/examples/crossbuild/Main.scala
+++ b/examples/crossbuild/Main.scala
@@ -1,0 +1,4 @@
+import examples.crossbuild.Hello211
+import examples.crossbuild.Hello213
+
+@main def hello = println(s"${(new Hello211).hello} from scala 2.11, ${(new Hello213).hello} from scala 2.13")

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -1,0 +1,41 @@
+workspace(name = "cross_build")
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
+    name = "bazel_skylib",
+    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
+    urls = [
+        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
+    ],
+)
+
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../..",
+)
+
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+
+scala_config(scala_version = "3.3.1", scala_versions = ["2.11.12", "2.13.12"])
+
+load(
+    "@io_bazel_rules_scala//scala:scala.bzl",
+    "rules_scala_setup",
+    "rules_scala_toolchain_deps_repositories",
+)
+
+rules_scala_setup()
+
+rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies", "rules_proto_toolchains")
+
+rules_proto_dependencies()
+
+rules_proto_toolchains()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
+
+scala_register_toolchains()

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -18,7 +18,13 @@ local_repository(
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "3.3.1", scala_versions = ["2.11.12", "2.13.12"])
+scala_config(
+    scala_version = "3.3.1",
+    scala_versions = [
+        "2.11.12",
+        "2.13.12",
+    ],
+)
 
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,68 +1,12 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
-load("//scala:providers.bzl", "declare_deps_provider")
-load("//scala:scala.bzl", "setup_scala_toolchain")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
+load("//scala:scala.bzl", "declare_dep_providers", "setup_scala_toolchains")
 
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
 )
 
-_SCALA_COMPILE_CLASSPATH_DEPS = [
-    "@io_bazel_rules_scala_scala_compiler",
-    "@io_bazel_rules_scala_scala_library",
-] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "@io_bazel_rules_scala_scala_interfaces",
-    "@io_bazel_rules_scala_scala_tasty_core",
-    "@io_bazel_rules_scala_scala_asm",
-    "@io_bazel_rules_scala_scala_library_2",
-])
-
-_SCALA_LIBRARY_CLASSPATH_DEPS = [
-    "@io_bazel_rules_scala_scala_library",
-] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "@io_bazel_rules_scala_scala_library_2",
-])
-
-_SCALA_MACRO_CLASSPATH_DEPS = [
-    "@io_bazel_rules_scala_scala_library",
-] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "@io_bazel_rules_scala_scala_library_2",
-])
-
-_PARSER_COMBINATORS_DEPS = ["@io_bazel_rules_scala_scala_parser_combinators"]
-
-_SCALA_XML_DEPS = ["@io_bazel_rules_scala_scala_xml"]
-
-_SEMANTICDB_DEPS = ["@org_scalameta_semanticdb_scalac"] if SCALA_MAJOR_VERSION.startswith("2") else []
-
-setup_scala_toolchain(
-    name = "default_toolchain",
-    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
-    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
-    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
-    use_argument_file_in_runner = True,
-)
-
-setup_scala_toolchain(
-    name = "unused_dependency_checker_error_toolchain",
-    dependency_tracking_method = "ast-plus",
-    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
-    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
-    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
-    unused_dependency_checker_mode = "error",
-)
-
-setup_scala_toolchain(
-    name = "minimal_direct_source_deps",
-    dependency_mode = "plus-one",
-    dependency_tracking_method = "ast",
-    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
-    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
-    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
-    strict_deps_mode = "error",
-    unused_dependency_checker_mode = "error",
-)
+setup_scala_toolchains()
 
 java_import(
     name = "bazel_test_runner_deploy",
@@ -76,44 +20,4 @@ java_library(
     visibility = ["//visibility:public"],
 )
 
-declare_deps_provider(
-    name = "scala_compile_classpath_provider",
-    deps_id = "scala_compile_classpath",
-    visibility = ["//visibility:public"],
-    deps = _SCALA_COMPILE_CLASSPATH_DEPS,
-)
-
-declare_deps_provider(
-    name = "scala_library_classpath_provider",
-    deps_id = "scala_library_classpath",
-    visibility = ["//visibility:public"],
-    deps = _SCALA_LIBRARY_CLASSPATH_DEPS,
-)
-
-declare_deps_provider(
-    name = "scala_macro_classpath_provider",
-    deps_id = "scala_macro_classpath",
-    visibility = ["//visibility:public"],
-    deps = _SCALA_MACRO_CLASSPATH_DEPS,
-)
-
-declare_deps_provider(
-    name = "scala_xml_provider",
-    deps_id = "scala_xml",
-    visibility = ["//visibility:public"],
-    deps = _SCALA_XML_DEPS,
-)
-
-declare_deps_provider(
-    name = "parser_combinators_provider",
-    deps_id = "parser_combinators",
-    visibility = ["//visibility:public"],
-    deps = _PARSER_COMBINATORS_DEPS,
-)
-
-declare_deps_provider(
-    name = "semanticdb_provider",
-    deps_id = "semanticdb",
-    visibility = ["//visibility:public"],
-    deps = _SEMANTICDB_DEPS,
-)
+declare_dep_providers()

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -90,6 +90,30 @@ implicit_deps = {
         default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac"),
         allow_files = True,
     ),
+    "_scalac_before_2_12_13": attr.label(
+        executable = True,
+        cfg = "exec",
+        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac:scalac_before_2_12_13"),
+        allow_files = True,
+    ),
+    "_scalac_after_2_12_13_and_before_2_13_12": attr.label(
+        executable = True,
+        cfg = "exec",
+        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac:scalac_after_2_12_13_and_before_2_13_12"),
+        allow_files = True,
+    ),
+    "_scalac_after_2_13_12": attr.label(
+        executable = True,
+        cfg = "exec",
+        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac:scalac_after_2_13_12"),
+        allow_files = True,
+    ),
+    "_scalac_3": attr.label(
+        executable = True,
+        cfg = "exec",
+        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac:scalac_3"),
+        allow_files = True,
+    ),
     "_exe": attr.label(
         executable = True,
         cfg = "exec",

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -3,12 +3,13 @@ load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
     _default_maven_server_urls = "default_maven_server_urls",
 )
-load("//third_party/repositories:repositories.bzl", "repositories")
+load("//third_party/repositories:repositories.bzl", "repositories", "toolchain_repositories")
 load(
     "@io_bazel_rules_scala_config//:config.bzl",
     "SCALA_MAJOR_VERSION",
     "SCALA_MINOR_VERSION",
     "SCALA_VERSION",
+    "SCALA_VERSIONS",
 )
 
 def _dt_patched_compiler_impl(rctx):
@@ -122,36 +123,27 @@ def rules_scala_setup(scala_compiler_srcjar = None):
 
     dt_patched_compiler_setup(scala_compiler_srcjar)
 
-ARTIFACT_IDS = [
-    "io_bazel_rules_scala_scala_library",
-    "io_bazel_rules_scala_scala_compiler",
-    "io_bazel_rules_scala_scala_reflect",
-    "io_bazel_rules_scala_scala_xml",
-    "io_bazel_rules_scala_scala_parser_combinators",
-    "org_scalameta_semanticdb_scalac",
-] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "io_bazel_rules_scala_scala_library",
-    "io_bazel_rules_scala_scala_compiler",
-    "io_bazel_rules_scala_scala_interfaces",
-    "io_bazel_rules_scala_scala_tasty_core",
-    "io_bazel_rules_scala_scala_asm",
-    "io_bazel_rules_scala_scala_xml",
-    "io_bazel_rules_scala_scala_parser_combinators",
-    "io_bazel_rules_scala_scala_library_2",
-]
-
 def rules_scala_toolchain_deps_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {},
         fetch_sources = False,
         validate_scala_version = True):
     repositories(
-        for_artifact_ids = ARTIFACT_IDS,
+        for_artifact_ids = _artifact_ids(SCALA_VERSION),
         maven_servers = maven_servers,
         fetch_sources = fetch_sources,
         overriden_artifacts = overriden_artifacts,
         validate_scala_version = validate_scala_version,
     )
+    for scala_version in SCALA_VERSIONS:
+        toolchain_repositories(
+            scala_version,
+            for_artifact_ids = _artifact_ids(scala_version),
+            maven_servers = maven_servers,
+            fetch_sources = fetch_sources,
+            overriden_artifacts = overriden_artifacts,
+            validate_scala_version = validate_scala_version,
+        )
 
 def scala_repositories(
         maven_servers = _default_maven_server_urls(),
@@ -168,3 +160,22 @@ def scala_repositories(
             overriden_artifacts,
             fetch_sources,
         )
+
+def _artifact_ids(scala_version):
+    return [
+        "io_bazel_rules_scala_scala_library",
+        "io_bazel_rules_scala_scala_compiler",
+        "io_bazel_rules_scala_scala_reflect",
+        "io_bazel_rules_scala_scala_xml",
+        "io_bazel_rules_scala_scala_parser_combinators",
+        "org_scalameta_semanticdb_scalac",
+    ] if scala_version.startswith("2") else [
+        "io_bazel_rules_scala_scala_library",
+        "io_bazel_rules_scala_scala_compiler",
+        "io_bazel_rules_scala_scala_interfaces",
+        "io_bazel_rules_scala_scala_tasty_core",
+        "io_bazel_rules_scala_scala_asm",
+        "io_bazel_rules_scala_scala_xml",
+        "io_bazel_rules_scala_scala_parser_combinators",
+        "io_bazel_rules_scala_scala_library_2",
+    ]

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -1,11 +1,88 @@
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:providers.bzl", "declare_deps_provider")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
+load("//scala/versions:versions.bzl", "sanitize_version")
+
+_SCALA_COMPILE_CLASSPATH_DEPS = {
+    "2": [
+        "@io_bazel_rules_scala_scala_compiler",
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_reflect",
+    ],
+    "3": [
+        "@io_bazel_rules_scala_scala_compiler",
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_interfaces",
+        "@io_bazel_rules_scala_scala_tasty_core",
+        "@io_bazel_rules_scala_scala_asm",
+        "@io_bazel_rules_scala_scala_library_2",
+    ],
+}
+
+_SCALA_LIBRARY_CLASSPATH_DEPS = {
+    "2": [
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_reflect",
+    ],
+    "3": [
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_library_2",
+    ],
+}
+
+_SCALA_MACRO_CLASSPATH_DEPS = {
+    "2": [
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_reflect",
+    ],
+    "3": [
+        "@io_bazel_rules_scala_scala_library",
+        "@io_bazel_rules_scala_scala_library_2",
+    ],
+}
+
+_PARSER_COMBINATORS_DEPS = {
+    "2": ["@io_bazel_rules_scala_scala_parser_combinators"],
+    "3": ["@io_bazel_rules_scala_scala_parser_combinators"],
+}
+
+_SCALA_XML_DEPS = {
+    "2": ["@io_bazel_rules_scala_scala_xml"],
+    "3": ["@io_bazel_rules_scala_scala_xml"],
+}
+
+_SCALA_SEMANTICDB_DEPS = {
+    "2": ["@org_scalameta_semanticdb_scalac"],
+    "3": [],
+}
+
+def _dependencies_by_version(version, deps):
+    return deps[version[0:1]]
+
+def _parser_combinators_deps(version = SCALA_VERSION):
+    return _dependencies_by_version(version, _PARSER_COMBINATORS_DEPS)
+
+def _scala_compile_classpath_deps(version = SCALA_VERSION):
+    return _dependencies_by_version(version, _SCALA_COMPILE_CLASSPATH_DEPS)
+
+def _scala_library_classpath_deps(version = SCALA_VERSION):
+    return _dependencies_by_version(version, _SCALA_LIBRARY_CLASSPATH_DEPS)
+
+def _scala_macro_classpath_deps(version = SCALA_VERSION):
+    return _dependencies_by_version(version, _SCALA_MACRO_CLASSPATH_DEPS)
+
+def _scala_xml_deps(version = SCALA_VERSION):
+    return _dependencies_by_version(version, _SCALA_XML_DEPS)
+
+def _scala_semanticdb_deps(version = SCALA_VERSION):
+    return _dependencies_by_version(version, _SCALA_SEMANTICDB_DEPS)
 
 def setup_scala_toolchain(
         name,
         scala_compile_classpath,
         scala_library_classpath,
         scala_macro_classpath,
+        scala_version = None,
         scala_xml_deps = None,
         parser_combinators_deps = None,
         semanticdb_deps = None,
@@ -83,6 +160,7 @@ def setup_scala_toolchain(
 
     scala_toolchain(
         name = "%s_impl" % name,
+        scala_version = scala_version,
         dep_providers = dep_providers,
         enable_semanticdb = enable_semanticdb,
         visibility = visibility,
@@ -93,5 +171,92 @@ def setup_scala_toolchain(
         name = name,
         toolchain = ":%s_impl" % name,
         toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+        target_settings = ["//scala/versions:" + sanitize_version(scala_version)] if scala_version else [],
         visibility = visibility,
+    )
+
+def setup_scala_toolchains():
+    setup_scala_toolchain(
+        name = "default_toolchain",
+        scala_compile_classpath = _scala_compile_classpath_deps(),
+        scala_library_classpath = _scala_library_classpath_deps(),
+        scala_macro_classpath = _scala_macro_classpath_deps(),
+        use_argument_file_in_runner = True,
+    )
+    setup_scala_toolchain(
+        name = "unused_dependency_checker_error_toolchain",
+        dependency_tracking_method = "ast-plus",
+        scala_compile_classpath = _scala_compile_classpath_deps(),
+        scala_library_classpath = _scala_library_classpath_deps(),
+        scala_macro_classpath = _scala_macro_classpath_deps(),
+        unused_dependency_checker_mode = "error",
+    )
+    setup_scala_toolchain(
+        name = "minimal_direct_source_deps",
+        dependency_mode = "plus-one",
+        dependency_tracking_method = "ast",
+        scala_compile_classpath = _scala_compile_classpath_deps(),
+        scala_library_classpath = _scala_library_classpath_deps(),
+        scala_macro_classpath = _scala_macro_classpath_deps(),
+        strict_deps_mode = "error",
+        unused_dependency_checker_mode = "error",
+    )
+    for scala_version in SCALA_VERSIONS:
+        sanitized_scala_version = sanitize_version(scala_version)
+        setup_scala_toolchain(
+            name = sanitized_scala_version + "_toolchain",
+            scala_version = scala_version,
+            parser_combinators_deps = _deps_with_version_suffix(sanitized_scala_version, _PARSER_COMBINATORS_DEPS),
+            scala_compile_classpath = _deps_with_version_suffix(sanitized_scala_version, _SCALA_COMPILE_CLASSPATH_DEPS),
+            scala_library_classpath = _deps_with_version_suffix(sanitized_scala_version, _SCALA_LIBRARY_CLASSPATH_DEPS),
+            scala_macro_classpath = _deps_with_version_suffix(sanitized_scala_version, _SCALA_MACRO_CLASSPATH_DEPS),
+            scala_xml_deps = _deps_with_version_suffix(sanitized_scala_version, _SCALA_XML_DEPS),
+            semanticdb_deps = _deps_with_version_suffix(sanitized_scala_version, _SCALA_SEMANTICDB_DEPS),
+            use_argument_file_in_runner = True,
+        )
+
+def _deps_with_version_suffix(version, deps):
+    return [dep + "_" + version for dep in deps[version[0:1]]]
+
+def declare_dep_providers():
+    declare_deps_provider(
+        name = "scala_compile_classpath_provider",
+        deps_id = "scala_compile_classpath",
+        visibility = ["//visibility:public"],
+        deps = _scala_compile_classpath_deps(),
+    )
+
+    declare_deps_provider(
+        name = "scala_library_classpath_provider",
+        deps_id = "scala_library_classpath",
+        visibility = ["//visibility:public"],
+        deps = _scala_library_classpath_deps(),
+    )
+
+    declare_deps_provider(
+        name = "scala_macro_classpath_provider",
+        deps_id = "scala_macro_classpath",
+        visibility = ["//visibility:public"],
+        deps = _scala_macro_classpath_deps(),
+    )
+
+    declare_deps_provider(
+        name = "scala_xml_provider",
+        deps_id = "scala_xml",
+        visibility = ["//visibility:public"],
+        deps = _scala_xml_deps(),
+    )
+
+    declare_deps_provider(
+        name = "parser_combinators_provider",
+        deps_id = "parser_combinators",
+        visibility = ["//visibility:public"],
+        deps = _parser_combinators_deps(),
+    )
+
+    declare_deps_provider(
+        name = "semanticdb_provider",
+        deps_id = "semanticdb",
+        visibility = ["//visibility:public"],
+        deps = _scala_semanticdb_deps(),
     )

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -9,6 +9,7 @@ load(
     "resolve_deps",
 )
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("@io_bazel_rules_scala//scala/versions:versions.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
     "extras_phases",
@@ -70,6 +71,8 @@ _scala_binary_attrs.update(common_attrs)
 
 _scala_binary_attrs.update(resolve_deps)
 
+_scala_binary_attrs.update(toolchain_transition_attr)
+
 def make_scala_binary(*extras):
     return rule(
         attrs = _dicts.add(
@@ -88,6 +91,7 @@ def make_scala_binary(*extras):
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         incompatible_use_toolchain_transition = True,
+        cfg = scala_version_transition,
         implementation = _scala_binary_impl,
     )
 

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -11,6 +11,7 @@ load(
     "resolve_deps",
 )
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("@io_bazel_rules_scala//scala/versions:versions.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
@@ -87,6 +88,8 @@ _scala_library_attrs.update(_library_attrs)
 
 _scala_library_attrs.update(resolve_deps)
 
+_scala_library_attrs.update(toolchain_transition_attr)
+
 def make_scala_library(*extras):
     return rule(
         attrs = _dicts.add(
@@ -103,6 +106,7 @@ def make_scala_library(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_library_impl,
     )

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -10,7 +10,9 @@ load(
 )
 load(
     "@io_bazel_rules_scala//scala/private:macros/setup_scala_toolchain.bzl",
+    _declare_dep_providers = "declare_dep_providers",
     _setup_scala_toolchain = "setup_scala_toolchain",
+    _setup_scala_toolchains = "setup_scala_toolchains",
 )
 load(
     "@io_bazel_rules_scala//scala/private:rules/scala_binary.bzl",
@@ -81,3 +83,5 @@ scala_test = _scala_test
 scala_test_suite = _scala_test_suite
 setup_scala_testing_toolchain = _setup_scala_testing_toolchain
 setup_scala_toolchain = _setup_scala_toolchain
+setup_scala_toolchains = _setup_scala_toolchains
+declare_dep_providers = _declare_dep_providers

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -101,6 +101,7 @@ def _scala_toolchain_impl(ctx):
         enable_semanticdb = ctx.attr.enable_semanticdb,
         semanticdb_bundle_in_jar = ctx.attr.semanticdb_bundle_in_jar,
         use_argument_file_in_runner = ctx.attr.use_argument_file_in_runner,
+        scala_version = ctx.attr.scala_version,
     )
     return [toolchain]
 
@@ -173,6 +174,7 @@ scala_toolchain = rule(
             default = False,
             doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
         ),
+        "scala_version": attr.string(),
     },
     fragments = ["java"],
 )

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -1,4 +1,11 @@
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+load("//scala/versions:versions.bzl", "sanitize_version")
+
 def scala_register_toolchains():
+    for scala_version in SCALA_VERSIONS:
+        native.register_toolchains(
+            "@io_bazel_rules_scala//scala:%s_toolchain" % sanitize_version(scala_version),
+        )
     native.register_toolchains(
         "@io_bazel_rules_scala//scala:default_toolchain",
     )

--- a/scala/versions/BUILD
+++ b/scala/versions/BUILD
@@ -1,0 +1,46 @@
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+string_flag(
+    name = "scala_version",
+    build_setting_default = "",
+    values = [
+        "",
+        "2.11.12",
+        "2.12.18",
+        "2.13.12",
+        "3.1.0",
+        "3.2.1",
+        "3.3.1",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "2_11_12",
+    flag_values = {":scala_version": "2.11.12"},
+)
+
+config_setting(
+    name = "2_12_18",
+    flag_values = {":scala_version": "2.12.18"},
+)
+
+config_setting(
+    name = "2_13_12",
+    flag_values = {":scala_version": "2.13.12"},
+)
+
+config_setting(
+    name = "3_1_0",
+    flag_values = {":scala_version": "3.1.0"},
+)
+
+config_setting(
+    name = "3_2_1",
+    flag_values = {":scala_version": "3.2.1"},
+)
+
+config_setting(
+    name = "3_3_1",
+    flag_values = {":scala_version": "3.3.1"},
+)

--- a/scala/versions/versions.bzl
+++ b/scala/versions/versions.bzl
@@ -1,0 +1,21 @@
+def _scala_version_transition_impl(settings, attr):
+    if attr.scala_version:
+        return {"//scala/versions:scala_version": attr.scala_version}
+    else:
+        return {}
+
+scala_version_transition = transition(
+    implementation = _scala_version_transition_impl,
+    inputs = [],
+    outputs = ["//scala/versions:scala_version"],
+)
+
+toolchain_transition_attr = {
+    "scala_version": attr.string(),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+}
+
+def sanitize_version(scala_version):
+    return scala_version.replace(".", "_")

--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -16,6 +16,11 @@ def _store_config(repository_ctx):
         repository_ctx.attr.scala_version,
     )
 
+    scala_versions = repository_ctx.os.environ.get(
+        "SCALA_VERSIONS",
+        repository_ctx.attr.scala_versions,
+    )
+
     enable_compiler_dependency_tracking = repository_ctx.os.environ.get(
         "ENABLE_COMPILER_DEPENDENCY_TRACKING",
         str(repository_ctx.attr.enable_compiler_dependency_tracking),
@@ -29,6 +34,7 @@ def _store_config(repository_ctx):
 
     config_file_content = "\n".join([
         "SCALA_VERSION='" + scala_version + "'",
+        "SCALA_VERSIONS=" + str(scala_versions),
         "SCALA_MAJOR_VERSION='" + scala_major_version + "'",
         "SCALA_MINOR_VERSION='" + scala_minor_version + "'",
         "ENABLE_COMPILER_DEPENDENCY_TRACKING=" + enable_compiler_dependency_tracking,
@@ -43,18 +49,21 @@ _config_repository = repository_rule(
         "scala_version": attr.string(
             mandatory = True,
         ),
+        "scala_versions": attr.string_list(mandatory = True),
         "enable_compiler_dependency_tracking": attr.bool(
             mandatory = True,
         ),
     },
-    environ = ["SCALA_VERSION", "ENABLE_COMPILER_DEPENDENCY_TRACKING"],
+    environ = ["SCALA_VERSION", "SCALA_VERSIONS", "ENABLE_COMPILER_DEPENDENCY_TRACKING"],
 )
 
 def scala_config(
         scala_version = _default_scala_version(),
+        scala_versions = [],
         enable_compiler_dependency_tracking = False):
     _config_repository(
         name = "io_bazel_rules_scala_config",
         scala_version = scala_version,
+        scala_versions = scala_versions,
         enable_compiler_dependency_tracking = enable_compiler_dependency_tracking,
     )

--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -13,7 +13,6 @@ SCALAC_DEPS = [
     "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/worker",
     "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
     "//src/java/io/bazel/rulesscala/scalac/compileoptions",
-    "//src/java/io/bazel/rulesscala/scalac/reporter",
 ]
 
 DEP_REPORTING_DEPS = ["//third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler:dep_reporting_compiler"] if ENABLE_COMPILER_DEPENDENCY_TRACKING and SCALA_MAJOR_VERSION.startswith("2") else []
@@ -29,7 +28,63 @@ java_binary(
     ],
     main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
     visibility = ["//visibility:public"],
-    deps = DEP_REPORTING_DEPS + SCALAC_DEPS,
+    deps = DEP_REPORTING_DEPS + SCALAC_DEPS + ["//src/java/io/bazel/rulesscala/scalac/reporter:reporter"],
+)
+
+java_binary(
+    name = "scalac_before_2_12_13",
+    srcs = [
+        ":scalac2_files",
+    ],
+    javacopts = [
+        "-source 1.8",
+        "-target 1.8",
+    ],
+    main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
+    visibility = ["//visibility:public"],
+    deps = SCALAC_DEPS + ["//src/java/io/bazel/rulesscala/scalac/reporter:reporter_before_2_12_13"],
+)
+
+java_binary(
+    name = "scalac_after_2_12_13_and_before_2_13_12",
+    srcs = [
+        ":scalac2_files",
+    ],
+    javacopts = [
+        "-source 1.8",
+        "-target 1.8",
+    ],
+    main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
+    visibility = ["//visibility:public"],
+    deps = SCALAC_DEPS + ["//src/java/io/bazel/rulesscala/scalac/reporter:reporter_after_2_12_13_and_before_2_13_12"],
+)
+
+java_binary(
+    name = "scalac_after_2_13_12",
+    srcs = [
+        ":scalac2_files",
+    ],
+    javacopts = [
+        "-source 1.8",
+        "-target 1.8",
+    ],
+    main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
+    visibility = ["//visibility:public"],
+    deps = SCALAC_DEPS + ["//src/java/io/bazel/rulesscala/scalac/reporter:reporter_after_2_13_12"],
+)
+
+java_binary(
+    name = "scalac_3",
+    srcs = [
+        ":scalac3_files",
+    ],
+    javacopts = [
+        "-source 1.8",
+        "-target 1.8",
+    ],
+    main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
+    visibility = ["//visibility:public"],
+    deps = SCALAC_DEPS + ["//src/java/io/bazel/rulesscala/scalac/reporter:reporter_3"],
 )
 
 java_binary(
@@ -43,7 +98,7 @@ java_binary(
     ],
     main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
     visibility = ["//visibility:public"],
-    deps = SCALAC_DEPS,
+    deps = SCALAC_DEPS + ["//src/java/io/bazel/rulesscala/scalac/reporter:reporter"],
 )
 
 filegroup(
@@ -58,4 +113,23 @@ filegroup(
         ] if SCALA_MAJOR_VERSION.startswith("2") else ["ScalacInvoker3.java"]
     ),
     visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "scalac2_files",
+    srcs = [
+        "ReportableMainClass.java",
+        "ScalacInvoker.java",
+        "ScalacInvokerResults.java",
+        "ScalacWorker.java",
+    ],
+)
+
+filegroup(
+    name = "scalac3_files",
+    srcs = [
+        "ScalacInvoker3.java",
+        "ScalacInvokerResults.java",
+        "ScalacWorker.java",
+    ],
 )

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/BUILD
@@ -11,3 +11,27 @@ filegroup(
     ],
     visibility = ["//visibility:public"],
 )
+
+filegroup(
+    name = "deps_tracking_reporter_before_2_12_13",
+    srcs = [
+        "before_2_12_13/DepsTrackingReporter.java",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "deps_tracking_reporter_after_2_12_13_and_before_2_13_12",
+    srcs = [
+        "after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+filegroup(
+    name = "deps_tracking_reporter_after_2_13_12",
+    srcs = [
+        "after_2_13_12/DepsTrackingReporter.java",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/src/java/io/bazel/rulesscala/scalac/reporter/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/reporter/BUILD
@@ -23,6 +23,63 @@ java_library(
     ],
 )
 
+java_library(
+    name = "reporter_before_2_12_13",
+    srcs = [
+        "before_2_12_13/ProtoReporter.java",
+        "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter:deps_tracking_reporter_before_2_12_13",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":scala_deps_java_proto",
+        "//scala/private/toolchain_deps:scala_compile_classpath",
+        "//src/java/io/bazel/rulesscala/scalac/compileoptions",
+        "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
+    ],
+)
+
+java_library(
+    name = "reporter_after_2_12_13_and_before_2_13_12",
+    srcs = [
+        "after_2_12_13_and_before_2_13_12/ProtoReporter.java",
+        "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter:deps_tracking_reporter_after_2_12_13_and_before_2_13_12",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":scala_deps_java_proto",
+        "//scala/private/toolchain_deps:scala_compile_classpath",
+        "//src/java/io/bazel/rulesscala/scalac/compileoptions",
+        "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
+    ],
+)
+
+java_library(
+    name = "reporter_after_2_13_12",
+    srcs = [
+        "after_2_13_12/ProtoReporter.java",
+        "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter:deps_tracking_reporter_after_2_13_12",
+    ],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":scala_deps_java_proto",
+        "//scala/private/toolchain_deps:scala_compile_classpath",
+        "//src/java/io/bazel/rulesscala/scalac/compileoptions",
+        "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
+    ],
+)
+
+java_library(
+    name = "reporter_3",
+    srcs = ["PlaceholderForEmptyScala3Lib.java"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":scala_deps_java_proto",
+        "//scala/private/toolchain_deps:scala_compile_classpath",
+        "//src/java/io/bazel/rulesscala/scalac/compileoptions",
+        "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
+    ],
+)
+
 proto_library(
     name = "scala_deps_proto",
     srcs = ["scala_deps.proto"],

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -33,7 +33,7 @@ local_repository(
 )
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
-scala_config(enable_compiler_dependency_tracking = True)
+scala_config(enable_compiler_dependency_tracking = True, scala_versions = ["2.11.12", "2.12.18", "2.13.12", "3.1.0", "3.2.1", "3.3.1"])
 
 load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "extract_major_version")
 
@@ -65,6 +65,8 @@ scalatest_repositories()
 
 register_toolchains("@io_bazel_rules_scala//testing:testing_toolchain")
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_toolchains")
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains", "scala_register_unused_deps_toolchains")
+
+scala_register_toolchains()
 
 scala_register_unused_deps_toolchains()

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -178,42 +178,42 @@ scala_binary(
 
 scala_binary(
     name = "hello211",
-    scala_version = "2.11.12",
-    main_class = "scalarules.test.versions.Hello211",
     srcs = ["versions/Hello211.scala"],
+    main_class = "scalarules.test.versions.Hello211",
+    scala_version = "2.11.12",
 )
 
 scala_binary(
     name = "hello212",
-    scala_version = "2.12.18",
-    main_class = "scalarules.test.versions.Hello212",
     srcs = ["versions/Hello212.scala"],
+    main_class = "scalarules.test.versions.Hello212",
+    scala_version = "2.12.18",
 )
 
 scala_binary(
     name = "hello213",
-    scala_version = "2.13.12",
-    main_class = "scalarules.test.versions.Hello213",
     srcs = ["versions/Hello213.scala"],
+    main_class = "scalarules.test.versions.Hello213",
+    scala_version = "2.13.12",
 )
 
 scala_binary(
     name = "hello31",
-    scala_version = "3.1.0",
-    main_class = "scalarules.test.versions.hello31",
     srcs = ["versions/Hello31.scala"],
+    main_class = "scalarules.test.versions.hello31",
+    scala_version = "3.1.0",
 )
 
 scala_binary(
     name = "hello32",
-    scala_version = "3.2.1",
-    main_class = "scalarules.test.versions.hello32",
     srcs = ["versions/Hello32.scala"],
+    main_class = "scalarules.test.versions.hello32",
+    scala_version = "3.2.1",
 )
 
 scala_binary(
     name = "hello33",
-    scala_version = "3.3.1",
-    main_class = "scalarules.test.versions.hello33",
     srcs = ["versions/Hello33.scala"],
+    main_class = "scalarules.test.versions.hello33",
+    scala_version = "3.3.1",
 )

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -156,6 +156,12 @@ scala_specs2_junit_test(
     "JavaBinary",
     "MixJavaScalaLibBinary",
     "ScalaBinary",
+    "hello211",
+    "hello212",
+    "hello213",
+    "hello31",
+    "hello32",
+    "hello33",
 ]]
 
 scala_library(
@@ -168,4 +174,46 @@ scala_binary(
     name = "test_scala_proto_server",
     main_class = "test.proto.TestServer",
     deps = [":lib_with_scala_proto_dep"],
+)
+
+scala_binary(
+    name = "hello211",
+    scala_version = "2.11.12",
+    main_class = "scalarules.test.versions.Hello211",
+    srcs = ["versions/Hello211.scala"],
+)
+
+scala_binary(
+    name = "hello212",
+    scala_version = "2.12.18",
+    main_class = "scalarules.test.versions.Hello212",
+    srcs = ["versions/Hello212.scala"],
+)
+
+scala_binary(
+    name = "hello213",
+    scala_version = "2.13.12",
+    main_class = "scalarules.test.versions.Hello213",
+    srcs = ["versions/Hello213.scala"],
+)
+
+scala_binary(
+    name = "hello31",
+    scala_version = "3.1.0",
+    main_class = "scalarules.test.versions.hello31",
+    srcs = ["versions/Hello31.scala"],
+)
+
+scala_binary(
+    name = "hello32",
+    scala_version = "3.2.1",
+    main_class = "scalarules.test.versions.hello32",
+    srcs = ["versions/Hello32.scala"],
+)
+
+scala_binary(
+    name = "hello33",
+    scala_version = "3.3.1",
+    main_class = "scalarules.test.versions.hello33",
+    srcs = ["versions/Hello33.scala"],
 )

--- a/test_version/version_specific_tests_dir/versions/Hello211.scala
+++ b/test_version/version_specific_tests_dir/versions/Hello211.scala
@@ -1,0 +1,9 @@
+package scalarules.test.versions
+
+object Hello211 {
+  
+  def main(args: Array[String]): Unit = {
+    println("hello211")
+  }
+  
+}

--- a/test_version/version_specific_tests_dir/versions/Hello212.scala
+++ b/test_version/version_specific_tests_dir/versions/Hello212.scala
@@ -1,0 +1,9 @@
+package scalarules.test.versions
+
+object Hello212 {
+
+  def main(args: Array[String]): Unit = {
+    println("hello212")
+  }
+
+}

--- a/test_version/version_specific_tests_dir/versions/Hello213.scala
+++ b/test_version/version_specific_tests_dir/versions/Hello213.scala
@@ -1,0 +1,9 @@
+package scalarules.test.versions
+
+object Hello213 {
+
+  def main(args: Array[String]): Unit = {
+    println("hello213")
+  }
+
+}

--- a/test_version/version_specific_tests_dir/versions/Hello31.scala
+++ b/test_version/version_specific_tests_dir/versions/Hello31.scala
@@ -1,0 +1,5 @@
+package scalarules.test
+package versions
+
+@main def hello31 = println("hello31")
+  

--- a/test_version/version_specific_tests_dir/versions/Hello32.scala
+++ b/test_version/version_specific_tests_dir/versions/Hello32.scala
@@ -1,0 +1,4 @@
+package scalarules.test
+package versions
+
+@main def hello32 = println("hello32")

--- a/test_version/version_specific_tests_dir/versions/Hello33.scala
+++ b/test_version/version_specific_tests_dir/versions/Hello33.scala
@@ -1,0 +1,4 @@
+package scalarules.test
+package versions
+
+@main def hello33 = println("hello33")

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -37,6 +37,8 @@ load(
     _scala_maven_import_external = "scala_maven_import_external",
 )
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION", "SCALA_VERSION")
+load("//scala:scala_cross_version.bzl", "extract_major_version")
+load("//scala/versions:versions.bzl", "sanitize_version")
 
 artifacts_by_major_scala_version = {
     "2.11": _artifacts_2_11,
@@ -82,6 +84,39 @@ def repositories(
             licenses = ["notice"],
             server_urls = maven_servers,
             deps = artifacts[id].get("deps", []),
+            runtime_deps = artifacts[id].get("runtime_deps", []),
+            testonly_ = artifacts[id].get("testonly", False),
+            fetch_sources = fetch_sources,
+        )
+
+def toolchain_repositories(
+        scala_version,
+        for_artifact_ids = [],
+        maven_servers = default_maven_server_urls(),
+        overriden_artifacts = {},
+        fetch_sources = True,
+        validate_scala_version = False):
+    major_scala_version = extract_major_version(scala_version)
+
+    if validate_scala_version:
+        repository_scala_version = scala_version_by_major_scala_version[major_scala_version]
+        default_version_matches = scala_version == repository_scala_version
+
+        if not default_version_matches and len(overriden_artifacts) == 0:
+            version_message = "Scala config (%s) version does not match repository version (%s)"
+            fail(version_message % (scala_version, repository_scala_version))
+
+    default_artifacts = artifacts_by_major_scala_version[major_scala_version]
+    artifacts = dict(default_artifacts.items() + overriden_artifacts.items())
+    version_suffix = "_" + sanitize_version(scala_version)
+    for id in for_artifact_ids:
+        _scala_maven_import_external(
+            name = id + version_suffix,
+            artifact = artifacts[id]["artifact"],
+            artifact_sha256 = artifacts[id]["sha256"],
+            licenses = ["notice"],
+            server_urls = maven_servers,
+            deps = [dep + version_suffix for dep in artifacts[id].get("deps", [])],
             runtime_deps = artifacts[id].get("runtime_deps", []),
             testonly_ = artifacts[id].get("testonly", False),
             fetch_sources = fetch_sources,


### PR DESCRIPTION
### Description
This PR allows the registration of multiple toolchains for various scala versions. 
Extends both `scala_library` and `scala_binary` with `scala_version` parameter which allows to pick proper toolchain
Detailed explanation [here](https://github.com/bazelbuild/rules_scala/issues/1290#issuecomment-1924182988)

I am already researching the next steps:
- support scalafmt for multiple scala versions
- fix glitches with BSP
- extend scala_test rule too

Gonna add some documentation when the API is approved

### Motivation
https://github.com/bazelbuild/rules_scala/issues/1290