### PR TITLE
test: Location expand environment variables

### DIFF
--- a/scala/private/phases/phase_test_environment.bzl
+++ b/scala/private/phases/phase_test_environment.bzl
@@ -2,37 +2,11 @@
 # https://bazel.build/rules/lib/testing#TestEnvironment
 
 def phase_test_environment(ctx, p):
-    test_env = ctx.attr.env
-    inherited_environment = ctx.attr.env_inherit
-
-    if inherited_environment and test_env:
-        return struct(
-            external_providers = {
-                "TestingEnvironment": testing.TestEnvironment(
-                    test_env,
-                    inherited_environment,
-                ),
-            },
-        )
-
-    elif test_env:
-        return struct(
-            external_providers = {
-                "TestingEnvironment": testing.TestEnvironment(
-                    test_env,
-                ),
-            },
-        )
-
-    elif inherited_environment:
-        return struct(
-            external_providers = {
-                "TestingEnvironment": testing.TestEnvironment(
-                    {},
-                    inherited_environment,
-                ),
-            },
-        )
-
-    else:
-        return struct()
+    return struct(
+        external_providers = {
+            "TestingEnvironment": testing.TestEnvironment(
+                {k: ctx.expand_location(v, ctx.attr.data) for k, v in ctx.attr.env.items()},
+                ctx.attr.env_inherit,
+            ),
+        },
+    )


### PR DESCRIPTION
### Description
Perform location expansion on testing environment.

### Motivation
I want to provide paths to the `scala_test` via the environment. https://github.com/ucb-bar/chiseltest requires `VERILATOR_ROOT` to be present in the environment. I want to use the `@verilator//:verilator_executable` provided by https://github.com/hdl/bazel_rules_hdl.

I removed some `if`s and `else`s whose necessity I did not quite understand, please advice if I have broken something.