### PR TITLE
Make scrooge_*_aspect have "provides = [ScroogeAspectInfo]"

### DIFF
--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -455,6 +455,7 @@ scrooge_scala_aspect = aspect(
             ),
         },
     ),
+    provides = [ScroogeAspectInfo],
     required_aspect_providers = common_aspect_providers,
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",
@@ -472,6 +473,7 @@ scrooge_java_aspect = aspect(
             "_java_toolchain": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),
         },
     ),
+    provides = [ScroogeAspectInfo],
     required_aspect_providers = common_aspect_providers,
     toolchains = [
         "@io_bazel_rules_scala//scala:toolchain_type",


### PR DESCRIPTION
### Description
Add `provides = [ScroogeAspectInfo]` to `scrooge_scala_aspect` and `scrooge_java_aspect`.

### Motivation
Same as #1549 – allows for aspect-on-aspect introspection of these aspects.