### PR TITLE
Download artifacts for all `SCALA_VERSIONS`

### DIFF
--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -7,12 +7,7 @@ load(
     _default_maven_server_urls = "default_maven_server_urls",
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
-load(
-    "@io_bazel_rules_scala_config//:config.bzl",
-    "SCALA_MAJOR_VERSION",
-    "SCALA_VERSION",
-    "SCALA_VERSIONS",
-)
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 def _dt_patched_compiler_impl(rctx):
     # Need to give the file a .zip extension so rctx.extract knows what type of archive it is
@@ -128,37 +123,39 @@ def rules_scala_setup(scala_compiler_srcjar = None):
     for scala_version in SCALA_VERSIONS:
         dt_patched_compiler_setup(scala_version, scala_compiler_srcjar)
 
-ARTIFACT_IDS = [
-    "io_bazel_rules_scala_scala_library",
-    "io_bazel_rules_scala_scala_compiler",
-    "io_bazel_rules_scala_scala_reflect",
-    "io_bazel_rules_scala_scala_xml",
-    "io_bazel_rules_scala_scala_parser_combinators",
-    "org_scalameta_semanticdb_scalac",
-] if SCALA_MAJOR_VERSION.startswith("2") else [
-    "io_bazel_rules_scala_scala_library",
-    "io_bazel_rules_scala_scala_compiler",
-    "io_bazel_rules_scala_scala_interfaces",
-    "io_bazel_rules_scala_scala_tasty_core",
-    "io_bazel_rules_scala_scala_asm",
-    "io_bazel_rules_scala_scala_xml",
-    "io_bazel_rules_scala_scala_parser_combinators",
-    "io_bazel_rules_scala_scala_library_2",
-]
+def _artifact_ids(scala_version):
+    return [
+        "io_bazel_rules_scala_scala_library",
+        "io_bazel_rules_scala_scala_compiler",
+        "io_bazel_rules_scala_scala_reflect",
+        "io_bazel_rules_scala_scala_xml",
+        "io_bazel_rules_scala_scala_parser_combinators",
+        "org_scalameta_semanticdb_scalac",
+    ] if scala_version.startswith("2") else [
+        "io_bazel_rules_scala_scala_library",
+        "io_bazel_rules_scala_scala_compiler",
+        "io_bazel_rules_scala_scala_interfaces",
+        "io_bazel_rules_scala_scala_tasty_core",
+        "io_bazel_rules_scala_scala_asm",
+        "io_bazel_rules_scala_scala_xml",
+        "io_bazel_rules_scala_scala_parser_combinators",
+        "io_bazel_rules_scala_scala_library_2",
+    ]
 
 def rules_scala_toolchain_deps_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {},
         fetch_sources = False,
         validate_scala_version = True):
