### PR TITLE
Configure rules behaviour/toolchain attributes via build settings

### DIFF
--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -8,6 +8,7 @@ load(
     "SCALA_MAJOR_VERSION",
 )
 load("@bazel_skylib//rules:common_settings.bzl", "BuildSettingInfo")
+load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
 
 def _compute_strict_deps_mode(input_strict_deps_mode, dependency_mode):
     if dependency_mode == "direct":
@@ -42,19 +43,66 @@ def _partition_patterns(patterns):
     ]
     return includes, excludes
 
+_deprecated_attrs = {
+    "dependency_mode": attr.string(values = ["direct", "plus-one", "transitive"]),
+    "strict_deps_mode": attr.string(values = ["off", "warn", "error", "default"]),
+    "unused_dependency_checker_mode": attr.string(values = ["off", "warn", "error"]),
+    "compiler_deps_mode": attr.string(values = ["off", "warn", "error"]),
+    "dependency_tracking_method": attr.string(values = ["ast-plus", "ast", "high-level", "default"]),
+    "dependency_tracking_strict_deps_patterns": attr.string_list(
+        doc = "List of target prefixes included for strict deps analysis. Exclude patterns with '-'",
+    ),
+    "dependency_tracking_unused_deps_patterns": attr.string_list(
+        doc = "List of target prefixes included for unused deps analysis. Exclude patterns with '-'",
+    ),
+    "enable_diagnostics_report": attr.bool(
+        doc = "Enable the output of structured diagnostics through the BEP",
+    ),
+    "enable_stats_file": attr.bool(
+        doc = "Enable writing of statsfile",
+    ),
+    "enable_semanticdb": attr.bool(
+        doc = "Enable SemanticDb",
+    ),
+    "semanticdb_bundle_in_jar": attr.bool(
+        doc = "Option to bundle the semanticdb files inside the output jar file",
+    ),
+    "use_argument_file_in_runner": attr.bool(
+        doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
+    ),
+}
+
+def _attr_to_flag(name):
+    return "//scala/settings:%s" % name
+
+_flag_attrs = {
+    "_" + k: attr.label(default = _attr_to_flag(k))
+    for k in _deprecated_attrs.keys()
+}
+
+def _resolve_flags(ctx):
+    def compute(name):
+        attr = getattr(ctx.attr, name)
+        return attr if attr else getattr(ctx.attr, "_" + name)[BuildSettingInfo].value
+
+    return struct(**{k: compute(k) for k in _deprecated_attrs.keys()})
+
 def _scala_toolchain_impl(ctx):
-    dependency_mode = ctx.attr.dependency_mode
+    flags = _resolve_flags(ctx)
+
+    dependency_mode = flags.dependency_mode
+
     strict_deps_mode = _compute_strict_deps_mode(
-        ctx.attr.strict_deps_mode,
+        flags.strict_deps_mode,
         dependency_mode,
     )
 
-    compiler_deps_mode = ctx.attr.compiler_deps_mode
+    compiler_deps_mode = flags.compiler_deps_mode
 
-    unused_dependency_checker_mode = ctx.attr.unused_dependency_checker_mode
+    unused_dependency_checker_mode = flags.unused_dependency_checker_mode
     dependency_tracking_method = _compute_dependency_tracking_method(
         dependency_mode,
-        ctx.attr.dependency_tracking_method,
+        flags.dependency_tracking_method,
     )
 
     # Final quality checks to possibly detect buggy code above
@@ -73,13 +121,10 @@ def _scala_toolchain_impl(ctx):
     if "ast-plus" == dependency_tracking_method and not ENABLE_COMPILER_DEPENDENCY_TRACKING:
         fail("To use 'ast-plus' dependency tracking, you must set 'enable_compiler_dependency_tracking' to True in scala_config")
 
-    enable_stats_file = ctx.attr.enable_stats_file
-    enable_diagnostics_report = ctx.attr.enable_diagnostics_report
-
-    all_strict_deps_patterns = ctx.attr.dependency_tracking_strict_deps_patterns
+    all_strict_deps_patterns = flags.dependency_tracking_strict_deps_patterns
     strict_deps_includes, strict_deps_excludes = _partition_patterns(all_strict_deps_patterns)
 
