### PR TITLE
Use JDK Throwable.printStackTrace

### DIFF
--- a/scala/support/JUnitXmlReporter.scala
+++ b/scala/support/JUnitXmlReporter.scala
@@ -18,7 +18,7 @@ package io.bazel.rules.scala
 import org.scalatest._
 import org.scalatest.events._
 
-import java.io.PrintWriter
+import java.io.{ PrintWriter, StringWriter }
 import java.net.InetAddress
 import java.net.UnknownHostException
 import java.text.SimpleDateFormat
@@ -397,16 +397,11 @@ class JUnitXmlReporter extends Reporter {
   // including any nested exceptions.
   //
   def getStackTrace(throwable: Throwable): String = {
-    "" + throwable +
-    Array.concat(throwable.getStackTrace).mkString("\n      at ",
-                                                   "\n      at ", "\n") +
-    {
-      if (throwable.getCause != null) {
-        "      Cause: " +
-        getStackTrace(throwable.getCause)
-      }
-      else ""
-    }
+    val stringWriter = new StringWriter
+    val printWriter = new PrintWriter(stringWriter)
+    throwable.printStackTrace(printWriter)
+    printWriter.flush()
+    stringWriter.toString
   }
 
   //


### PR DESCRIPTION
### Description
This prints stack traces with both cause and suppressions. Without this change, suppressions aren't printed and causes are overly long.

For example, this test:
```
package com.humio

import org.scalatest.funsuite.AnyFunSuite

class MyTest extends AnyFunSuite {

  test("failure") {
    val cause = new Throwable("cause")
    val suppression = new Throwable("suppression")
    cause.addSuppressed(suppression)
    fail(cause)
  }
}
```

Will be displayed like this with the patch:

```
org.scalatest.exceptions.TestFailedException was thrown.
org.scalatest.exceptions.TestFailedException
	at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
	at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
	at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
	at org.scalatest.Assertions.fail(Assertions.scala:965)
	at org.scalatest.Assertions.fail$(Assertions.scala:961)
	at org.scalatest.funsuite.AnyFunSuite.fail(AnyFunSuite.scala:1564)
	at com.humio.MyTest.$anonfun$new$1(MyTest.scala:11)
	at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
	at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
	at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
	at org.scalatest.Transformer.apply(Transformer.scala:22)
	at org.scalatest.Transformer.apply(Transformer.scala:20)
	at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
	at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
	at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
	at org.scalatest.funsuite.AnyFunSuite.withFixture(AnyFunSuite.scala:1564)
	at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
	at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
	at org.scalatest.funsuite.AnyFunSuite.runTest(AnyFunSuite.scala:1564)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
	at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
	at scala.collection.immutable.List.foreach(List.scala:334)
	at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
	at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
	at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
	at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
	at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
	at org.scalatest.Suite.run(Suite.scala:1114)
	at org.scalatest.Suite.run$(Suite.scala:1096)
	at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$$super$run(AnyFunSuite.scala:1564)
	at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
	at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
	at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
	at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
	at org.scalatest.funsuite.AnyFunSuite.run(AnyFunSuite.scala:1564)
	at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1178)
	at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1225)
	at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
	at org.scalatest.Suite.runNestedSuites(Suite.scala:1223)
	at org.scalatest.Suite.runNestedSuites$(Suite.scala:1156)
	at org.scalatest.tools.DiscoverySuite.runNestedSuites(DiscoverySuite.scala:30)
	at org.scalatest.Suite.run(Suite.scala:1111)
	at org.scalatest.Suite.run$(Suite.scala:1096)
	at org.scalatest.tools.DiscoverySuite.run(DiscoverySuite.scala:30)
	at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
	at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
	at scala.collection.immutable.List.foreach(List.scala:334)
	at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
	at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
	at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
	at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
	at org.scalatest.tools.Runner$.main(Runner.scala:775)
	at org.scalatest.tools.Runner.main(Runner.scala)
	at io.bazel.rulesscala.scala_test.Runner.main(Runner.java:33)
Caused by: java.lang.Throwable: cause
	at com.humio.MyTest.$anonfun$new$1(MyTest.scala:8)
	... 53 more
	Suppressed: java.lang.Throwable: suppression
		at com.humio.MyTest.$anonfun$new$1(MyTest.scala:9)
		... 53 more
```

Without the patch:
```
org.scalatest.exceptions.TestFailedException was thrown.
org.scalatest.exceptions.TestFailedException
      at org.scalatest.Assertions.newAssertionFailedException(Assertions.scala:472)
      at org.scalatest.Assertions.newAssertionFailedException$(Assertions.scala:471)
      at org.scalatest.funsuite.AnyFunSuite.newAssertionFailedException(AnyFunSuite.scala:1564)
      at org.scalatest.Assertions.fail(Assertions.scala:965)
      at org.scalatest.Assertions.fail$(Assertions.scala:961)
      at org.scalatest.funsuite.AnyFunSuite.fail(AnyFunSuite.scala:1564)
      at com.humio.MyTest.$anonfun$new$1(MyTest.scala:11)
      at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
      at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
      at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
      at org.scalatest.Transformer.apply(Transformer.scala:22)
      at org.scalatest.Transformer.apply(Transformer.scala:20)
      at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
      at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
      at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
      at org.scalatest.funsuite.AnyFunSuite.withFixture(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
      at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
      at org.scalatest.funsuite.AnyFunSuite.runTest(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
      at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
      at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
      at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
      at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
      at org.scalatest.Suite.run(Suite.scala:1114)
      at org.scalatest.Suite.run$(Suite.scala:1096)
      at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$$super$run(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
      at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
      at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
      at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
      at org.scalatest.funsuite.AnyFunSuite.run(AnyFunSuite.scala:1564)
      at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1178)
      at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1225)
      at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
      at org.scalatest.Suite.runNestedSuites(Suite.scala:1223)
      at org.scalatest.Suite.runNestedSuites$(Suite.scala:1156)
      at org.scalatest.tools.DiscoverySuite.runNestedSuites(DiscoverySuite.scala:30)
      at org.scalatest.Suite.run(Suite.scala:1111)
      at org.scalatest.Suite.run$(Suite.scala:1096)
      at org.scalatest.tools.DiscoverySuite.run(DiscoverySuite.scala:30)
      at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
      at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
      at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
      at org.scalatest.tools.Runner$.main(Runner.scala:775)
      at org.scalatest.tools.Runner.main(Runner.scala)
      at io.bazel.rulesscala.scala_test.Runner.main(Runner.java:33)
      Cause: java.lang.Throwable: cause
      at com.humio.MyTest.$anonfun$new$1(MyTest.scala:8)
      at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
      at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
      at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
      at org.scalatest.Transformer.apply(Transformer.scala:22)
      at org.scalatest.Transformer.apply(Transformer.scala:20)
      at org.scalatest.funsuite.AnyFunSuiteLike$$anon$1.apply(AnyFunSuiteLike.scala:226)
      at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
      at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
      at org.scalatest.funsuite.AnyFunSuite.withFixture(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.invokeWithFixture$1(AnyFunSuiteLike.scala:224)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTest$1(AnyFunSuiteLike.scala:236)
      at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest(AnyFunSuiteLike.scala:236)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTest$(AnyFunSuiteLike.scala:218)
      at org.scalatest.funsuite.AnyFunSuite.runTest(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$runTests$1(AnyFunSuiteLike.scala:269)
      at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
      at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
      at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests(AnyFunSuiteLike.scala:269)
      at org.scalatest.funsuite.AnyFunSuiteLike.runTests$(AnyFunSuiteLike.scala:268)
      at org.scalatest.funsuite.AnyFunSuite.runTests(AnyFunSuite.scala:1564)
      at org.scalatest.Suite.run(Suite.scala:1114)
      at org.scalatest.Suite.run$(Suite.scala:1096)
      at org.scalatest.funsuite.AnyFunSuite.org$scalatest$funsuite$AnyFunSuiteLike$$super$run(AnyFunSuite.scala:1564)
      at org.scalatest.funsuite.AnyFunSuiteLike.$anonfun$run$1(AnyFunSuiteLike.scala:273)
      at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
      at org.scalatest.funsuite.AnyFunSuiteLike.run(AnyFunSuiteLike.scala:273)
      at org.scalatest.funsuite.AnyFunSuiteLike.run$(AnyFunSuiteLike.scala:272)
      at org.scalatest.funsuite.AnyFunSuite.run(AnyFunSuite.scala:1564)
      at org.scalatest.Suite.callExecuteOnSuite$1(Suite.scala:1178)
      at org.scalatest.Suite.$anonfun$runNestedSuites$1(Suite.scala:1225)
      at scala.collection.ArrayOps$.foreach$extension(ArrayOps.scala:1323)
      at org.scalatest.Suite.runNestedSuites(Suite.scala:1223)
      at org.scalatest.Suite.runNestedSuites$(Suite.scala:1156)
      at org.scalatest.tools.DiscoverySuite.runNestedSuites(DiscoverySuite.scala:30)
      at org.scalatest.Suite.run(Suite.scala:1111)
      at org.scalatest.Suite.run$(Suite.scala:1096)
      at org.scalatest.tools.DiscoverySuite.run(DiscoverySuite.scala:30)
      at org.scalatest.tools.SuiteRunner.run(SuiteRunner.scala:47)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13(Runner.scala:1321)
      at org.scalatest.tools.Runner$.$anonfun$doRunRunRunDaDoRunRun$13$adapted(Runner.scala:1315)
      at scala.collection.immutable.List.foreach(List.scala:334)
      at org.scalatest.tools.Runner$.doRunRunRunDaDoRunRun(Runner.scala:1315)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24(Runner.scala:992)
      at org.scalatest.tools.Runner$.$anonfun$runOptionallyWithPassFailReporter$24$adapted(Runner.scala:970)
      at org.scalatest.tools.Runner$.withClassLoaderAndDispatchReporter(Runner.scala:1481)
      at org.scalatest.tools.Runner$.runOptionallyWithPassFailReporter(Runner.scala:970)
      at org.scalatest.tools.Runner$.main(Runner.scala:775)
      at org.scalatest.tools.Runner.main(Runner.scala)
      at io.bazel.rulesscala.scala_test.Runner.main(Runner.java:33)
```