### PR TITLE
Introduce build setting for current Scala version

### DIFF
--- a/cross-compilation-doc.md
+++ b/cross-compilation-doc.md
@@ -8,3 +8,30 @@ The support for cross-compilation is currently under development.
 File created there, `config.bzl`, consists of many variables. In particular:
 * `SCALA_VERSION` – representing the default Scala version, e.g. `"3.3.1"`;
 * `SCALA_VERSIONS` – representing all configured Scala versions (currently one), e.g. `["3.3.1"]`.
+
+
+## Build settings
+Configured `SCALA_VERSIONS` correspond to allowed values of [build setting](https://bazel.build/extending/config#user-defined-build-setting).
+
+### `scala_version`
+`@io_bazel_rules_scala_config` in its root package defines the following build setting:
+```starlark
+string_setting(
+    name = "scala_version",
+    build_setting_default = "3.3.1",
+    values = ["3.3.1"],
+    visibility = ["//visibility:public"],
+)
+```
+This build setting can be subject of change by [transitions](https://bazel.build/extending/config#user-defined-transitions) (within allowed `values`).
+
+### Config settings
+Then for each Scala version we have a [config setting](https://bazel.build/extending/config#build-settings-and-select):
+```starlark
+config_setting(
+    name = "scala_version_3_3_1",
+    flag_values = {":scala_version": "3.3.1"},
+)
+```
+The `name` of `config_setting` corresponds to `"scala_version" + version_suffix(scala_version)`.
+One may use this config setting in `select()` e.g. to provide dependencies relevant to a currently used Scala version.

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -44,3 +44,7 @@ def scala_mvn_artifact(
     artifactid = gav[1]
     version = gav[2]
     return "%s:%s_%s:%s" % (groupid, artifactid, major_scala_version, version)
+
+def sanitize_version(scala_version):
+    """ Makes Scala version usable in target names. """
+    return scala_version.replace(".", "_")

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -48,3 +48,6 @@ def scala_mvn_artifact(
 def sanitize_version(scala_version):
     """ Makes Scala version usable in target names. """
     return scala_version.replace(".", "_")
+
+def version_suffix(scala_version):
+    return "_" + sanitize_version(scala_version)


### PR DESCRIPTION
### Description
Build setting & config setting to transition and query about the Scala version.

A small change compared to #1552 is that I don't allow an empty string value for the build setting.

This shouldn't change any behavior.

### Motivation
Originally #1290.
Partitioned from #1552.
