### PR TITLE
Build and register toolchains for all `SCALA_VERSIONS`

### DIFF
--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,16 +1,27 @@
 load("@rules_java//java:defs.bzl", "java_import", "java_library")
 load("//scala:providers.bzl", "declare_deps_provider")
+load("//scala:scala_cross_version.bzl", "version_suffix")
 load("//scala/private:macros/setup_scala_toolchain.bzl", "default_deps", "setup_scala_toolchain")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
 
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
 )
 
-setup_scala_toolchain(
+[
+    setup_scala_toolchain(
+        name = "toolchain" + version_suffix(scala_version),
+        scala_version = scala_version,
+        use_argument_file_in_runner = True,
+    )
+    for scala_version in SCALA_VERSIONS
+]
+
+# Alias for backward compatibility
+alias(
     name = "default_toolchain",
-    use_argument_file_in_runner = True,
+    actual = "toolchain" + version_suffix(SCALA_VERSION),
 )
 
 setup_scala_toolchain(

--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -1,7 +1,7 @@
 load("//scala:scala.bzl", "scala_binary")
 load("//scala:scala_cross_version.bzl", "version_suffix")
-load("//scala/scalafmt/toolchain:toolchain.bzl", "export_scalafmt_deps", "scalafmt_toolchain")
-load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
+load("//scala/scalafmt/toolchain:toolchain.bzl", "export_scalafmt_deps")
+load("//scala/scalafmt/toolchain:setup_scalafmt_toolchain.bzl", "setup_scalafmt_toolchains")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 load(
     "//scala/scalafmt:phase_scalafmt_ext.bzl",
@@ -36,34 +36,12 @@ scalafmt_singleton(
     visibility = ["//visibility:public"],
 )
 
-declare_deps_provider(
-    name = "scalafmt_classpath_provider",
-    deps_id = "scalafmt_classpath",
-    visibility = ["//visibility:public"],
-    deps = [dep + version_suffix(SCALA_VERSION) for dep in [
-        "@com_geirsson_metaconfig_core",
-        "@org_scalameta_common",
-        "@org_scalameta_parsers",
-        "@org_scalameta_scalafmt_core",
-        "@org_scalameta_scalameta",
-        "@org_scalameta_trees",
-    ]],
-)
+setup_scalafmt_toolchains()
 
-scalafmt_toolchain(
-    name = "scalafmt_toolchain_impl",
-    dep_providers = [
-        ":scalafmt_classpath_provider",
-    ],
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
+# Alias for backward compatibility:
+alias(
     name = "scalafmt_toolchain",
-    target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(SCALA_VERSION)],
-    toolchain = ":scalafmt_toolchain_impl",
-    toolchain_type = "//scala/scalafmt/toolchain:scalafmt_toolchain_type",
-    visibility = ["//visibility:public"],
+    actual = "scalafmt_toolchain" + version_suffix(SCALA_VERSION),
 )
 
 export_scalafmt_deps(

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -1,6 +1,7 @@
 load(
     "//scala:scala_cross_version.bzl",
     "extract_major_version",
+    "version_suffix",
     _default_maven_server_urls = "default_maven_server_urls",
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
@@ -55,4 +56,10 @@ def scalafmt_repositories(
             maven_servers = maven_servers,
             overriden_artifacts = overriden_artifacts,
         )
-    native.register_toolchains("@io_bazel_rules_scala//scala/scalafmt:scalafmt_toolchain")
+    _register_scalafmt_toolchains()
+
+def _register_scalafmt_toolchains():
+    for scala_version in SCALA_VERSIONS:
+        native.register_toolchains(
+            "@io_bazel_rules_scala//scala/scalafmt:scalafmt_toolchain" + version_suffix(scala_version),
+        )

--- a/scala/scalafmt/toolchain/setup_scalafmt_toolchain.bzl
+++ b/scala/scalafmt/toolchain/setup_scalafmt_toolchain.bzl
@@ -1,0 +1,49 @@
+load("//scala/scalafmt/toolchain:toolchain.bzl", "scalafmt_toolchain")
+load("//scala:providers.bzl", "declare_deps_provider")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+
+_SCALAFMT_DEPS = [
+    "@com_geirsson_metaconfig_core",
+    "@org_scalameta_common",
+    "@org_scalameta_parsers",
+    "@org_scalameta_scalafmt_core",
+    "@org_scalameta_scalameta",
+    "@org_scalameta_trees",
+]
+
+def setup_scalafmt_toolchain(
+        name,
+        scalafmt_classpath,
+        scala_version,
+        visibility = ["//visibility:public"]):
+    scalafmt_classpath_provider = "%s_scalafmt_classpath_provider" % name
+    declare_deps_provider(
+        name = scalafmt_classpath_provider,
+        deps_id = "scalafmt_classpath",
+        visibility = visibility,
+        deps = scalafmt_classpath,
+    )
+    scalafmt_toolchain(
+        name = "%s_impl" % name,
+        dep_providers = [scalafmt_classpath_provider],
+        visibility = visibility,
+    )
+    native.toolchain(
+        name = name,
+        target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(scala_version)],
+        toolchain = ":%s_impl" % name,
+        toolchain_type = "//scala/scalafmt/toolchain:scalafmt_toolchain_type",
+        visibility = visibility,
+    )
+
+def setup_scalafmt_toolchains():
+    for scala_version in SCALA_VERSIONS:
+        setup_scalafmt_toolchain(
+            name = "scalafmt_toolchain" + version_suffix(scala_version),
+            scala_version = scala_version,
+            scalafmt_classpath = _deps(scala_version),
+        )
+
+def _deps(scala_version):
+    return [dep + version_suffix(scala_version) for dep in _SCALAFMT_DEPS]

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -1,7 +1,11 @@
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
+
 def scala_register_toolchains():
-    native.register_toolchains(
-        "@io_bazel_rules_scala//scala:default_toolchain",
-    )
+    for scala_version in SCALA_VERSIONS:
+        native.register_toolchains(
+            "@io_bazel_rules_scala//scala:toolchain" + version_suffix(scala_version),
+        )
 
 def scala_register_unused_deps_toolchains():
     native.register_toolchains(

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,6 +1,6 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "setup_scala_testing_toolchain")
 load("//scala:scala_cross_version.bzl", "version_suffix")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
 
 _SPECS2_DEPS = [
     "@io_bazel_rules_scala_org_specs2_specs2_common",
@@ -33,19 +33,38 @@ _SCALATEST_DEPS = [
     "@io_bazel_rules_scala_scalatest_shouldmatchers",
 ]
 
-setup_scala_testing_toolchain(
+[
+    setup_scala_testing_toolchain(
+        name = "testing_toolchain" + version_suffix(scala_version),
+        junit_classpath = _JUNIT_DEPS,
+        scala_version = scala_version,
+        scalatest_classpath = [dep + version_suffix(scala_version) for dep in _SCALATEST_DEPS],
+        specs2_classpath = _SPECS2_DEPS,
+        specs2_junit_classpath = _SPECS2_JUNIT_DEPS,
+        visibility = ["//visibility:public"],
+    )
+    for scala_version in SCALA_VERSIONS
+]
+
+[
+    setup_scala_testing_toolchain(
+        name = "scalatest_toolchain" + version_suffix(scala_version),
+        scala_version = scala_version,
+        scalatest_classpath = [dep + version_suffix(scala_version) for dep in _SCALATEST_DEPS],
+        visibility = ["//visibility:public"],
+    )
+    for scala_version in SCALA_VERSIONS
+]
+
+# Aliases for backward compatibility:
+alias(
     name = "testing_toolchain",
-    junit_classpath = _JUNIT_DEPS,
-    scalatest_classpath = [dep + version_suffix(SCALA_VERSION) for dep in _SCALATEST_DEPS],
-    specs2_classpath = _SPECS2_DEPS,
-    specs2_junit_classpath = _SPECS2_JUNIT_DEPS,
-    visibility = ["//visibility:public"],
+    actual = "testing_toolchain" + version_suffix(SCALA_VERSION),
 )
 
-setup_scala_testing_toolchain(
+alias(
     name = "scalatest_toolchain",
-    scalatest_classpath = [dep + version_suffix(SCALA_VERSION) for dep in _SCALATEST_DEPS],
-    visibility = ["//visibility:public"],
+    actual = "scalatest_toolchain" + version_suffix(SCALA_VERSION),
 )
 
 setup_scala_testing_toolchain(

--- a/testing/scalatest.bzl
+++ b/testing/scalatest.bzl
@@ -1,7 +1,10 @@
 load("//scalatest:scalatest.bzl", _repositories = "scalatest_repositories")
+load("//scala:scala_cross_version.bzl", "version_suffix")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 def scalatest_repositories():
     _repositories()
 
 def scalatest_toolchain():
-    native.register_toolchains("@io_bazel_rules_scala//testing:scalatest_toolchain")
+    for scala_version in SCALA_VERSIONS:
+        native.register_toolchains("@io_bazel_rules_scala//testing:scalatest_toolchain" + version_suffix(scala_version))

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
@@ -1,10 +1,13 @@
 load("//scala:scala.bzl", "scala_library_for_plugin_bootstrapping")
-load("//scala:scala_cross_version.bzl", "version_suffix")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
 
 scala_library_for_plugin_bootstrapping(
     name = "dep_reporting_compiler",
-    srcs = ["@scala_compiler_source%s//:src" % version_suffix(SCALA_VERSION)],
+    srcs = select({
+        "@io_bazel_rules_scala_config//:scala_version" + version_suffix(v): ["@scala_compiler_source%s//:src" % version_suffix(v)]
+        for v in SCALA_VERSIONS
+    }),
     scalac_jvm_flags = ["-Xmx128M"],  # fixme - workaround for a failing test
     visibility = ["//visibility:public"],
     deps = ["//scala/private/toolchain_deps:scala_compile_classpath"],


### PR DESCRIPTION
### Description
Build and register toolchains for all `SCALA_VERSIONS`.
There are aliases for toolchains for default Scala version provided – for backward-compatibility, similarly as in #1573.

### Motivation
Originally #1290.
Partitioned from #1552. 
