### PR TITLE
Build with JDK 21

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -90,24 +90,14 @@ tasks:
     platform: ubuntu2004
     run_targets:
     -  "//tools:lint_check"
-  jdk_21:
-    name: "bazel test //test/... with jdk21"
+  test_rules_scala_jdk21:
+    name: "./test_rules_scala with jdk21"
     platform: ubuntu2004
     shell_commands:
       - mv tools/bazel.rc.buildkite tools/bazel.rc
       - echo "import %workspace%/tools/bazel.rc" > .bazelrc
-    build_flags:
-      - "--java_language_version=21"
-      - "--java_runtime_version=21"
-      - "--tool_java_language_version=21"
-      - "--tool_java_runtime_version=21"
-    build_targets:
-      - "//test/..."
-    test_flags:
-      - "--java_language_version=21"
-      - "--java_runtime_version=21"
-      - "--tool_java_language_version=21"
-      - "--tool_java_runtime_version=21"
-    test_targets:
-      - "//test/..."
-
+      - echo "build --java_language_version=21" >> .bazelrc
+      - echo "build --java_runtime_version=21" >> .bazelrc
+      - echo "build --tool_java_language_version=21" >> .bazelrc
+      - echo "build --tool_java_runtime_version=21" >> .bazelrc
+      - "./test_rules_scala.sh"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -94,6 +94,7 @@ tasks:
     name: "./test_rules_scala with jdk21"
     platform: ubuntu2004
     shell_commands:
+      - sudo apt update && sudo apt install -y libxml2-utils
       - mv tools/bazel.rc.buildkite tools/bazel.rc
       - echo "import %workspace%/tools/bazel.rc" > .bazelrc
       - echo "build --java_language_version=21" >> .bazelrc

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -90,3 +90,24 @@ tasks:
     platform: ubuntu2004
     run_targets:
     -  "//tools:lint_check"
+  jdk_21:
+    name: "bazel test //test/... with jdk21"
+    platform: ubuntu2004
+    shell_commands:
+      - mv tools/bazel.rc.buildkite tools/bazel.rc
+      - echo "import %workspace%/tools/bazel.rc" > .bazelrc
+    build_flags:
+      - "--java_language_version=21"
+      - "--java_runtime_version=21"
+      - "--tool_java_language_version=21"
+      - "--tool_java_runtime_version=21"
+    build_targets:
+      - "//test/..."
+    test_flags:
+      - "--java_language_version=21"
+      - "--java_runtime_version=21"
+      - "--tool_java_language_version=21"
+      - "--tool_java_runtime_version=21"
+    test_targets:
+      - "//test/..."
+

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -203,3 +203,9 @@ repositories(
     ],
     maven_servers = MAVEN_SERVER_URLS,
 )
