### PR TITLE
Don't rely on `SCALA_VERSION` in phases

### DIFF
--- a/cross-compilation-doc.md
+++ b/cross-compilation-doc.md
@@ -35,3 +35,15 @@ config_setting(
 ```
 The `name` of `config_setting` corresponds to `"scala_version" + version_suffix(scala_version)`.
 One may use this config setting in `select()` e.g. to provide dependencies relevant to a currently used Scala version.
+
+
+## Version-dependent behavior
+Don't rely on `SCALA_VERSION` as it represents the default Scala version, not necessarily the one that is currently requested.
+
+If you need to customize the behavior for specific Scala version, there are two scenarios.
+
+### From toolchain
+TODO
+
+### From config setting
+TODO

--- a/cross-compilation-doc.md
+++ b/cross-compilation-doc.md
@@ -43,7 +43,13 @@ Don't rely on `SCALA_VERSION` as it represents the default Scala version, not ne
 If you need to customize the behavior for specific Scala version, there are two scenarios.
 
 ### From toolchain
-TODO
+If you have an access to the Scala toolchain (`@io_bazel_rules_scala//scala:toolchain_type`), there is `scala_version` field provided in there:
+```starlark
+def _rule_impl(ctx):
+    ...
+    ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scala_version
+    ...
+```
 
 ### From config setting
 TODO

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -17,9 +17,6 @@ load(
     _compile_scala = "compile_scala",
 )
 load(":resources.bzl", _resource_paths = "paths")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
-
-buildijar_default_value = True if SCALA_VERSION.startswith("2.") else False
 
 def phase_compile_binary(ctx, p):
     args = struct(
@@ -105,6 +102,8 @@ def phase_compile_common(ctx, p):
     return _phase_compile_default(ctx, p)
 
 def _phase_compile_default(ctx, p, _args = struct()):
+    buildijar_default_value = True if ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scala_version.startswith("2.") else False
+
     return _phase_compile(
         ctx,
         p,

--- a/scala/private/phases/phase_semanticdb.bzl
+++ b/scala/private/phases/phase_semanticdb.bzl
@@ -3,7 +3,6 @@ load(
     "find_deps_info_on",
 )
 load("@io_bazel_rules_scala//scala:semanticdb_provider.bzl", "SemanticdbInfo")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def phase_semanticdb(ctx, p):
@@ -37,7 +36,7 @@ def phase_semanticdb(ctx, p):
                     outputfilename = "%s/%s/%s.semanticdb" % (semanticdb_intpath, semanticdb_outpath, currSrc.path)
                     output_files.append(ctx.actions.declare_file(outputfilename))
 
-        if SCALA_MAJOR_VERSION.startswith("2"):
+        if toolchain.scala_version.startswith("2"):
             semanticdb_deps = find_deps_info_on(ctx, toolchain_type_label, "semanticdb").deps
 
             if len(semanticdb_deps) == 0:

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -7,6 +7,7 @@ load(
     "ENABLE_COMPILER_DEPENDENCY_TRACKING",
     "SCALA_MAJOR_VERSION",
 )
+load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
 
 def _compute_strict_deps_mode(input_strict_deps_mode, dependency_mode):
     if dependency_mode == "direct":
@@ -101,6 +102,7 @@ def _scala_toolchain_impl(ctx):
         enable_semanticdb = ctx.attr.enable_semanticdb,
         semanticdb_bundle_in_jar = ctx.attr.semanticdb_bundle_in_jar,
         use_argument_file_in_runner = ctx.attr.use_argument_file_in_runner,
+        scala_version = ctx.attr._scala_version[BuildSettingInfo].value,
     )
     return [toolchain]
 
@@ -173,6 +175,7 @@ scala_toolchain = rule(
             default = False,
             doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
         ),
+        "_scala_version": attr.label(default = "@io_bazel_rules_scala_config//:scala_version"),
     },
     fragments = ["java"],
 )


### PR DESCRIPTION
### Description
Before enabling cross-build we need to review (and most likely replace) all uses of `SCALA_VERSION`. This PR reviews usage of `SCALA_VERSION` when a resolved toolchain is available.

This shouldn't change any behavior.

### Motivation
Originally #1290.
Partitioned from #1552.