-    all_unused_deps_patterns = ctx.attr.dependency_tracking_unused_deps_patterns
+    all_unused_deps_patterns = flags.dependency_tracking_unused_deps_patterns
     unused_deps_includes, unused_deps_excludes = _partition_patterns(all_unused_deps_patterns)
 
     toolchain = platform_common.ToolchainInfo(
@@ -96,12 +141,12 @@ def _scala_toolchain_impl(ctx):
         unused_deps_exclude_patterns = unused_deps_excludes,
         scalac_jvm_flags = ctx.attr.scalac_jvm_flags,
         scala_test_jvm_flags = ctx.attr.scala_test_jvm_flags,
-        enable_diagnostics_report = enable_diagnostics_report,
+        enable_diagnostics_report = flags.enable_diagnostics_report,
         jacocorunner = ctx.attr.jacocorunner,
-        enable_stats_file = enable_stats_file,
-        enable_semanticdb = ctx.attr.enable_semanticdb,
-        semanticdb_bundle_in_jar = ctx.attr.semanticdb_bundle_in_jar,
-        use_argument_file_in_runner = ctx.attr.use_argument_file_in_runner,
+        enable_stats_file = flags.enable_stats_file,
+        enable_semanticdb = flags.enable_semanticdb,
+        semanticdb_bundle_in_jar = flags.semanticdb_bundle_in_jar,
+        use_argument_file_in_runner = flags.use_argument_file_in_runner,
         scala_version = ctx.attr._scala_version[BuildSettingInfo].value,
     )
     return [toolchain]
@@ -120,62 +165,20 @@ def _default_dep_providers():
 
 scala_toolchain = rule(
     _scala_toolchain_impl,
-    attrs = {
-        "scalacopts": attr.string_list(),
-        "dep_providers": attr.label_list(
-            default = _default_dep_providers(),
-            providers = [_DepsInfo],
-        ),
-        "dependency_mode": attr.string(
-            default = "direct",
-            values = ["direct", "plus-one", "transitive"],
-        ),
-        "strict_deps_mode": attr.string(
-            default = "default",
-            values = ["off", "warn", "error", "default"],
-        ),
-        "unused_dependency_checker_mode": attr.string(
-            default = "off",
-            values = ["off", "warn", "error"],
-        ),
-        "compiler_deps_mode": attr.string(
-            default = "off",
-            values = ["off", "warn", "error"],
-        ),
-        "dependency_tracking_method": attr.string(
-            default = "default",
-            values = ["ast-plus", "ast", "high-level", "default"],
-        ),
-        "dependency_tracking_strict_deps_patterns": attr.string_list(
-            doc = "List of target prefixes included for strict deps analysis. Exclude patterns with '-'",
-            default = [""],
-        ),
-        "dependency_tracking_unused_deps_patterns": attr.string_list(
-            doc = "List of target prefixes included for unused deps analysis. Exclude patterns with '-'",
-            default = [""],
-        ),
-        "scalac_jvm_flags": attr.string_list(),
-        "scala_test_jvm_flags": attr.string_list(),
-        "enable_diagnostics_report": attr.bool(
-            doc = "Enable the output of structured diagnostics through the BEP",
-        ),
-        "jacocorunner": attr.label(
-            default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
-        ),
-        "enable_stats_file": attr.bool(
-            default = True,
-            doc = "Enable writing of statsfile",
-        ),
-        "enable_semanticdb": attr.bool(
-            default = False,
-            doc = "Enable SemanticDb",
-        ),
-        "semanticdb_bundle_in_jar": attr.bool(default = False, doc = "Option to bundle the semanticdb files inside the output jar file"),
-        "use_argument_file_in_runner": attr.bool(
-            default = False,
-            doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
-        ),
-        "_scala_version": attr.label(default = "@io_bazel_rules_scala_config//:scala_version"),
-    },
+    attrs = _dicts.add(
+        _deprecated_attrs,
+        _flag_attrs,
+        {
+            "dep_providers": attr.label_list(
+                default = _default_dep_providers(),
+                providers = [_DepsInfo],
+            ),
+            "jacocorunner": attr.label(default = Label("@bazel_tools//tools/jdk:JacocoCoverage")),
+            "scalacopts": attr.string_list(),
+            "scalac_jvm_flags": attr.string_list(),
+            "scala_test_jvm_flags": attr.string_list(),
+            "_scala_version": attr.label(default = "@io_bazel_rules_scala_config//:scala_version"),
+        },
+    ),
     fragments = ["java"],
 )

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -43,66 +43,80 @@ def _partition_patterns(patterns):
     ]
     return includes, excludes
 
