### PR TITLE
Move default toolchain dependencies logic to .bzl file

### DIFF
--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,65 +1,31 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
 load("//scala:providers.bzl", "declare_deps_provider")
-load("//scala:scala.bzl", "setup_scala_toolchain")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
+load("//scala/private:macros/setup_scala_toolchain.bzl", "default_deps", "setup_scala_toolchain_with_default_classpaths")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
 )
 
-_SCALA_COMPILE_CLASSPATH_DEPS = [
-    "@io_bazel_rules_scala_scala_compiler",
-    "@io_bazel_rules_scala_scala_library",
-] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "@io_bazel_rules_scala_scala_interfaces",
-    "@io_bazel_rules_scala_scala_tasty_core",
-    "@io_bazel_rules_scala_scala_asm",
-    "@io_bazel_rules_scala_scala_library_2",
-])
-
-_SCALA_LIBRARY_CLASSPATH_DEPS = [
-    "@io_bazel_rules_scala_scala_library",
-] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "@io_bazel_rules_scala_scala_library_2",
-])
-
-_SCALA_MACRO_CLASSPATH_DEPS = [
-    "@io_bazel_rules_scala_scala_library",
-] + (["@io_bazel_rules_scala_scala_reflect"] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "@io_bazel_rules_scala_scala_library_2",
-])
-
-_PARSER_COMBINATORS_DEPS = ["@io_bazel_rules_scala_scala_parser_combinators"]
-
-_SCALA_XML_DEPS = ["@io_bazel_rules_scala_scala_xml"]
-
-_SEMANTICDB_DEPS = ["@org_scalameta_semanticdb_scalac"] if SCALA_MAJOR_VERSION.startswith("2") else []
-
-setup_scala_toolchain(
+setup_scala_toolchain_with_default_classpaths(
     name = "default_toolchain",
-    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
-    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
-    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
+    scala_version = SCALA_VERSION,
     use_argument_file_in_runner = True,
 )
 
-setup_scala_toolchain(
+setup_scala_toolchain_with_default_classpaths(
     name = "unused_dependency_checker_error_toolchain",
     dependency_tracking_method = "ast-plus",
-    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
-    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
-    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
+    scala_version = SCALA_VERSION,
     unused_dependency_checker_mode = "error",
 )
 
-setup_scala_toolchain(
+setup_scala_toolchain_with_default_classpaths(
     name = "minimal_direct_source_deps",
     dependency_mode = "plus-one",
     dependency_tracking_method = "ast",
-    scala_compile_classpath = _SCALA_COMPILE_CLASSPATH_DEPS,
-    scala_library_classpath = _SCALA_LIBRARY_CLASSPATH_DEPS,
-    scala_macro_classpath = _SCALA_MACRO_CLASSPATH_DEPS,
+    scala_version = SCALA_VERSION,
     strict_deps_mode = "error",
     unused_dependency_checker_mode = "error",
 )
@@ -80,40 +46,40 @@ declare_deps_provider(
     name = "scala_compile_classpath_provider",
     deps_id = "scala_compile_classpath",
     visibility = ["//visibility:public"],
-    deps = _SCALA_COMPILE_CLASSPATH_DEPS,
+    deps = default_deps("scala_compile_classpath", SCALA_VERSION),
 )
 
 declare_deps_provider(
     name = "scala_library_classpath_provider",
     deps_id = "scala_library_classpath",
     visibility = ["//visibility:public"],
-    deps = _SCALA_LIBRARY_CLASSPATH_DEPS,
+    deps = default_deps("scala_library_classpath", SCALA_VERSION),
 )
 
 declare_deps_provider(
     name = "scala_macro_classpath_provider",
     deps_id = "scala_macro_classpath",
     visibility = ["//visibility:public"],
-    deps = _SCALA_MACRO_CLASSPATH_DEPS,
+    deps = default_deps("scala_macro_classpath", SCALA_VERSION),
 )
 
 declare_deps_provider(
     name = "scala_xml_provider",
     deps_id = "scala_xml",
     visibility = ["//visibility:public"],
-    deps = _SCALA_XML_DEPS,
+    deps = default_deps("scala_xml", SCALA_VERSION),
 )
 
 declare_deps_provider(
     name = "parser_combinators_provider",
     deps_id = "parser_combinators",
     visibility = ["//visibility:public"],
-    deps = _PARSER_COMBINATORS_DEPS,
+    deps = default_deps("parser_combinators", SCALA_VERSION),
 )
 
 declare_deps_provider(
     name = "semanticdb_provider",
     deps_id = "semanticdb",
     visibility = ["//visibility:public"],
-    deps = _SEMANTICDB_DEPS,
+    deps = default_deps("semanticdb", SCALA_VERSION),
 )

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,6 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
 load("//scala:providers.bzl", "declare_deps_provider")
-load("//scala/private:macros/setup_scala_toolchain.bzl", "default_deps", "setup_scala_toolchain_with_default_classpaths")
+load("//scala/private:macros/setup_scala_toolchain.bzl", "default_deps", "setup_scala_toolchain")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 toolchain_type(
@@ -8,24 +8,21 @@ toolchain_type(
     visibility = ["//visibility:public"],
 )
 
-setup_scala_toolchain_with_default_classpaths(
+setup_scala_toolchain(
     name = "default_toolchain",
-    scala_version = SCALA_VERSION,
     use_argument_file_in_runner = True,
 )
 
-setup_scala_toolchain_with_default_classpaths(
+setup_scala_toolchain(
     name = "unused_dependency_checker_error_toolchain",
     dependency_tracking_method = "ast-plus",
-    scala_version = SCALA_VERSION,
     unused_dependency_checker_mode = "error",
 )
 
-setup_scala_toolchain_with_default_classpaths(
+setup_scala_toolchain(
     name = "minimal_direct_source_deps",
     dependency_mode = "plus-one",
     dependency_tracking_method = "ast",
-    scala_version = SCALA_VERSION,
     strict_deps_mode = "error",
     unused_dependency_checker_mode = "error",
 )

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -5,9 +5,9 @@ load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def setup_scala_toolchain(
         name,
-        scala_compile_classpath,
-        scala_library_classpath,
-        scala_macro_classpath,
+        scala_compile_classpath = None,
+        scala_library_classpath = None,
+        scala_macro_classpath = None,
         scala_version = SCALA_VERSION,
         scala_xml_deps = None,
         parser_combinators_deps = None,
@@ -22,6 +22,8 @@ def setup_scala_toolchain(
     scala_macro_classpath_provider = "%s_scala_macro_classpath_provider" % name
     semanticdb_deps_provider = "%s_semanticdb_deps_provider" % name
 
+    if scala_compile_classpath == None:
+        scala_compile_classpath = default_deps("scala_compile_classpath", scala_version)
     declare_deps_provider(
         name = scala_compile_classpath_provider,
         deps_id = "scala_compile_classpath",
@@ -29,6 +31,8 @@ def setup_scala_toolchain(
         deps = scala_compile_classpath,
     )
 
+    if scala_library_classpath == None:
+        scala_library_classpath = default_deps("scala_library_classpath", scala_version)
     declare_deps_provider(
         name = scala_library_classpath_provider,
         deps_id = "scala_library_classpath",
@@ -36,6 +40,8 @@ def setup_scala_toolchain(
         deps = scala_library_classpath,
     )
 
+    if scala_macro_classpath == None:
+        scala_macro_classpath = default_deps("scala_macro_classpath", scala_version)
     declare_deps_provider(
         name = scala_macro_classpath_provider,
         deps_id = "scala_macro_classpath",
@@ -152,16 +158,3 @@ _DEFAULT_DEPS = {
 def default_deps(deps_id, scala_version):
     versions = _DEFAULT_DEPS[deps_id]
     return versions.get("any", []) + versions.get(scala_version[0], [])
-
-def setup_scala_toolchain_with_default_classpaths(
-        name,
-        scala_version,
-        **kwargs):
-    for dep_id in (
-        "scala_compile_classpath",
-        "scala_library_classpath",
-        "scala_macro_classpath",
-    ):
-        if dep_id not in kwargs:
-            kwargs[dep_id] = default_deps(dep_id, scala_version)
-    setup_scala_toolchain(name = name, **kwargs)

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -99,3 +99,69 @@ def setup_scala_toolchain(
         target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(scala_version)],
         visibility = visibility,
     )
+
+_DEFAULT_DEPS = {
+    "scala_compile_classpath": {
+        "any": [
+            "@io_bazel_rules_scala_scala_compiler",
+            "@io_bazel_rules_scala_scala_library",
+        ],
+        "2": [
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
+        "3": [
+            "@io_bazel_rules_scala_scala_interfaces",
+            "@io_bazel_rules_scala_scala_tasty_core",
+            "@io_bazel_rules_scala_scala_asm",
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
+    "scala_library_classpath": {
+        "any": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+        "2": [
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
+        "3": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
+    "scala_macro_classpath": {
+        "any": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+        "2": [
+            "@io_bazel_rules_scala_scala_reflect",
+        ],
+        "3": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
+    "scala_xml": {
+        "any": ["@io_bazel_rules_scala_scala_xml"],
+    },
+    "parser_combinators": {
+        "any": ["@io_bazel_rules_scala_scala_parser_combinators"],
+    },
+    "semanticdb": {
+        "2": ["@org_scalameta_semanticdb_scalac"],
+    },
+}
+
+def default_deps(deps_id, scala_version):
+    versions = _DEFAULT_DEPS[deps_id]
+    return versions.get("any", []) + versions.get(scala_version[0], [])
+
+def setup_scala_toolchain_with_default_classpaths(
+        name,
+        scala_version,
+        **kwargs):
+    for dep_id in (
+        "scala_compile_classpath",
+        "scala_library_classpath",
+        "scala_macro_classpath",
+    ):
+        if dep_id not in kwargs:
+            kwargs[dep_id] = default_deps(dep_id, scala_version)
+    setup_scala_toolchain(name = name, **kwargs)


### PR DESCRIPTION
### Description

Purely refactoring change.
Encapsulates the logic of selecting dependencies into a function. Should come in handy in future changes.

### Motivation
Originally #1290.
Partitioned from / inspired by #1552.
