### PR TITLE
Handle incorrect Scalac options and prevent printing ScalacWorker stacktraces

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
@@ -40,10 +40,10 @@ class ScalacInvoker{
     
     ConsoleReporter reporter = (ConsoleReporter) comp.getReporter();
     if (reporter == null) {
-			// Can happen only when `ReportableMainClass::newCompiler` was not invoked,
-			// typically due to invalid settings
-			throw new ScalacWorker.InvalidSettings();
-		}
+      // Can happen only when `ReportableMainClass::newCompiler` was not invoked,
+      // typically due to invalid settings
+      throw new ScalacWorker.InvalidSettings();
+    }
 
     if (reporter instanceof ProtoReporter) {
       ProtoReporter protoReporter = (ProtoReporter) reporter;

--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
@@ -24,11 +24,11 @@ class ScalacInvoker{
       comp.process(compilerArgs);
     } catch (Throwable ex) {
       if (ex.toString().contains("scala.reflect.internal.Types$TypeError")) {
-        throw new RuntimeException("Build failure with type error", ex);
+        throw new ScalacWorker.CompilationFailed("with type error", ex);
       } else if (ex.toString().contains("java.lang.StackOverflowError")) {
-        throw new RuntimeException("Build failure with StackOverflowError", ex);
+        throw new ScalacWorker.CompilationFailed("with StackOverflowError", ex);
       } else if (isMacroException(ex)) {
-        throw new RuntimeException("Build failure during macro expansion", ex);
+        throw new ScalacWorker.CompilationFailed("during macro expansion", ex);
       } else {
         throw ex;
       }
@@ -58,7 +58,7 @@ class ScalacInvoker{
 
     if (reporter.hasErrors()) {
       reporter.flush();
-      throw new RuntimeException("Build failed");
+      throw new ScalacWorker.CompilationFailed("with errors.");
     }
 
     return results;

--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker.java
@@ -39,6 +39,12 @@ class ScalacInvoker{
     results.stopTime = System.currentTimeMillis();
     
     ConsoleReporter reporter = (ConsoleReporter) comp.getReporter();
+    if (reporter == null) {
+			// Can happen only when `ReportableMainClass::newCompiler` was not invoked,
+			// typically due to invalid settings
+			throw new ScalacWorker.InvalidSettings();
+		}
+
     if (reporter instanceof ProtoReporter) {
       ProtoReporter protoReporter = (ProtoReporter) reporter;
       protoReporter.writeTo(Paths.get(ops.diagnosticsFile));

--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker3.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker3.java
@@ -44,7 +44,7 @@ class ScalacInvoker{
 
     if (reporter.hasErrors()) {
 //      reporter.flush();
-      throw new RuntimeException("Build failed");
+      throw new ScalacWorker.CompilationFailed("with errors.");
     }
 
     return results;

--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker3.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker3.java
@@ -22,7 +22,11 @@ class ScalacInvoker{
     Driver driver = new dotty.tools.dotc.Driver();
     Contexts.Context ctx = driver.initCtx().fresh();
 
-    Tuple2<scala.collection.immutable.List<AbstractFile>, Contexts.Context> r = driver.setup(compilerArgs, ctx).get();
+    Tuple2<scala.collection.immutable.List<AbstractFile>, Contexts.Context> r = 
+      driver.setup(compilerArgs, ctx)
+        .getOrElse(() -> {
+          throw new ScalacWorker.InvalidSettings();
+        });
 
     Compiler compiler = driver.newCompiler(r._2);
 

--- a/src/java/io/bazel/rulesscala/scalac/ScalacInvoker3.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacInvoker3.java
@@ -43,7 +43,7 @@ class ScalacInvoker{
 
 
     if (reporter.hasErrors()) {
-//      reporter.flush();
+      reporter.flush(ctx);
       throw new ScalacWorker.CompilationFailed("with errors.");
     }
 

--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -34,7 +34,7 @@ class ScalacWorker implements Worker.Interface {
 
   public static class CompilationFailed extends WorkerException {
     public CompilationFailed(String reason, Throwable cause) {
-      super("Compilation failed " + reason, cause);
+      super("Build failure " + reason, cause);
     }
     public CompilationFailed(String reason) {
       this(reason, null);

--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -32,6 +32,15 @@ class ScalacWorker implements Worker.Interface {
     }
   }
 
+  public static class CompilationFailed extends WorkerException {
+    public CompilationFailed(String reason, Throwable cause) {
+      super("Compilation failed " + reason, cause);
+    }
+    public CompilationFailed(String reason) {
+      this(reason, null);
+    }
+  }
+
   private static final boolean isWindows =
       System.getProperty("os.name").toLowerCase().contains("windows");
 

--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -26,6 +26,12 @@ import java.util.stream.Collectors;
 
 class ScalacWorker implements Worker.Interface {
 
+  public static class InvalidSettings extends WorkerException {
+    public InvalidSettings() {
+      super("Failed to invoke Scala compiler, ensure passed options are valid");
+    }
+  }
+
   private static final boolean isWindows =
       System.getProperty("os.name").toLowerCase().contains("windows");
 

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -33,6 +33,9 @@ public final class Worker {
 			public WorkerException(String message) {
 				super(message);
 			}
+      public WorkerException(String message, Throwable cause) {
+				super(message, cause);
+			}
 		}
   }
 

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -97,8 +97,7 @@ public final class Worker {
           } catch (ExitTrapped e) {
             code = e.code;
           } catch (Exception e) {
-            System.err.println(e.getMessage());
-            if (e instanceof Interface.WorkerException) {}
+            if (e instanceof Interface.WorkerException) System.err.println(e.getMessage());
             else e.printStackTrace();
             code = 1;
           }

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -27,6 +27,13 @@ public final class Worker {
 
   public static interface Interface {
     public void work(String[] args) throws Exception;
+
+
+    public abstract class WorkerException extends RuntimeException {
+			public WorkerException(String message) {
+				super(message);
+			}
+		}
   }
 
   /**
@@ -88,7 +95,8 @@ public final class Worker {
             code = e.code;
           } catch (Exception e) {
             System.err.println(e.getMessage());
-            e.printStackTrace();
+            if (e instanceof Interface.WorkerException) {}
+            else e.printStackTrace();
             code = 1;
           }
 

--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -30,13 +30,13 @@ public final class Worker {
 
 
     public abstract class WorkerException extends RuntimeException {
-			public WorkerException(String message) {
-				super(message);
-			}
+      public WorkerException(String message) {
+        super(message);
+      }
       public WorkerException(String message, Throwable cause) {
-				super(message, cause);
-			}
-		}
+        super(message, cause);
+      }
+    }
   }
 
   /**

--- a/test/shell/test_invalid_scalacopts.sh
+++ b/test/shell/test_invalid_scalacopts.sh
@@ -1,0 +1,43 @@
+# shellcheck source=./test_runner.sh
+
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+test_logs_contains() {
+  scalaVersion=$1
+  expected=$2
+  
+  bazel build \
+   --repo_env=SCALA_VERSION=${scalaVersion} \
+   //test_expect_failure/scalacopts_invalid:empty \
+   2>&1 | grep "$expected"
+}
+
+test_logs_not_contains() {
+  scalaVersion=$1
+  expected=$2
+
+  bazel build \
+   --repo_env=SCALA_VERSION=${scalaVersion} \
+   //test_expect_failure/scalacopts_invalid:empty \
+   2>&1 | grep -v "$expected"
+}
+
+test_logs_contains_no_stacktrace() {
+  bazel build \
+   --extra_toolchains="//test_expect_failure/scalacopts_invalid" \
+   --repo_env=SCALA_VERSION=${scalaVersion} \
+   //test_expect_failure/scalacopts_invalid:empty
+}
+
+for scalaVersion in 2.12.19 2.13.14 3.3.3; do
+  if [[ "$scalaVersion" == 3.* ]]; then
+    $runner test_logs_contains $scalaVersion "not-existing is not a valid choice for -source"
+  else
+    $runner test_logs_contains $scalaVersion "bad option: '-source:not-existing'"
+  fi
+  $runner test_logs_contains $scalaVersion 'Failed to invoke Scala compiler, ensure passed options are valid'
+  $runner test_logs_not_contains $scalaVersion 'at io.bazel.rulesscala.scalac.ScalacWorker.main'
+done

--- a/test/shell/test_invalid_scalacopts.sh
+++ b/test/shell/test_invalid_scalacopts.sh
@@ -25,13 +25,6 @@ test_logs_not_contains() {
    2>&1 | grep -v "$expected"
 }
 
-test_logs_contains_no_stacktrace() {
-  bazel build \
-   --extra_toolchains="//test_expect_failure/scalacopts_invalid" \
-   --repo_env=SCALA_VERSION=${scalaVersion} \
-   //test_expect_failure/scalacopts_invalid:empty
-}
-
 for scalaVersion in 2.12.19 2.13.14 3.3.3; do
   if [[ "$scalaVersion" == 3.* ]]; then
     $runner test_logs_contains $scalaVersion "not-existing is not a valid choice for -source"

--- a/test_expect_failure/scalacopts_invalid/BUILD
+++ b/test_expect_failure/scalacopts_invalid/BUILD
@@ -1,0 +1,7 @@
+load("//scala:scala.bzl", "scala_library")
+
+scala_library(
+    name = "empty",
+    srcs = ["Empty.scala"],
+    scalacopts = ["-source:not-existing"],
+)

--- a/test_expect_failure/scalacopts_invalid/Empty.scala
+++ b/test_expect_failure/scalacopts_invalid/Empty.scala
@@ -1,0 +1,3 @@
+package test_expect_failure.scalacopts_invalid
+
+class Empty

--- a/test_rules_scala.sh
+++ b/test_rules_scala.sh
@@ -58,3 +58,4 @@ $runner bazel build //test_statsfile:SimpleNoStatsFile_statsfile --extra_toolcha
 . "${test_dir}"/test_persistent_worker.sh
 . "${test_dir}"/test_semanticdb.sh
 . "${test_dir}"/test_scaladoc.sh
+. "${test_dir}"/test_invalid_scalacopts.sh


### PR DESCRIPTION
### Description
- Handle cases when passing invalid scalac options 
- Prevent printing internal stack traces of ScalaWorker on compilation failing in an expected way

### Motivation
Fixes #1605 
When passing invalid scalac options, eg. `-source:not-existing` the Scala compiler would either: 
 - return `None` form `Driver.setup` leading to runtime exception in `None.get` (Scala 3) 
 - would not create an instance in `Driver.newCompiler` required to create `ProtoReporter` or `DepsTrackingReporter` leading to `reporter` being not initialized (Scala 2) 
 This fix handles both of this cases by termination executing earlier with a known exception. 
 
 In each of cases Scalac compiler would always show error message about which setting was invalid. This is expected behaviour. Because of that, there is no reason to print stack traces on invalid scalac setting  from `ScalaInvoker` exposing internal implementaiton to the user. It can be handled by either not filling stack traces or introducing a common subtype handled in the worker. 
 The later option was chosen and additionally extended to handle expected compiler errors. This should reduce amount of boilerplate logs. 
 
 

