### PR TITLE
Use version-aware naming for `scala_compiler_source` repository

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
@@ -1,8 +1,10 @@
 load("//scala:scala.bzl", "scala_library_for_plugin_bootstrapping")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 scala_library_for_plugin_bootstrapping(
     name = "dep_reporting_compiler",
-    srcs = ["@scala_compiler_source//:src"],
+    srcs = ["@scala_compiler_source%s//:src" % version_suffix(SCALA_VERSION)],
     scalac_jvm_flags = ["-Xmx128M"],  # fixme - workaround for a failing test
     visibility = ["//visibility:public"],
     deps = ["//scala/private/toolchain_deps:scala_compile_classpath"],


### PR DESCRIPTION
### Description
A small preparation for multiple `SCALA_VERSIONS`.

In theory breaking, as removes `@scala_compiler_source` repository.
But I guess it's too internal to anyone depend on it.

### Motivation
Originally #1290.
Partitioned from #1552.
