### PR TITLE
Make scala_proto_aspect have "provides = [ScalaProtoAspectInfo]"

### DIFF
--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -208,6 +208,7 @@ def make_scala_proto_aspect(*extras):
         implementation = _scala_proto_aspect_impl,
         attr_aspects = ["deps"],
         incompatible_use_toolchain_transition = True,
+        provides = [ScalaProtoAspectInfo],
         attrs = dicts.add(
             attrs,
             extras_phases(extras),


### PR DESCRIPTION
### Description
Add `provides = [ScalaProtoAspectInfo]` to `scala_proto_aspect`.

### Motivation
`scala_proto_aspect` always returns a `ScalaProtoAspectInfo` provider, so there's no reason why the provider is not listed in the `aspect(provides=[…])` list. Crucially, having `provides = [ScalaProtoAspectInfo]` enables [aspect-on-aspect](https://bazel.build/reference/glossary#aspect-on-aspect), allowing a second aspect to inspect the result of `scala_proto_aspect`.