### PR TITLE
JacocoRunner script: update for Jacoco 0.8.11 and Bazel 7.0.2

### DIFF
--- a/scripts/build_jacocorunner/0001-Build-Jacoco-for-Bazel-7.0.patch
+++ b/scripts/build_jacocorunner/0001-Build-Jacoco-for-Bazel-7.0.patch
@@ -1,0 +1,29 @@
+From 712d62a8238f3a7fe51e1cf4cc2520b5f249e1d3 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Gergely=20F=C3=A1bi=C3=A1n?= <gergo.fb@gmail.com>
+Date: Tue, 09 Apr 2024 12:28:00 +0200
+Subject: [PATCH] Build Jacoco for Bazel
+
+---
+ org.jacoco.build/pom.xml | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/org.jacoco.build/pom.xml b/org.jacoco.build/pom.xml
+index 8aae1543..067cc6a7 100644
+--- a/org.jacoco.build/pom.xml
++++ b/org.jacoco.build/pom.xml
+@@ -691,11 +691,11 @@
+
+                 buildDate = qualifier.substring(0, 4) + "/" + qualifier.substring(4, 6) + "/" + qualifier.substring(6, 8);
+                 project.getProperties().setProperty("build.date", buildDate);
+
+                 commitId = project.getProperties().get("build.commitId");
+-                pkgName = commitId.substring(commitId.length() - 7, commitId.length());
++                pkgName = "4742761";
+                 project.getProperties().setProperty("jacoco.runtime.package.name", "org.jacoco.agent.rt.internal_" + pkgName);
+
+                 void loadLicense(String libraryId) {
+                     version = project.getProperties().get(libraryId + ".version");
+                     path = project.getBasedir().toPath().resolve("../org.jacoco.build/licenses/" + libraryId + "-" + version + ".html");
+-- 
+2.25.1
+

--- a/scripts/build_jacocorunner/build_jacocorunner.sh
+++ b/scripts/build_jacocorunner/build_jacocorunner.sh
@@ -2,23 +2,25 @@
 #
 # Script to build custom version of `JacocoCoverage_jarjar_deploy.jar` from Jacoco and Bazel repositories.
 #
+# The script has three flavours: Bazel 5, 6 and 7. Documenting the details for Bazel 7 here.
+#
 # The default `JacocoCoverage_jarjar_deploy.jar` has some issues:
 #
-# 1. Scala support on newer Jacoco versions (including 0.8.7) is still lacking some functionality
+# 1. Scala support on newer Jacoco versions (including 0.8.11) is still lacking some functionality
 #
 #    E.g. a lot of generated methods for case classes, lazy vals or other Scala features are causing falsely missed branches in branch coverage.
 #
 #    Proposed changes in:
 #    https://github.com/gergelyfabian/jacoco/tree/scala
 #
-#    Backported to 0.8.7 (to be usable with current Bazel):
-#    https://github.com/gergelyfabian/jacoco/tree/0.8.7-scala
+#    Backported to 0.8.11 (to be usable with current Bazel):
+#    https://github.com/gergelyfabian/jacoco/tree/0.8.11-scala
 #
 # 2. Bazel's code for generating `JacocoCoverage_jarjar_deploy.jar` needs changes after our Jacoco changes
 #
 #    It implements an interface that we have extended, so that implementation also needs to be extended.
 #
-#    This has been added on https://github.com/gergelyfabian/bazel/tree/jacoco_0.8.7_scala.
+#    This has been added on https://github.com/gergelyfabian/bazel/tree/7.0.2_jacoco_0.8.11_scala.
 #
 # You can use this script to build a custom version of `JacocoCoverage_jarjar_deploy.jar`, including any fixes from the above list you wish
 # and then provide the built jar as a parameter of `java_toolchain` and/or `scala_toolchain` to use the changed behavior for coverage.
@@ -30,7 +32,7 @@
 # There are also some patches that may need to be applied for Jacoco, according to your preferences:
 #
 # 1. Bazel is compatible only with Jacoco in a specific package name. This is not Jacoco-specific, so not committed to the Jacoco fork.
-#    See 0001-Build-Jacoco-for-Bazel.patch.
+#    See 0001-Build-Jacoco-for-Bazel-*.patch (for each Bazel version).
 # 2. Building Jacoco behind a proxy needs a workaround.
 #    See 0002-Build-Jacoco-behind-proxy.patch.
 #
@@ -43,22 +45,12 @@
 set -e
 
 # Note!!
-# Ensure Java 8 is used for building Jacoco (experienced issue when using e.g. Java 17).
-# You may need to change this on your system.
-# If this matches your system, you could uncomment these lines:
+# Ensure Java 8 is used for building Jacoco <0.8.11 (experienced issue when using e.g. Java 17).
+# Java 17+ is needed for Jacoco 0.8.11+.
+#
+# If it's necessary and this matches your system, you could uncomment these lines:
 #export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
 #export PATH=$JAVA_HOME/bin:$PATH
-
-JAVA_VERSION=$(java -version 2>&1 | head -1 \
-                                  | cut -d'"' -f2 \
-                                  | sed 's/^1\.//' \
-                                  | cut -d'.' -f1)
-
-if [ "$JAVA_VERSION" != "8" ]; then
-  echo "Unexpected java version: $JAVA_VERSION"
-  echo "Please ensure this script is run with Java 8"
-  exit 1
-fi
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
   readlink_cmd="readlink"
@@ -80,7 +72,7 @@ bazel_major_version=$1
 if [ -z "$bazel_major_version" ]; then
   echo "Please provide Bazel major version"
   exit 1
-elif [ "$bazel_major_version" != "5" ] && [ "$bazel_major_version" != "6" ]; then
+elif [ "$bazel_major_version" != "5" ] && [ "$bazel_major_version" != "6" ] && [ "$bazel_major_version" != "7" ]; then
   echo "Unsupported Bazel major version: $bazel_major_version"
   exit 1
 fi
@@ -89,8 +81,6 @@ echo "Selected Bazel major version: $bazel_major_version"
 jacoco_repo=$build_dir/jacoco
 # Take a fork for Jacoco that contains Scala fixes.
 jacoco_remote=https://github.com/gergelyfabian/jacoco
-# Take further fixes for Scala (2.11, 2.12 and 2.13) - branch in development:
-jacoco_branch=0.8.7-scala
 
 # Choose the patches that you'd like to use:
 jacoco_patches=""
@@ -99,20 +89,42 @@ jacoco_patches="$jacoco_patches 0001-Build-Jacoco-for-Bazel-$bazel_major_version
 # Uncomment this if you are behind a proxy:
 #jacoco_patches="$jacoco_patches 0002-Build-Jacoco-behind-proxy.patch"
 
-
-# Jacoco version should be 0.8.7 in any case as Bazel is only compatible with that at this moment.
-jacoco_version=0.8.7
-
 bazel_repo=$build_dir/bazel
 bazel_remote=https://github.com/gergelyfabian/bazel
 if [ "$bazel_major_version" = "5" ]; then
+  # Take further fixes for Scala (2.11, 2.12 and 2.13) - branch in development:
+  jacoco_branch=0.8.7-scala
+  jacoco_version=0.8.7
   bazel_version=6.0.0-pre.20220520.1
   # Version of Bazel with extending Bazel's Jacoco interface implementation for our 0.8.7-scala jacoco branch.
   bazel_branch=jacoco_0.8.7_scala
-else
+elif [ "$bazel_major_version" = "6" ]; then
+  # Take further fixes for Scala (2.11, 2.12 and 2.13) - branch in development:
+  jacoco_branch=0.8.7-scala
+  jacoco_version=0.8.7
   bazel_version=6.3.2
   # Version of Bazel with extending Bazel's Jacoco interface implementation for our 0.8.7-scala jacoco branch.
   bazel_branch=6.3.2_jacoco_0.8.7_scala
+else
+  # Take further fixes for Scala (2.11, 2.12 and 2.13) - branch in development:
+  jacoco_branch=0.8.11-scala
+  jacoco_version=0.8.11
+  bazel_version=7.0.2
+  # Version of Bazel with extending Bazel's Jacoco interface implementation for our 0.8.11-scala jacoco branch.
+  bazel_branch=7.0.2_jacoco_0.8.11_scala
+fi
+
+if [ "$bazel_major_version" != "7" ]; then
+  JAVA_VERSION=$(java -version 2>&1 | head -1 \
+                                    | cut -d'"' -f2 \
+                                    | sed 's/^1\.//' \
+                                    | cut -d'.' -f1)
+
+  if [ "$JAVA_VERSION" != "8" ]; then
+    echo "Unexpected java version: $JAVA_VERSION"
+    echo "Please ensure this script is run with Java 8"
+    exit 1
+  fi
 fi
 
 bazel_build_target=JacocoCoverage_jarjar_deploy.jar

--- a/scripts/build_jacocorunner/build_jacocorunner.sh
+++ b/scripts/build_jacocorunner/build_jacocorunner.sh
@@ -49,7 +49,7 @@ set -e
 # Java 17+ is needed for Jacoco 0.8.11+.
 #
 # If it's necessary and this matches your system, you could uncomment these lines:
-#export JAVA_HOME=/usr/lib/jvm/java-8-openjdk-amd64
+#export JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64
 #export PATH=$JAVA_HOME/bin:$PATH
 
 if [[ "$OSTYPE" == "linux-gnu"* ]]; then
@@ -114,12 +114,18 @@ else
   bazel_branch=7.0.2_jacoco_0.8.11_scala
 fi
 
-if [ "$bazel_major_version" != "7" ]; then
-  JAVA_VERSION=$(java -version 2>&1 | head -1 \
-                                    | cut -d'"' -f2 \
-                                    | sed 's/^1\.//' \
-                                    | cut -d'.' -f1)
+JAVA_VERSION=$(java -version 2>&1 | head -1 \
+                                  | cut -d'"' -f2 \
+                                  | sed 's/^1\.//' \
+                                  | cut -d'.' -f1)
 
+if [ "$bazel_major_version" == "7" ]; then
+  if [ "$JAVA_VERSION" != "17" ]; then
+    echo "Unexpected java version: $JAVA_VERSION"
+    echo "Please ensure this script is run with Java 17"
+    exit 1
+  fi
+else
   if [ "$JAVA_VERSION" != "8" ]; then
     echo "Unexpected java version: $JAVA_VERSION"
     echo "Please ensure this script is run with Java 8"


### PR DESCRIPTION
rules_scala has issues with coverage on JDK 21.

Bazel has solved this in https://github.com/bazelbuild/bazel/issues/20845 by upgrading Jacoco and ASM.

Added option to build JacocoRunner for Bazel 7, the version with fix will be used with Jacoco interface changes.
Jacoco upgraded to 0.8.11 (including the Jacoco/Bazel branches used for that).

