### PR TITLE
Add VirtusLab as adopter

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ Here's a (non-exhaustive) list of companies that use `rules_scala` in production
 * [Stripe](https://stripe.com/)
 * [Tally](https://www.meettally.com/)
 * [Twitter](https://twitter.com/)
+* [VirtusLab](https://virtuslab.com/)
 * [VSCO](https://vsco.co)
 * [Wix](https://www.wix.com/)
 


### PR DESCRIPTION
### Description

Add VirtusLab as a user of Bazel Scala rules

### Motivation

We are using Bazel Scala rules for our nad our client's projects. As the maintainer of Scala 3, we have started to work on improving support for Scala (especially Scala 3) in Bazel.
