### PR TITLE
Check if java_runtime.version is available

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -228,4 +228,6 @@ def is_windows(ctx):
 # This must be a runtime used in generated java_binary script (usually workers using SecurityManager)
 def allow_security_manager(ctx, runtime = None):
     java_runtime = runtime if runtime else ctx.attr._java_host_runtime[java_common.JavaRuntimeInfo]
-    return ["-Djava.security.manager=allow"] if java_runtime.version >= 17 else []
+
+    # Bazel 5.x doesn't have java_runtime.version defined
+    return ["-Djava.security.manager=allow"] if hasattr(java_runtime, "version") and java_runtime.version >= 17 else []


### PR DESCRIPTION
### Description

Bazel 5.x doesn't have `java_runtime.version` defined. This makes `rules_scala` work again with Bazel 5.3.1.

### Motivation

See #1590 for details.