### PR TITLE
Propagate maven_coordinates tag to generated scala_import so pom generation includes the dependency

### DIFF
--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -204,8 +204,10 @@ def _serialize_given_rule_import(
         "%s(" % rule_name,
         "    name = %s," % repr(name),
         "    jars = [%s]," % repr(path),
-        "    tags = [\"maven_coordinates=%s\"]," % coordinates,
     ]
+
+    if coordinates:
+        lines.append("    tags = [\"maven_coordinates=%s\"]," % coordinates)
     if srcpath:
         lines.append("    srcjar = %s," % repr(srcpath))
     for prop in props:
@@ -292,7 +294,7 @@ def jvm_maven_import_external(
 
         srcjar_urls = _convert_coordinates_to_urls(src_coordinates, server_urls)
 
-    jvm_import_external(coordinates = artifact, jar_urls = jar_urls, srcjar_urls = srcjar_urls, **kwargs)
+    jvm_import_external(jar_urls = jar_urls, srcjar_urls = srcjar_urls, coordinates = artifact, **kwargs)
 
 def scala_import_external(
         rule_load = "load(\"@io_bazel_rules_scala//scala:scala_import.bzl\", \"scala_import\")",


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

Add a `maven_coordinates=` tag to the generated scala maven dependency targets.

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

`rules_jvm_external` pom generation uses the `maven_coordinates=x:y:z` tag to determine the formatting of a dependency in the pom. Because this tag is missing, the scala dependencies are excluded from the generated pom.
I need for example `@io_bazel_rules_scala_scala_library//jar` to appear in my generated pom as
```xml
<dependency>
    <groupId>org.scala-lang</groupId>
    <artifactId>scala-library</artifactId>
    <version>2.13.12</version>
</dependency>
```