### PR TITLE
Add support for add_exports/add_opens

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,6 +15,17 @@ load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
 bazel_skylib_workspace()
 
+http_archive(
+    name = "bazel_features",
+    sha256 = "70d355d5e34c3fe453f5556d6c0f02ffed0eb2c7ce4c8ee016d94d654bc6a014",
+    strip_prefix = "bazel_features-1.8.0",
+    url = "https://github.com/bazel-contrib/bazel_features/releases/download/v1.8.0/bazel_features-v1.8.0.tar.gz",
+)
+
+load("@bazel_features//:deps.bzl", "bazel_features_deps")
+
+bazel_features_deps()
+
 _build_tools_release = "5.1.0"
 
 http_archive(

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -1,5 +1,7 @@
 """Shared attributes for rules"""
 
+load("@bazel_features_version//:version.bzl", _bazel_version = "version")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load(
     "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
@@ -48,7 +50,10 @@ common_attrs_for_plugin_bootstrapping = {
         default = False,
         mandatory = False,
     ),
-}
+} | ({
+    "add_exports": attr.string_list(),
+    "add_opens": attr.string_list(),
+} if versions.is_at_least("7.0.0", _bazel_version) else {})
 
 common_attrs = {}
 

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -3,6 +3,8 @@
 #
 # DOCUMENT THIS
 #
+load("@bazel_features_version//:version.bzl", _bazel_version = "version")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load(
     "@io_bazel_rules_scala//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
@@ -299,7 +301,7 @@ def _create_scala_compilation_provider(ctx, ijar, source_jar, deps_providers):
     runtime_deps = []
     if hasattr(ctx.attr, "runtime_deps"):
         runtime_deps = [dep[JavaInfo] for dep in ctx.attr.runtime_deps]
-    return JavaInfo(
+    kwargs = dict(
         output_jar = ctx.outputs.jar,
         compile_jar = ijar,
         source_jar = source_jar,
@@ -308,6 +310,12 @@ def _create_scala_compilation_provider(ctx, ijar, source_jar, deps_providers):
         runtime_deps = runtime_deps,
         neverlink = ctx.attr.neverlink,
     )
+    # The JavaInfo constructor's add_exports and add_opens flags were added in Bazel 7:
+    # https://github.com/bazelbuild/bazel/issues/20033
+    if versions.is_at_least("7.0.0", _bazel_version):
+        kwargs["add_exports"] = getattr(ctx.attr, "add_exports", [])
+        kwargs["add_opens"] = getattr(ctx.attr, "add_opens", [])
+    return JavaInfo(**kwargs)
 
 def _pack_source_jar(ctx, scala_srcs, input_srcjars):
     # https://github.com/bazelbuild/bazel/blob/ff6c0333e4f957bb9f7ab5401b01dbf3e9b515b1/src/main/java/com/google/devtools/build/lib/rules/java/JavaInfoBuildHelper.java#L180-L183

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -69,6 +69,15 @@ def _phase_write_executable(
     executable = p.declare_executable.executable
     wrapper = p.java_wrapper
 
+    # Add --add-exports / --add-opens flags
+    merged_java_info = p.compile.merged_provider
+    add_exports = merged_java_info.module_flags_info.add_exports
+    add_opens = merged_java_info.module_flags_info.add_opens
+    if add_exports or add_opens:
+        jvm_flags = list(jvm_flags)
+        jvm_flags += ["--add-exports=%s=ALL-UNNAMED" % x for x in add_exports.to_list()]
+        jvm_flags += ["--add-opens=%s=ALL-UNNAMED" % x for x in add_opens.to_list()]
+
     if (is_windows(ctx)):
         return _write_executable_windows(ctx, executable, rjars, main_class, jvm_flags, wrapper, use_jacoco)
     else:

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -1,3 +1,5 @@
+load("@bazel_features_version//:version.bzl", _bazel_version = "version")
+load("@bazel_skylib//lib:versions.bzl", "versions")
 load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 load("//scala/settings:stamp_settings.bzl", "StampScalaImport")
 load(
@@ -68,7 +70,7 @@ def _scala_import_impl(ctx):
     ]
 
 def _new_java_info(ctx, jar, stamped_jar):
-    return JavaInfo(
+    kwargs = dict(
         output_jar = jar,
         compile_jar = stamped_jar,
         exports = [target[JavaInfo] for target in ctx.attr.exports],
@@ -77,6 +79,12 @@ def _new_java_info(ctx, jar, stamped_jar):
         source_jar = ctx.file.srcjar,
         neverlink = ctx.attr.neverlink,
     )
+    # The JavaInfo constructor's add_exports and add_opens flags were added in Bazel 7:
+    # https://github.com/bazelbuild/bazel/issues/20033
+    if versions.is_at_least("7.0.0", _bazel_version):
+        kwargs["add_exports"] = ctx.attr.add_exports
+        kwargs["add_opens"] = ctx.attr.add_opens
+    return JavaInfo(**kwargs)
 
 def _add_labels_of_current_code_jars(code_jars, label, jars2labels):
     for jar in code_jars.to_list():
@@ -148,6 +156,9 @@ scala_import = rule(
         "java_compile_toolchain": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
         ),
-    },
+    } | ({
+        "add_exports": attr.string_list(),
+        "add_opens": attr.string_list(),
+    } if versions.is_at_least("7.0.0", _bazel_version) else {}),
     toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
 )


### PR DESCRIPTION
I'm happy to write some tests for this, but existing tests appear to be broken in CI, and much of the functionality requires Bazel 7.0.0 to work anyway (while CI is still on Bazel 6.3).

----

### Description
* In `scala_binary`, `scala_test`, and friends, read `java_info.module_flags_info` and include those `--add-exports` and `--add-opens` JVM flags in the launcher script.
* On Bazel 7.0.0+, add `add_exports` and `add_opens` attributes to all rules (including `scala_import`) and propagate the flags through `JavaInfo`.
    * Bazel's `JavaInfo` constructor only added this functionality in 7.0.0; see https://github.com/bazelbuild/bazel/issues/20033.

### Motivation
JDK 17 [strongly encapsulates JDK internals](https://openjdk.org/jeps/403), so many libraries need `--add-exports=` and `--add-opens=` JVM flags to run. Bazel's Java rules already support adding those flags through `java_library(add_opens = [...], add_exports = [...])`, and these fields are read in Bazel's `java_binary` rule. This PR adds the same functionality to Scala rules.

Fixes #1523