### PR TITLE
Make suffixed scala version config setting publicly visible

### DIFF
--- a/scala_config.bzl
+++ b/scala_config.bzl
@@ -14,6 +14,7 @@ def _config_setting(scala_version):
     return """config_setting(
     name = "scala_version{version_suffix}",
     flag_values = {{":scala_version": "{version}"}},
+    visibility = ["//visibility:public"],
 )
 """.format(version_suffix = version_suffix(scala_version), version = scala_version)
 


### PR DESCRIPTION
### Description

I cannot upgrade from 6.3.0 to 6.5.0 without this change, see attached issue below.

### Motivation

See #1590