### PR TITLE
Handle the removal of to_proto and to_json from struct

### DIFF
--- a/scala/private/phases/phase_default_info.bzl
+++ b/scala/private/phases/phase_default_info.bzl
@@ -17,8 +17,10 @@ def phase_default_info(ctx, p):
         runfiles.append(java_runtime.files)
 
     phase_names = dir(p)
-    phase_names.remove("to_json")
-    phase_names.remove("to_proto")
+    if "to_json" in phase_names:
+        phase_names.remove("to_json")
+    if "to_proto" in phase_names:
+        phase_names.remove("to_proto")
     for phase_name in phase_names:
         phase = getattr(p, phase_name)
 


### PR DESCRIPTION
Check that the names exist before trying to remove them from the list of fields on a struct.

These methods do not exist if --incompatible_struct_has_no_methods is passed or if they
have been removed in a future version of Bazel.