-    repositories(
-        scala_version = SCALA_VERSION,
-        for_artifact_ids = ARTIFACT_IDS,
-        maven_servers = maven_servers,
-        fetch_sources = fetch_sources,
-        overriden_artifacts = overriden_artifacts,
-        validate_scala_version = validate_scala_version,
-    )
+    for scala_version in SCALA_VERSIONS:
+        repositories(
+            scala_version = scala_version,
+            for_artifact_ids = _artifact_ids(scala_version),
+            maven_servers = maven_servers,
+            fetch_sources = fetch_sources,
+            overriden_artifacts = overriden_artifacts,
+            validate_scala_version = validate_scala_version,
+        )
 
 def scala_repositories(
         maven_servers = _default_maven_server_urls(),

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -1,9 +1,10 @@
 load(
     "//scala:scala_cross_version.bzl",
+    "extract_major_version",
     _default_maven_server_urls = "default_maven_server_urls",
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION", "SCALA_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 def scalafmt_default_config(path = ".scalafmt.conf"):
     build = []
@@ -14,42 +15,44 @@ def scalafmt_default_config(path = ".scalafmt.conf"):
     build.append(")")
     native.new_local_repository(name = "scalafmt_default", build_file_content = "\n".join(build), path = "")
 
+_SCALAFMT_DEPS = [
+    "org_scalameta_common",
+    "org_scalameta_fastparse",
+    "org_scalameta_fastparse_utils",
+    "org_scalameta_parsers",
+    "org_scalameta_scalafmt_core",
+    "org_scalameta_scalameta",
+    "org_scalameta_trees",
+    "org_typelevel_paiges_core",
+    "com_typesafe_config",
+    "org_scala_lang_scalap",
+    "com_thesamet_scalapb_lenses",
+    "com_thesamet_scalapb_scalapb_runtime",
+    "com_lihaoyi_fansi",
+    "com_lihaoyi_fastparse",
+    "org_scalameta_fastparse_utils",
+    "org_scala_lang_modules_scala_collection_compat",
+    "com_lihaoyi_pprint",
+    "com_lihaoyi_sourcecode",
+    "com_google_protobuf_protobuf_java",
+    "com_geirsson_metaconfig_core",
+    "com_geirsson_metaconfig_typesafe_config",
+]
+
+def _artifact_ids(scala_version):
+    major_version = extract_major_version(scala_version)
+    geny = ["com_lihaoyi_geny"] if major_version != "2.11" else []
+    parallel_collections = ["io_bazel_rules_scala_scala_parallel_collections"] if major_version == "2.13" or major_version.startswith("3") else []
+    return _SCALAFMT_DEPS + geny + parallel_collections
+
 def scalafmt_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {}):
-    artifact_ids = [
-        "org_scalameta_common",
-        "org_scalameta_fastparse",
-        "org_scalameta_fastparse_utils",
-        "org_scalameta_parsers",
-        "org_scalameta_scalafmt_core",
-        "org_scalameta_scalameta",
-        "org_scalameta_trees",
-        "org_typelevel_paiges_core",
-        "com_typesafe_config",
-        "org_scala_lang_scalap",
-        "com_thesamet_scalapb_lenses",
-        "com_thesamet_scalapb_scalapb_runtime",
-        "com_lihaoyi_fansi",
-        "com_lihaoyi_fastparse",
-        "org_scalameta_fastparse_utils",
-        "org_scala_lang_modules_scala_collection_compat",
-        "com_lihaoyi_pprint",
-        "com_lihaoyi_sourcecode",
-        "com_google_protobuf_protobuf_java",
-        "com_geirsson_metaconfig_core",
-        "com_geirsson_metaconfig_typesafe_config",
-    ]
-    if SCALA_MAJOR_VERSION != "2.11":
-        artifact_ids.append("com_lihaoyi_geny")
-    if SCALA_MAJOR_VERSION == "2.13" or SCALA_MAJOR_VERSION.startswith("3"):
-        artifact_ids.append("io_bazel_rules_scala_scala_parallel_collections")
-
-    repositories(
-        scala_version = SCALA_VERSION,
-        for_artifact_ids = artifact_ids,
-        maven_servers = maven_servers,
-        fetch_sources = True,
-        overriden_artifacts = overriden_artifacts,
-    )
+    for scala_version in SCALA_VERSIONS:
+        repositories(
+            scala_version = scala_version,
+            for_artifact_ids = _artifact_ids(scala_version),
+            maven_servers = maven_servers,
+            overriden_artifacts = overriden_artifacts,
+        )
     native.register_toolchains("@io_bazel_rules_scala//scala/scalafmt:scalafmt_toolchain")

--- a/scalatest/scalatest.bzl
+++ b/scalatest/scalatest.bzl
@@ -3,27 +3,28 @@ load(
     _default_maven_server_urls = "default_maven_server_urls",
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 def scalatest_repositories(
         maven_servers = _default_maven_server_urls(),
         fetch_sources = True):
-    repositories(
-        scala_version = SCALA_VERSION,
-        for_artifact_ids = [
-            "io_bazel_rules_scala_scalatest",
-            "io_bazel_rules_scala_scalatest_compatible",
-            "io_bazel_rules_scala_scalatest_core",
-            "io_bazel_rules_scala_scalatest_featurespec",
-            "io_bazel_rules_scala_scalatest_flatspec",
-            "io_bazel_rules_scala_scalatest_freespec",
-            "io_bazel_rules_scala_scalatest_funsuite",
-            "io_bazel_rules_scala_scalatest_funspec",
-            "io_bazel_rules_scala_scalatest_matchers_core",
-            "io_bazel_rules_scala_scalatest_shouldmatchers",
-            "io_bazel_rules_scala_scalatest_mustmatchers",
-            "io_bazel_rules_scala_scalactic",
-        ],
-        maven_servers = maven_servers,
-        fetch_sources = fetch_sources,
-    )
+    for scala_version in SCALA_VERSIONS:
+        repositories(
+            scala_version = scala_version,
+            for_artifact_ids = [
+                "io_bazel_rules_scala_scalatest",
+                "io_bazel_rules_scala_scalatest_compatible",
+                "io_bazel_rules_scala_scalatest_core",
+                "io_bazel_rules_scala_scalatest_featurespec",
+                "io_bazel_rules_scala_scalatest_flatspec",
+                "io_bazel_rules_scala_scalatest_freespec",
+                "io_bazel_rules_scala_scalatest_funsuite",
+                "io_bazel_rules_scala_scalatest_funspec",
+                "io_bazel_rules_scala_scalatest_matchers_core",
+                "io_bazel_rules_scala_scalatest_shouldmatchers",
+                "io_bazel_rules_scala_scalatest_mustmatchers",
+                "io_bazel_rules_scala_scalactic",
+            ],
+            maven_servers = maven_servers,
+            fetch_sources = fetch_sources,
+        )


### PR DESCRIPTION
### Description
Basically make the artifacts available for all configured Scala versions (currently still only one).
After #1573 these will be available under version-suffixed repository names.

### Motivation
Originally #1290.
Partitioned from #1552. 
