### PR TITLE
Allow transitioning Scala version with `scala_version` attribute of rules

### DIFF
--- a/cross-compilation-doc.md
+++ b/cross-compilation-doc.md
@@ -55,6 +55,45 @@ def _rule_impl(ctx):
 TODO
 
 
+## Requesting specific version
+To use other than default version of Scala, you need to change the current `@io_bazel_rules_scala_config//:scala_version` build setting.
+
+Simple transition, setting the Scala version to one found in `scala_version` attribute:
+```starlark
+def _scala_version_transition_impl(settings, attr):
+    if attr.scala_version:
+        return {"@io_bazel_rules_scala_config//:scala_version": attr.scala_version}
+    else:
+        return {}
+
+scala_version_transition = transition(
+    implementation = _scala_version_transition_impl,
+    inputs = [],
+    outputs = ["@io_bazel_rules_scala_config//:scala_version"],
+)
+```
+
+To use it in a rule, use the `scala_version_transition` as `cfg` and use `toolchain_transition_attr` in `attrs`:
+```starlark
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+
+_scala_library_attrs.update(toolchain_transition_attr)
+
+def make_scala_library(*extras):
+    return rule(
+        attrs = _dicts.add(
+            ...
+            toolchain_transition_attr,
+            ...
+        ),
+        ...
+        cfg = scala_version_transition,
+        incompatible_use_toolchain_transition = True,
+        ...
+    )
+```
+
+
 ## Toolchains
 Standard [toolchain resolution](https://bazel.build/extending/toolchains#toolchain-resolution) procedure determines which toolchain to use for Scala targets.
 

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -9,6 +9,7 @@ load(
     "resolve_deps",
 )
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
     "extras_phases",
@@ -70,6 +71,8 @@ _scala_binary_attrs.update(common_attrs)
 
 _scala_binary_attrs.update(resolve_deps)
 
+_scala_binary_attrs.update(toolchain_transition_attr)
+
 def make_scala_binary(*extras):
     return rule(
         attrs = _dicts.add(
@@ -87,6 +90,7 @@ def make_scala_binary(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_binary_impl,
     )

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -8,6 +8,7 @@ load(
     "launcher_template",
 )
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
     "extras_phases",
@@ -123,6 +124,8 @@ _scala_junit_test_attrs.update({
     "tests_from": attr.label_list(providers = [[JavaInfo]]),
 })
 
+_scala_junit_test_attrs.update(toolchain_transition_attr)
+
 def make_scala_junit_test(*extras):
     return rule(
         attrs = _dicts.add(
@@ -140,6 +143,7 @@ def make_scala_junit_test(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_junit_test_impl,
     )

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -15,6 +15,7 @@ load(
     "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
     "extras_phases",
@@ -87,6 +88,8 @@ _scala_library_attrs.update(_library_attrs)
 
 _scala_library_attrs.update(resolve_deps)
 
+_scala_library_attrs.update(toolchain_transition_attr)
+
 def make_scala_library(*extras):
     return rule(
         attrs = _dicts.add(
@@ -103,6 +106,7 @@ def make_scala_library(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_library_impl,
     )
@@ -185,6 +189,8 @@ _scala_library_for_plugin_bootstrapping_attrs.update(
     common_attrs_for_plugin_bootstrapping,
 )
 
+_scala_library_for_plugin_bootstrapping_attrs.update(toolchain_transition_attr)
+
 def make_scala_library_for_plugin_bootstrapping(*extras):
     return rule(
         attrs = _dicts.add(
@@ -201,6 +207,7 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_library_for_plugin_bootstrapping_impl,
     )
@@ -245,6 +252,8 @@ _scala_macro_library_attrs.update(_library_attrs)
 
 _scala_macro_library_attrs.update(resolve_deps)
 
+_scala_macro_library_attrs.update(toolchain_transition_attr)
+
 # Set unused_dependency_checker_mode default to off for scala_macro_library
 _scala_macro_library_attrs["unused_dependency_checker_mode"] = attr.string(
     default = "off",
@@ -273,6 +282,7 @@ def make_scala_macro_library(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_macro_library_impl,
     )

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -9,6 +9,7 @@ load(
     "resolve_deps",
 )
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
     "extras_phases",
@@ -65,6 +66,8 @@ _scala_repl_attrs.update(common_attrs)
 
 _scala_repl_attrs.update(resolve_deps)
 
+_scala_repl_attrs.update(toolchain_transition_attr)
+
 def make_scala_repl(*extras):
     return rule(
         attrs = _dicts.add(
@@ -79,6 +82,7 @@ def make_scala_repl(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_repl_impl,
     )

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -9,6 +9,7 @@ load(
 )
 load("@io_bazel_rules_scala//scala/private:common.bzl", "sanitize_string_for_usage")
 load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
     "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
     "extras_phases",
@@ -108,6 +109,8 @@ _scala_test_attrs.update(common_attrs)
 
 _scala_test_attrs.update(_test_resolve_deps)
 
+_scala_test_attrs.update(toolchain_transition_attr)
+
 def make_scala_test(*extras):
     return rule(
         attrs = _dicts.add(
@@ -126,6 +129,7 @@ def make_scala_test(*extras):
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
+        cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         implementation = _scala_test_impl,
     )

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -51,3 +51,22 @@ def sanitize_version(scala_version):
 
 def version_suffix(scala_version):
     return "_" + sanitize_version(scala_version)
+
+def _scala_version_transition_impl(settings, attr):
+    if attr.scala_version:
+        return {"@io_bazel_rules_scala_config//:scala_version": attr.scala_version}
+    else:
+        return {}
+
+scala_version_transition = transition(
+    implementation = _scala_version_transition_impl,
+    inputs = [],
+    outputs = ["@io_bazel_rules_scala_config//:scala_version"],
+)
+
+toolchain_transition_attr = {
+    "scala_version": attr.string(),
+    "_allowlist_function_transition": attr.label(
+        default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+    ),
+}


### PR DESCRIPTION
### Description
Implements transition and exposes it via the `scala_version` attribute for a number of common rules.

No effect at the moment, as for now we have only one valid setting.
After allowing more Scala versions when configuring rules repository, this will become the central part of the cross-build.

### Motivation
Originally #1290.
Partitioned from #1552.