### PR TITLE
Bind toolchains to Scala version

### DIFF
--- a/cross-compilation-doc.md
+++ b/cross-compilation-doc.md
@@ -53,3 +53,31 @@ def _rule_impl(ctx):
 
 ### From config setting
 TODO
+
+
+## Toolchains
+Standard [toolchain resolution](https://bazel.build/extending/toolchains#toolchain-resolution) procedure determines which toolchain to use for Scala targets.
+
+Toolchain should declare its compatibility with Scala version by using `target_settings` attribute of the `toolchain` rule:
+
+```starlark
+toolchain(
+    ...
+    target_settings = ["@io_bazel_rules_scala_config//:scala_version_3_3_1"],
+    ...
+)
+```
+
+### Cross-build support tiers
+`rules_scala` consists of many toolchains implementing various toolchain types.
+Their support level for cross-build setup varies.
+
+We can distinguish following tiers:
+
+* No `target_settings` set – not migrated, will work on the default `SCALA_VERSION`; undefined behavior on other versions.
+  * (all toolchains not mentioned elsewhere)
+* `target_settings` set to the `SCALA_VERSION` – not fully migrated; will work only on the default `SCALA_VERSION` and will fail the toolchain resolution on other versions.
+  * [the main Scala toolchain](scala/BUILD)
+  * [Scalafmt](scala/scalafmt/BUILD)
+  * [Scalatest](testing/testing.bzl)
+* Multiple toolchain instances with `target_settings` corresponding to each of `SCALA_VERSIONS` – fully migrated; will work in cross-build setup.

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -1,11 +1,14 @@
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:providers.bzl", "declare_deps_provider")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def setup_scala_toolchain(
         name,
         scala_compile_classpath,
         scala_library_classpath,
         scala_macro_classpath,
+        scala_version = SCALA_VERSION,
         scala_xml_deps = None,
         parser_combinators_deps = None,
         semanticdb_deps = None,
@@ -93,5 +96,6 @@ def setup_scala_toolchain(
         name = name,
         toolchain = ":%s_impl" % name,
         toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+        target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(scala_version)],
         visibility = visibility,
     )

--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -1,6 +1,8 @@
 load("//scala:scala.bzl", "scala_binary")
+load("//scala:scala_cross_version.bzl", "version_suffix")
 load("//scala/scalafmt/toolchain:toolchain.bzl", "export_scalafmt_deps", "scalafmt_toolchain")
 load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 load(
     "//scala/scalafmt:phase_scalafmt_ext.bzl",
     "scalafmt_singleton",
@@ -58,6 +60,7 @@ scalafmt_toolchain(
 
 toolchain(
     name = "scalafmt_toolchain",
+    target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(SCALA_VERSION)],
     toolchain = ":scalafmt_toolchain_impl",
     toolchain_type = "//scala/scalafmt/toolchain:scalafmt_toolchain_type",
     visibility = ["//visibility:public"],

--- a/testing/testing.bzl
+++ b/testing/testing.bzl
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
 load("@io_bazel_rules_scala//testing/toolchain:toolchain.bzl", "scala_testing_toolchain")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def _declare_deps_provider(macro_name, deps_id, deps, visibility):
     label = "%s_%s_provider" % (macro_name, deps_id)
@@ -13,6 +15,7 @@ def _declare_deps_provider(macro_name, deps_id, deps, visibility):
 
 def setup_scala_testing_toolchain(
         name,
+        scala_version = SCALA_VERSION,
         junit_classpath = None,
         specs2_classpath = None,
         specs2_junit_classpath = None,
@@ -70,5 +73,6 @@ def setup_scala_testing_toolchain(
         name = name,
         toolchain = ":" + name + "_impl",
         toolchain_type = "@io_bazel_rules_scala//testing/toolchain:testing_toolchain_type",
+        target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(scala_version)],
         visibility = visibility,
     )


### PR DESCRIPTION
### Description
Use `target_settings` to indicate which Scala version is supported by the toolchain. This will become useful when multiple toolchains for each Scala version are defined.

The choice of toolchains to cover by this (first) migration is quite arbitrary, but should be enough to enable the basic cross-build use cases.

No change in behavior if the default Scala version is used.

### Motivation
Originally #1290.
Partitioned from #1552.
