### PR TITLE
Use version-aware naming for artifact repositories

### DIFF
--- a/examples/testing/multi_frameworks_toolchain/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/BUILD
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "setup_scala_testing_toolchain")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 setup_scala_testing_toolchain(
     name = "testing_toolchain",
@@ -6,7 +8,7 @@ setup_scala_testing_toolchain(
         "@io_bazel_rules_scala_junit_junit",
         "@io_bazel_rules_scala_org_hamcrest_hamcrest_core",
     ],
-    scalatest_classpath = [
+    scalatest_classpath = [dep + version_suffix(SCALA_VERSION) for dep in [
         "@io_bazel_rules_scala_scalactic",
         "@io_bazel_rules_scala_scalatest",
         "@io_bazel_rules_scala_scalatest_compatible",
@@ -19,7 +21,7 @@ setup_scala_testing_toolchain(
         "@io_bazel_rules_scala_scalatest_matchers_core",
         "@io_bazel_rules_scala_scalatest_mustmatchers",
         "@io_bazel_rules_scala_scalatest_shouldmatchers",
-    ],
+    ]],
     specs2_classpath = [
         "@io_bazel_rules_scala_org_specs2_specs2_common",
         "@io_bazel_rules_scala_org_specs2_specs2_core",

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -10,6 +10,7 @@ load("//third_party/repositories:repositories.bzl", "repositories")
 load(
     "@io_bazel_rules_scala_config//:config.bzl",
     "SCALA_MAJOR_VERSION",
+    "SCALA_VERSION",
     "SCALA_VERSIONS",
 )
 
@@ -151,6 +152,7 @@ def rules_scala_toolchain_deps_repositories(
         fetch_sources = False,
         validate_scala_version = True):
     repositories(
+        scala_version = SCALA_VERSION,
         for_artifact_ids = ARTIFACT_IDS,
         maven_servers = maven_servers,
         fetch_sources = fetch_sources,

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -157,4 +157,5 @@ _DEFAULT_DEPS = {
 
 def default_deps(deps_id, scala_version):
     versions = _DEFAULT_DEPS[deps_id]
-    return versions.get("any", []) + versions.get(scala_version[0], [])
+    deps = versions.get("any", []) + versions.get(scala_version[0], [])
+    return [dep + version_suffix(scala_version) for dep in deps]

--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -40,14 +40,14 @@ declare_deps_provider(
     name = "scalafmt_classpath_provider",
     deps_id = "scalafmt_classpath",
     visibility = ["//visibility:public"],
-    deps = [
+    deps = [dep + version_suffix(SCALA_VERSION) for dep in [
         "@com_geirsson_metaconfig_core",
         "@org_scalameta_common",
         "@org_scalameta_parsers",
         "@org_scalameta_scalafmt_core",
         "@org_scalameta_scalameta",
         "@org_scalameta_trees",
-    ],
+    ]],
 )
 
 scalafmt_toolchain(

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -3,7 +3,7 @@ load(
     _default_maven_server_urls = "default_maven_server_urls",
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION", "SCALA_VERSION")
 
 def scalafmt_default_config(path = ".scalafmt.conf"):
     build = []
@@ -46,6 +46,7 @@ def scalafmt_repositories(
         artifact_ids.append("io_bazel_rules_scala_scala_parallel_collections")
 
     repositories(
+        scala_version = SCALA_VERSION,
         for_artifact_ids = artifact_ids,
         maven_servers = maven_servers,
         fetch_sources = True,

--- a/scalatest/scalatest.bzl
+++ b/scalatest/scalatest.bzl
@@ -3,11 +3,13 @@ load(
     _default_maven_server_urls = "default_maven_server_urls",
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def scalatest_repositories(
         maven_servers = _default_maven_server_urls(),
         fetch_sources = True):
     repositories(
+        scala_version = SCALA_VERSION,
         for_artifact_ids = [
             "io_bazel_rules_scala_scalatest",
             "io_bazel_rules_scala_scalatest_compatible",

--- a/test/plugins/BUILD
+++ b/test/plugins/BUILD
@@ -21,7 +21,7 @@ scala_library(
         ":gen-scalac-plugin.xml",
     ],
     deps = [
-        "@io_bazel_rules_scala_scala_compiler",
+        "//scala/private/toolchain_deps:scala_compile_classpath",
     ],
 )
 

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,4 +1,6 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "setup_scala_testing_toolchain")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 _SPECS2_DEPS = [
     "@io_bazel_rules_scala_org_specs2_specs2_common",
@@ -34,7 +36,7 @@ _SCALATEST_DEPS = [
 setup_scala_testing_toolchain(
     name = "testing_toolchain",
     junit_classpath = _JUNIT_DEPS,
-    scalatest_classpath = _SCALATEST_DEPS,
+    scalatest_classpath = [dep + version_suffix(SCALA_VERSION) for dep in _SCALATEST_DEPS],
     specs2_classpath = _SPECS2_DEPS,
     specs2_junit_classpath = _SPECS2_JUNIT_DEPS,
     visibility = ["//visibility:public"],
@@ -42,7 +44,7 @@ setup_scala_testing_toolchain(
 
 setup_scala_testing_toolchain(
     name = "scalatest_toolchain",
-    scalatest_classpath = _SCALATEST_DEPS,
+    scalatest_classpath = [dep + version_suffix(SCALA_VERSION) for dep in _SCALATEST_DEPS],
     visibility = ["//visibility:public"],
 )
 

--- a/third_party/dependency_analyzer/src/test/analyzer_test.bzl
+++ b/third_party/dependency_analyzer/src/test/analyzer_test.bzl
@@ -1,9 +1,9 @@
 load(":analyzer_test_scala_2.bzl", "analyzer_tests_scala_2")
 load(":analyzer_test_scala_3.bzl", "analyzer_tests_scala_3")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION", "SCALA_VERSION")
 
 def tests():
     if SCALA_MAJOR_VERSION.startswith("2"):
-        analyzer_tests_scala_2()
+        analyzer_tests_scala_2(SCALA_VERSION)
     else:
-        analyzer_tests_scala_3()
+        analyzer_tests_scala_3(SCALA_VERSION)

--- a/third_party/dependency_analyzer/src/test/analyzer_test_scala_2.bzl
+++ b/third_party/dependency_analyzer/src/test/analyzer_test_scala_2.bzl
@@ -1,10 +1,12 @@
 load("//scala:scala.bzl", "scala_test")
+load("//scala:scala_cross_version.bzl", "version_suffix")
 
-def analyzer_tests_scala_2():
+def analyzer_tests_scala_2(scala_version):
+    suffix = version_suffix(scala_version)
     common_jvm_flags = [
         "-Dplugin.jar.location=$(execpath //third_party/dependency_analyzer/src/main:dependency_analyzer)",
-        "-Dscala.library.location=$(rootpath @io_bazel_rules_scala_scala_library)",
-        "-Dscala.reflect.location=$(rootpath @io_bazel_rules_scala_scala_reflect)",
+        "-Dscala.library.location=$(rootpath @io_bazel_rules_scala_scala_library%s)" % suffix,
+        "-Dscala.reflect.location=$(rootpath @io_bazel_rules_scala_scala_reflect%s)" % suffix,
     ]
 
     scala_test(
@@ -19,9 +21,9 @@ def analyzer_tests_scala_2():
             "//third_party/dependency_analyzer/src/main:dependency_analyzer",
             "//third_party/dependency_analyzer/src/main:scala_version",
             "//third_party/utils/src/test:test_util",
-            "@io_bazel_rules_scala_scala_compiler",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scala_compiler" + suffix,
+            "@io_bazel_rules_scala_scala_library" + suffix,
+            "@io_bazel_rules_scala_scala_reflect" + suffix,
         ],
     )
 
@@ -33,8 +35,8 @@ def analyzer_tests_scala_2():
         ],
         deps = [
             "//third_party/dependency_analyzer/src/main:scala_version",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scala_library" + suffix,
+            "@io_bazel_rules_scala_scala_reflect" + suffix,
         ],
     )
 
@@ -50,9 +52,9 @@ def analyzer_tests_scala_2():
             "//src/java/io/bazel/rulesscala/io_utils",
             "//third_party/dependency_analyzer/src/main:dependency_analyzer",
             "//third_party/utils/src/test:test_util",
-            "@io_bazel_rules_scala_scala_compiler",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scala_compiler" + suffix,
+            "@io_bazel_rules_scala_scala_library" + suffix,
+            "@io_bazel_rules_scala_scala_reflect" + suffix,
         ],
     )
 
@@ -71,9 +73,9 @@ def analyzer_tests_scala_2():
             "//third_party/dependency_analyzer/src/main:dependency_analyzer",
             "//third_party/utils/src/test:test_util",
             "@com_google_guava_guava_21_0_with_file//jar",
-            "@io_bazel_rules_scala_scala_compiler",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scala_compiler" + suffix,
+            "@io_bazel_rules_scala_scala_library" + suffix,
+            "@io_bazel_rules_scala_scala_reflect" + suffix,
             "@org_apache_commons_commons_lang_3_5_without_file//:linkable_org_apache_commons_commons_lang_3_5_without_file",
         ],
     )
@@ -91,9 +93,9 @@ def analyzer_tests_scala_2():
         deps = [
             "//third_party/dependency_analyzer/src/main:dependency_analyzer",
             "//third_party/utils/src/test:test_util",
-            "@io_bazel_rules_scala_scala_compiler",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_reflect",
+            "@io_bazel_rules_scala_scala_compiler" + suffix,
+            "@io_bazel_rules_scala_scala_library" + suffix,
+            "@io_bazel_rules_scala_scala_reflect" + suffix,
             "@org_apache_commons_commons_lang_3_5_without_file//:linkable_org_apache_commons_commons_lang_3_5_without_file",
         ],
     )

--- a/third_party/dependency_analyzer/src/test/analyzer_test_scala_3.bzl
+++ b/third_party/dependency_analyzer/src/test/analyzer_test_scala_3.bzl
@@ -1,13 +1,15 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load("//scala:scala_cross_version.bzl", "version_suffix")
 
-def analyzer_tests_scala_3():
+def analyzer_tests_scala_3(scala_version):
+    suffix = version_suffix(scala_version)
     common_jvm_flags = [
         "-Dplugin.jar.location=$(execpath //third_party/dependency_analyzer/src/main:dependency_analyzer)",
-        "-Dscala.library.location=$(rootpath @io_bazel_rules_scala_scala_library)",
+        "-Dscala.library.location=$(rootpath @io_bazel_rules_scala_scala_library%s)" % suffix,
         # Scala 2 standard library is required for compilation.
         # Without it compilation fails with error:
         # class dotty.tools.dotc.core.Symbols$NoSymbol$ cannot be cast to class dotty.tools.dotc.core.Symbols$ClassSymbol
-        "-Dscala.library2.location=$(rootpath @io_bazel_rules_scala_scala_library_2)",
+        "-Dscala.library2.location=$(rootpath @io_bazel_rules_scala_scala_library_2%s)" % suffix,
     ]
 
     scala_test(
@@ -21,7 +23,7 @@ def analyzer_tests_scala_3():
             "//scala/private/toolchain_deps:scala_compile_classpath",
             "//third_party/dependency_analyzer/src/main:dependency_analyzer",
             "//third_party/utils/src/test:test_util",
-            "@io_bazel_rules_scala_scala_library",
-            "@io_bazel_rules_scala_scala_library_2",
+            "@io_bazel_rules_scala_scala_library" + suffix,
+            "@io_bazel_rules_scala_scala_library_2" + suffix,
         ],
     )


### PR DESCRIPTION
### Description
It enables the logic implemented in #1562. The choice of toolchains to cover is the same as in #1566.

Now, e.g., instead of referring to the artifact's repository `@io_bazel_rules_scala_scala_compiler`, we ~need to~ may use the version-aware name, like `@io_bazel_rules_scala_scala_compiler_3_3_0`.

**In future** this may require an update in client's code. In particular in cases they don't use the default toolchains provided by the rules, and construct their own dependency providers. One would need to manually add the version suffix to the repository names, or use a construction like `+ version_suffix(SCALA_VERSION)` in their code.

**For now** a backward compatibility layer is provided in a shape of repository with aliases, pointing to artifacts for the default Scala version.


### Motivation
#1290 
