### PR TITLE
[bugfix] normalize paths to enable running external tests

### DIFF
--- a/src/java/io/bazel/rulesscala/scala_test/Runner.java
+++ b/src/java/io/bazel/rulesscala/scala_test/Runner.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -48,7 +49,9 @@ public class Runner {
     if (workspace == null || workspace.trim().isEmpty())
       throw new IllegalArgumentException(RULES_SCALA_MAIN_WS_NAME + " is null or empty.");
 
-    String runnerArgsFilePath = Runfiles.create().rlocation(workspace + "/" + runnerArgsFileKey);
+
+    Path runnerArgsUnresolvedFileLocation = Paths.get(workspace + "/" + runnerArgsFileKey).normalize();
+    String runnerArgsFilePath = Runfiles.create().rlocation(runnerArgsUnresolvedFileLocation.toString());
     if (runnerArgsFilePath == null)
       throw new IllegalArgumentException("rlocation value is null for key: " + runnerArgsFileKey);
 
@@ -90,7 +93,8 @@ public class Runner {
       String[] runpathElements = runnerArgs.get(runpathFlag + 1).split(File.pathSeparator);
       Runfiles runfiles = Runfiles.create();
       for (int i = 0; i < runpathElements.length; i++) {
-        runpathElements[i] = runfiles.rlocation(rulesWorkspace + "/" + runpathElements[i]);
+        Path runPathElementPath = Paths.get(rulesWorkspace + "/" + runpathElements[i]).normalize();
+        runpathElements[i] = runfiles.rlocation(runPathElementPath.toString());
       }
       String runpath = String.join(File.separator, runpathElements);
       runnerArgs.set(runpathFlag + 1, runpath);


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->

Normalize file paths before passing them to runfiles.rlocation() within the test runner. 

Before this change, you could not execute a bazel test target that is not in the primary workspace, it would error with 

For example running `bazel run @my_external_repo//my/path/to:test` 
```
Exception in thread "main" java.lang.reflect.InvocationTargetException
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:566)
	at com.google.testing.coverage.JacocoCoverageRunner.main(JacocoCoverageRunner.java:592)
Caused by: java.lang.IllegalArgumentException: path is not normalized: "my_workspace/../my_external_repo/my/path/to/test/test.args"
	at com.google.devtools.build.runfiles.Util.checkArgument(Util.java:45)
	at com.google.devtools.build.runfiles.Runfiles.rlocation(Runfiles.java:337)
	at io.bazel.rulesscala.scala_test.Runner.extendFromFileArgs(Runner.java:51)
	at io.bazel.rulesscala.scala_test.Runner.extendArgs(Runner.java:37)
	at io.bazel.rulesscala.scala_test.Runner.main(Runner.java:33)
	... 5 more
```

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->

We should be able to run tests from external repos