+
+load("//test/toolchains:jdk.bzl", "remote_jdk21_repositories", "remote_jdk21_toolchains")
+
+remote_jdk21_repositories()
+
+remote_jdk21_toolchains()

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -84,6 +84,9 @@ implicit_deps = {
     "_java_runtime": attr.label(
         default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
     ),
+    "_java_host_runtime": attr.label(
+        default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+    ),
     "_scalac": attr.label(
         executable = True,
         cfg = "exec",

--- a/scala/private/phases/phase_coverage.bzl
+++ b/scala/private/phases/phase_coverage.bzl
@@ -8,6 +8,10 @@ load(
     "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
+load(
+    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    _allow_security_manager = "allow_security_manager",
+)
 
 def phase_coverage_library(ctx, p):
     args = struct(
@@ -60,7 +64,7 @@ def _phase_coverage(ctx, p, srcjars):
             outputs = [output_jar],
             executable = ctx.attr._code_coverage_instrumentation_worker.files_to_run,
             execution_requirements = {"supports-workers": "1"},
-            arguments = [args],
+            arguments = ["--jvm_flag=%s" % f for f in _allow_security_manager(ctx)] + [args],
         )
 
         replacements = {input_jar: output_jar}

--- a/scala/scalafmt/phase_scalafmt_ext.bzl
+++ b/scala/scalafmt/phase_scalafmt_ext.bzl
@@ -23,6 +23,9 @@ ext_scalafmt = {
             default = "//scala/scalafmt",
             executable = True,
         ),
+        "_java_host_runtime": attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+        ),
         "_runner": attr.label(
             allow_single_file = True,
             default = "//scala/scalafmt:runner",

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -5,6 +5,7 @@ load(
     "//scala/private:rule_impls.bzl",
     "compile_scala",
     "specified_java_compile_toolchain",
+    _allow_security_manager = "allow_security_manager",
 )
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(
@@ -73,7 +74,7 @@ def _generate_sources(ctx, toolchain, proto):
 
     ctx.actions.run(
         executable = toolchain.worker,
-        arguments = [toolchain.worker_flags, args],
+        arguments = ["--jvm_flag=%s" % f for f in _allow_security_manager(ctx)] + [toolchain.worker_flags, args],
         inputs = depset(transitive = [descriptors, toolchain.generators_jars]),
         outputs = outputs.values(),
         tools = [toolchain.protoc],
@@ -202,6 +203,9 @@ def make_scala_proto_aspect(*extras):
     attrs = {
         "_java_toolchain": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+        ),
+        "_java_host_runtime": attr.label(
+            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
         ),
     }
     return aspect(

--- a/test/BUILD
+++ b/test/BUILD
@@ -776,22 +776,22 @@ scala_junit_test(
     runtime_deps = [":JunitMixedSeparateTarget"],
 )
 
-scala_library(
-    name = "JunitRuntimePlatform",
-    srcs = [
-        "src/main/scala/scalarules/test/junit/runtime_platform/JunitRuntimePlatformTest.java",
-    ],
-    deps = ["@io_bazel_rules_scala_junit_junit"],
-)
-
-scala_junit_test(
-    name = "JunitRuntimePlatform_test_runner",
-    size = "small",
-    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
-    suffixes = ["Test"],
-    tests_from = [":JunitRuntimePlatform"],
-    runtime_deps = [":JunitRuntimePlatform"],
-)
+#scala_library(
+#    name = "JunitRuntimePlatform",
+#    srcs = [
+#        "src/main/scala/scalarules/test/junit/runtime_platform/JunitRuntimePlatformTest.java",
+#    ],
+#    deps = ["@io_bazel_rules_scala_junit_junit"],
+#)
+#
+#scala_junit_test(
+#    name = "JunitRuntimePlatform_test_runner",
+#    size = "small",
+#    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+#    suffixes = ["Test"],
+#    tests_from = [":JunitRuntimePlatform"],
+#    runtime_deps = [":JunitRuntimePlatform"],
+#)
 
 scala_junit_test(
     name = "JunitNoTestEnvironmentTest",

--- a/test/BUILD
+++ b/test/BUILD
@@ -776,22 +776,24 @@ scala_junit_test(
     runtime_deps = [":JunitMixedSeparateTarget"],
 )
 
-#scala_library(
-#    name = "JunitRuntimePlatform",
-#    srcs = [
-#        "src/main/scala/scalarules/test/junit/runtime_platform/JunitRuntimePlatformTest.java",
-#    ],
-#    deps = ["@io_bazel_rules_scala_junit_junit"],
-#)
-#
-#scala_junit_test(
-#    name = "JunitRuntimePlatform_test_runner",
-#    size = "small",
-#    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
-#    suffixes = ["Test"],
-#    tests_from = [":JunitRuntimePlatform"],
-#    runtime_deps = [":JunitRuntimePlatform"],
-#)
+scala_library(
+    name = "JunitRuntimePlatform",
+    srcs = [
+        "src/main/scala/scalarules/test/junit/runtime_platform/JunitRuntimePlatformTest.java",
+    ],
+    # make sure java compilation toolchain matches runtime toolchain ie --target
+    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java11",
+    deps = ["@io_bazel_rules_scala_junit_junit"],
+)
+
+scala_junit_test(
+    name = "JunitRuntimePlatform_test_runner",
+    size = "small",
+    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    suffixes = ["Test"],
+    tests_from = [":JunitRuntimePlatform"],
+    runtime_deps = [":JunitRuntimePlatform"],
+)
 
 scala_junit_test(
     name = "JunitNoTestEnvironmentTest",

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -130,3 +130,26 @@ toolchain(
     toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
+
+load(
+    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
+    "BASE_JDK9_JVM_OPTS",
+    "DEFAULT_JAVACOPTS",
+    "DEFAULT_TOOLCHAIN_CONFIGURATION",
+    "default_java_toolchain",
+)
+
+default_java_toolchain(
+    name = "java21_toolchain",
+    configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
+    java_runtime = select({
+        "@platforms//os:linux": "@remotejdk21_linux//:jdk",
+        "@platforms//os:macos": "@remotejdk21_macos//:jdk",
+        "@platforms//os:windows": "@remotejdk21_win//:jdk",
+    }),
+    javacopts = DEFAULT_JAVACOPTS,
+    jvm_opts = BASE_JDK9_JVM_OPTS,
+    source_version = "21",
+    target_version = "21",
+    visibility = ["//visibility:public"],
+)

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -1,4 +1,26 @@
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load(
+    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
+    "BASE_JDK9_JVM_OPTS",
+    "DEFAULT_JAVACOPTS",
+    "DEFAULT_TOOLCHAIN_CONFIGURATION",
+    "default_java_toolchain",
+)
+
+default_java_toolchain(
+    name = "java21_toolchain",
+    configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
+    java_runtime = select({
+        "@platforms//os:linux": "@remotejdk21_linux//:jdk",
+        "@platforms//os:macos": "@remotejdk21_macos//:jdk",
+        "@platforms//os:windows": "@remotejdk21_win//:jdk",
+    }),
+    javacopts = DEFAULT_JAVACOPTS,
+    jvm_opts = BASE_JDK9_JVM_OPTS,
+    source_version = "21",
+    target_version = "21",
+    visibility = ["//visibility:public"],
+)
 
 scala_toolchain(
     name = "ast_plus_one_deps_unused_deps_warn_impl",
@@ -128,28 +150,5 @@ toolchain(
     name = "use_argument_file_in_runner",
     toolchain = "use_argument_file_in_runner_impl",
     toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
-load(
-    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
-    "BASE_JDK9_JVM_OPTS",
-    "DEFAULT_JAVACOPTS",
-    "DEFAULT_TOOLCHAIN_CONFIGURATION",
-    "default_java_toolchain",
-)
-
-default_java_toolchain(
-    name = "java21_toolchain",
-    configuration = DEFAULT_TOOLCHAIN_CONFIGURATION,
-    java_runtime = select({
-        "@platforms//os:linux": "@remotejdk21_linux//:jdk",
-        "@platforms//os:macos": "@remotejdk21_macos//:jdk",
-        "@platforms//os:windows": "@remotejdk21_win//:jdk",
-    }),
-    javacopts = DEFAULT_JAVACOPTS,
-    jvm_opts = BASE_JDK9_JVM_OPTS,
-    source_version = "21",
-    target_version = "21",
     visibility = ["//visibility:public"],
 )

--- a/test/toolchains/jdk.bzl
+++ b/test/toolchains/jdk.bzl
@@ -1,0 +1,54 @@
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+
+def remote_jdk21_repositories():
+    maybe(
+        remote_java_repository,
+        name = "remotejdk21_linux",
+        target_compatible_with = [
+            "@platforms//os:linux",
+            "@platforms//cpu:x86_64",
+        ],
+        sha256 = "5ad730fbee6bb49bfff10bf39e84392e728d89103d3474a7e5def0fd134b300a",
+        strip_prefix = "zulu21.32.17-ca-jdk21.0.2-linux_x64",
+        urls = [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-linux_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-linux_x64.tar.gz",
+        ],
+        version = "21",
+    )
+
+    maybe(
+        remote_java_repository,
+        name = "remotejdk21_macos",
+        target_compatible_with = [
+            "@platforms//os:macos",
+            "@platforms//cpu:x86_64",
+        ],
+        sha256 = "3ad8fe288eb57d975c2786ae453a036aa46e47ab2ac3d81538ebae2a54d3c025",
+        strip_prefix = "zulu21.32.17-ca-jdk21.0.2-macosx_x64",
+        urls = [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-macosx_x64.tar.gz",
+            "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-macosx_x64.tar.gz",
+        ],
+        version = "21",
+    )
+
+    maybe(
+        remote_java_repository,
+        name = "remotejdk21_win",
+        target_compatible_with = [
+            "@platforms//os:windows",
+            "@platforms//cpu:x86_64",
+        ],
+        sha256 = "f7cc15ca17295e69c907402dfe8db240db446e75d3b150da7bf67243cded93de",
+        strip_prefix = "zulu21.32.17-ca-jdk21.0.2-win_x64",
+        urls = [
+            "https://mirror.bazel.build/cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-win_x64.zip",
+            "https://cdn.azul.com/zulu/bin/zulu21.32.17-ca-jdk21.0.2-win_x64.zip",
+        ],
+        version = "21",
+    )
+
+def remote_jdk21_toolchains():
+    native.register_toolchains("//test/toolchains:java21_toolchain_definition")

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -13,6 +13,7 @@ load(
 )
 load(
     "//scala/private:rule_impls.bzl",
+    "allow_security_manager",
     "compile_java",
     "compile_scala",
 )
@@ -205,7 +206,7 @@ def _generate_jvm_code(ctx, label, compile_thrifts, include_thrifts, jar_output,
         # be correctly handled since the executable is a jvm app that will
         # consume the flags on startup.
         #arguments = ["--jvm_flag=%s" % flag for flag in ctx.attr.jvm_flags] +
-        arguments = ["@" + argfile.path],
+        arguments = ["--jvm_flag=%s" % f for f in allow_security_manager(ctx)] + ["@" + argfile.path],
     )
 
 def _compiled_jar_file(actions, scrooge_jar):
@@ -434,6 +435,7 @@ common_attrs = {
             ),
         ],
     ),
+    "_java_host_runtime": attr.label(default = Label("@bazel_tools//tools/jdk:current_host_java_runtime")),
 }
 
 common_aspect_providers = [


### PR DESCRIPTION
Codebase doesn't build with jdk 21 with default settings.

Issue is that workers and test runners use SecurityManager which fails at runtime.

Fix is to conditionally add -Djava.security.manager=allow jvm flag to:
- tools executed via ctx.actions.run if host jdk is >= 17
- generated test executables if target jdk is >= 17

This change involves some kind of guessing with which jdk version worker will be run. 

JDK is linked into worker/executable runfiles and it matches host jdk (hence added _java_host_runtime attribute to all relevant rules)

Added separate [build](https://github.com/bazelbuild/rules_scala/pull/1556/files#diff-b03048100ab56455b5b377a5c20ffd3d17f80c719befca45253af622eb9395efR93) for jdk 21 