-_deprecated_attrs = {
-    "dependency_mode": attr.string(values = ["direct", "plus-one", "transitive"]),
-    "strict_deps_mode": attr.string(values = ["off", "warn", "error", "default"]),
-    "unused_dependency_checker_mode": attr.string(values = ["off", "warn", "error"]),
-    "compiler_deps_mode": attr.string(values = ["off", "warn", "error"]),
-    "dependency_tracking_method": attr.string(values = ["ast-plus", "ast", "high-level", "default"]),
+_config_attrs = {
+    "dependency_mode": attr.string(
+        default = "direct",
+        values = ["direct", "plus-one", "transitive"],
+    ),
+    "strict_deps_mode": attr.string(
+        default = "default",
+        values = ["off", "warn", "error", "default"],
+    ),
+    "unused_dependency_checker_mode": attr.string(
+        default = "off",
+        values = ["off", "warn", "error"],
+    ),
+    "compiler_deps_mode": attr.string(
+        default = "off",
+        values = ["off", "warn", "error"],
+    ),
+    "dependency_tracking_method": attr.string(
+        default = "default",
+        values = ["ast-plus", "ast", "high-level", "default"],
+    ),
     "dependency_tracking_strict_deps_patterns": attr.string_list(
         doc = "List of target prefixes included for strict deps analysis. Exclude patterns with '-'",
+        default = [""],
     ),
     "dependency_tracking_unused_deps_patterns": attr.string_list(
         doc = "List of target prefixes included for unused deps analysis. Exclude patterns with '-'",
+        default = [""],
     ),
     "enable_diagnostics_report": attr.bool(
         doc = "Enable the output of structured diagnostics through the BEP",
     ),
     "enable_stats_file": attr.bool(
+        default = True,
         doc = "Enable writing of statsfile",
     ),
     "enable_semanticdb": attr.bool(
+        default = False,
         doc = "Enable SemanticDb",
     ),
-    "semanticdb_bundle_in_jar": attr.bool(
-        doc = "Option to bundle the semanticdb files inside the output jar file",
-    ),
+    "semanticdb_bundle_in_jar": attr.bool(default = False, doc = "Option to bundle the semanticdb files inside the output jar file"),
     "use_argument_file_in_runner": attr.bool(
+        default = False,
         doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
     ),
 }
 
-def _attr_to_flag(name):
-    return "//scala/settings:%s" % name
-
-_flag_attrs = {
-    "_" + k: attr.label(default = _attr_to_flag(k))
-    for k in _deprecated_attrs.keys()
+_config_flags = {
+    "_" + k: attr.label(default = "//scala/settings:%s" % k)
+    for k in _config_attrs.keys()
 }
 
-def _resolve_flags(ctx):
-    def compute(name):
-        attr = getattr(ctx.attr, name)
-        return attr if attr else getattr(ctx.attr, "_" + name)[BuildSettingInfo].value
-
-    return struct(**{k: compute(k) for k in _deprecated_attrs.keys()})
+def _config(ctx):
+    if ctx.attr._scala_toolchain_flags[BuildSettingInfo].value:
+        return struct(**{k: getattr(ctx.attr, "_" + k)[BuildSettingInfo].value for k in _config_attrs.keys()})
+    else:
+        return struct(**{k: getattr(ctx.attr, k) for k in _config_attrs.keys()})
 
 def _scala_toolchain_impl(ctx):
-    flags = _resolve_flags(ctx)
+    config = _config(ctx)
 
-    dependency_mode = flags.dependency_mode
+    dependency_mode = config.dependency_mode
 
     strict_deps_mode = _compute_strict_deps_mode(
-        flags.strict_deps_mode,
+        config.strict_deps_mode,
         dependency_mode,
     )
 
-    compiler_deps_mode = flags.compiler_deps_mode
+    compiler_deps_mode = config.compiler_deps_mode
 
-    unused_dependency_checker_mode = flags.unused_dependency_checker_mode
+    unused_dependency_checker_mode = config.unused_dependency_checker_mode
     dependency_tracking_method = _compute_dependency_tracking_method(
         dependency_mode,
-        flags.dependency_tracking_method,
+        config.dependency_tracking_method,
     )
 
     # Final quality checks to possibly detect buggy code above
@@ -121,10 +135,10 @@ def _scala_toolchain_impl(ctx):
     if "ast-plus" == dependency_tracking_method and not ENABLE_COMPILER_DEPENDENCY_TRACKING:
         fail("To use 'ast-plus' dependency tracking, you must set 'enable_compiler_dependency_tracking' to True in scala_config")
 
-    all_strict_deps_patterns = flags.dependency_tracking_strict_deps_patterns
+    all_strict_deps_patterns = config.dependency_tracking_strict_deps_patterns
     strict_deps_includes, strict_deps_excludes = _partition_patterns(all_strict_deps_patterns)
 
-    all_unused_deps_patterns = flags.dependency_tracking_unused_deps_patterns
+    all_unused_deps_patterns = config.dependency_tracking_unused_deps_patterns
     unused_deps_includes, unused_deps_excludes = _partition_patterns(all_unused_deps_patterns)
 
     toolchain = platform_common.ToolchainInfo(
@@ -141,12 +155,12 @@ def _scala_toolchain_impl(ctx):
         unused_deps_exclude_patterns = unused_deps_excludes,
         scalac_jvm_flags = ctx.attr.scalac_jvm_flags,
         scala_test_jvm_flags = ctx.attr.scala_test_jvm_flags,
-        enable_diagnostics_report = flags.enable_diagnostics_report,
+        enable_diagnostics_report = config.enable_diagnostics_report,
         jacocorunner = ctx.attr.jacocorunner,
-        enable_stats_file = flags.enable_stats_file,
-        enable_semanticdb = flags.enable_semanticdb,
-        semanticdb_bundle_in_jar = flags.semanticdb_bundle_in_jar,
-        use_argument_file_in_runner = flags.use_argument_file_in_runner,
+        enable_stats_file = config.enable_stats_file,
+        enable_semanticdb = config.enable_semanticdb,
+        semanticdb_bundle_in_jar = config.semanticdb_bundle_in_jar,
+        use_argument_file_in_runner = config.use_argument_file_in_runner,
         scala_version = ctx.attr._scala_version[BuildSettingInfo].value,
     )
     return [toolchain]
@@ -166,8 +180,8 @@ def _default_dep_providers():
 scala_toolchain = rule(
     _scala_toolchain_impl,
     attrs = _dicts.add(
-        _deprecated_attrs,
-        _flag_attrs,
+        _config_attrs,
+        _config_flags,
         {
             "dep_providers": attr.label_list(
                 default = _default_dep_providers(),
@@ -178,6 +192,7 @@ scala_toolchain = rule(
             "scalac_jvm_flags": attr.string_list(),
             "scala_test_jvm_flags": attr.string_list(),
             "_scala_version": attr.label(default = "@io_bazel_rules_scala_config//:scala_version"),
+            "_scala_toolchain_flags": attr.label(default = "//scala/settings:scala_toolchain_flags"),
         },
     ),
     fragments = ["java"],

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -88,6 +88,8 @@ _config_attrs = {
         default = False,
         doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
     ),
+    "scalac_jvm_flags": attr.string_list(),
+    "scala_test_jvm_flags": attr.string_list(),
 }
 
 _config_flags = {
@@ -189,8 +191,6 @@ scala_toolchain = rule(
             ),
             "jacocorunner": attr.label(default = Label("@bazel_tools//tools/jdk:JacocoCoverage")),
             "scalacopts": attr.string_list(),
-            "scalac_jvm_flags": attr.string_list(),
-            "scala_test_jvm_flags": attr.string_list(),
             "_scala_version": attr.label(default = "@io_bazel_rules_scala_config//:scala_version"),
             "_scala_toolchain_flags": attr.label(default = "//scala/settings:scala_toolchain_flags"),
         },

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -1,7 +1,97 @@
+package(default_visibility = ["//visibility:public"])
+
 load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
 
 stamp_scala_import(
     name = "stamp_scala_import",
     build_setting_default = True,
-    visibility = ["//visibility:public"],
+)
+
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag", "string_list_flag")
+
+string_flag(
+    name = "dependency_mode",
+    build_setting_default = "direct",
+    values = [
+        "direct",
+        "plus-one",
+        "transitive",
+    ],
+)
+
+string_flag(
+    name = "strict_deps_mode",
+    build_setting_default = "default",
+    values = [
+        "off",
+        "warn",
+        "error",
+        "default",
+    ],
+)
+
+string_flag(
+    name = "unused_dependency_checker_mode",
+    build_setting_default = "off",
+    values = [
+        "off",
+        "warn",
+        "error",
+    ],
+)
+
+string_flag(
+    name = "compiler_deps_mode",
+    build_setting_default = "off",
+    values = [
+        "off",
+        "warn",
+        "error",
+    ],
+)
+
+string_flag(
+    name = "dependency_tracking_method",
+    build_setting_default = "default",
+    values = [
+        "ast-plus",
+        "ast",
+        "high-level",
+        "default",
+    ],
+)
+
+string_list_flag(
+    name = "dependency_tracking_strict_deps_patterns",
+    build_setting_default = [],
+)
+
+string_list_flag(
+    name = "dependency_tracking_unused_deps_patterns",
+    build_setting_default = [],
+)
+
+bool_flag(
+    name = "enable_diagnostics_report",
+    build_setting_default = False,
+)
+
+bool_flag(
+    name = "enable_stats_file",
+    build_setting_default = True,
+)
+
+bool_flag(
+    name = "enable_semanticdb",
+    build_setting_default = False,
+)
+
+bool_flag(
+    name = "semanticdb_bundle_in_jar",
+    build_setting_default = False,
+)
+
+bool_flag(
+    name = "use_argument_file_in_runner",
+    build_setting_default = False,
 )

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -1,13 +1,12 @@
-package(default_visibility = ["//visibility:public"])
-
 load("//scala/settings:stamp_settings.bzl", "stamp_scala_import")
+load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag", "string_list_flag")
+
+package(default_visibility = ["//visibility:public"])
 
 stamp_scala_import(
     name = "stamp_scala_import",
     build_setting_default = True,
 )
-
-load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag", "string_list_flag")
 
 bool_flag(
     name = "scala_toolchain_flags",

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -100,3 +100,13 @@ bool_flag(
     name = "use_argument_file_in_runner",
     build_setting_default = False,
 )
+
+string_list_flag(
+    name = "scalac_jvm_flags",
+    build_setting_default = [],
+)
+
+string_list_flag(
+    name = "scala_test_jvm_flags",
+    build_setting_default = [],
+)

--- a/scala/settings/BUILD
+++ b/scala/settings/BUILD
@@ -9,6 +9,11 @@ stamp_scala_import(
 
 load("@bazel_skylib//rules:common_settings.bzl", "bool_flag", "string_flag", "string_list_flag")
 
+bool_flag(
+    name = "scala_toolchain_flags",
+    build_setting_default = False,
+)
+
 string_flag(
     name = "dependency_mode",
     build_setting_default = "direct",


### PR DESCRIPTION
### Description

Configure rules via build settings instead of attributes on toolchain.

Eventually toolchain should contain only attributes that are scala version specific (ie jars, scalac opts, executables)

For backwards compatibility make this behaviour configurable (ie either use attributes on toolchain or build flags) by `//scala/settings:scala_toolchain_flags` boolean flag which defaults to false meaning keep current behaviour.

Flags are put under `//scala/settings:*` with names matching to toolchain attributes.

### Motivation

Many scala toolchain attributes are not dependent on scala version, but rather control rules behaviour or enables some features. This becomes more relevant when multiple scala versions are used during the build, which would require setting same attributes to same values for each scala version.

This would prevent having different configs per scala version, but it's doable fairly easily. On the other hand I'm not sure this is needed. For example when strict_deps are enabled most likely it's irrelevant what scala version is used.

TODOS: add docs, add tests, remove toolchains for tests that flip single flag.