### PR TITLE
Introduce `SCALA_VERSIONS`

### DIFF
--- a/cross-compilation-doc.md
+++ b/cross-compilation-doc.md
@@ -1,0 +1,10 @@
+# Cross compilation support
+
+The support for cross-compilation is currently under development.
+
+## Version configuration
+
+`scala_config` creates the repository `@io_bazel_rules_scala_config`.
+File created there, `config.bzl`, consists of many variables. In particular:
+* `SCALA_VERSION` – representing the default Scala version, e.g. `"3.3.1"`;
+* `SCALA_VERSIONS` – representing all configured Scala versions (currently one), e.g. `["3.3.1"]`.

--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -11,10 +11,14 @@ def _validate_supported_scala_version(scala_major_version, scala_minor_version):
         fail("Scala version must be newer or equal to 2.12.1 to use compiler dependency tracking.")
 
 def _store_config(repository_ctx):
+    # Default version
     scala_version = repository_ctx.os.environ.get(
         "SCALA_VERSION",
         repository_ctx.attr.scala_version,
     )
+
+    # All versions supported
+    scala_versions = [scala_version]
 
     enable_compiler_dependency_tracking = repository_ctx.os.environ.get(
         "ENABLE_COMPILER_DEPENDENCY_TRACKING",
@@ -29,6 +33,7 @@ def _store_config(repository_ctx):
 
     config_file_content = "\n".join([
         "SCALA_VERSION='" + scala_version + "'",
+        "SCALA_VERSIONS=" + str(scala_versions),
         "SCALA_MAJOR_VERSION='" + scala_major_version + "'",
         "SCALA_MINOR_VERSION='" + scala_minor_version + "'",
         "ENABLE_COMPILER_DEPENDENCY_TRACKING=" + enable_compiler_dependency_tracking,


### PR DESCRIPTION
### Description
A variable to hold all (possibly more than one in the future) configured versions of Scala.

### Motivation
Originally #1290.
#1552 may be still too big to review. Let's start with some manageable, smaller chunks.

Plan for following PRs: https://github.com/bazelbuild/rules_scala/compare/master...aszady:rules_scala:cross-compilation?expand=1
