### PR TITLE
Add netrc support for downloading sources

### DIFF
--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -125,7 +125,7 @@ def _jvm_import_external(repository_ctx):
             lines.append("")
     repository_ctx.download(urls, path, sha, auth = _get_auth(repository_ctx, urls))
     if srcurls and _should_fetch_sources_in_current_env(repository_ctx):
-        repository_ctx.download(srcurls, srcpath, srcsha)
+        repository_ctx.download(srcurls, srcpath, srcsha, auth = _get_auth(repository_ctx, srcurls))
     repository_ctx.file("BUILD", "\n".join(lines))
     repository_ctx.file("jar/BUILD", "\n".join([
         _HEADER,


### PR DESCRIPTION
### Description
https://github.com/bazelbuild/rules_scala/pull/1509 missed a spot - netrc authentication also needs to be added to downloading sources for this to work in an environment, where we only use private mirrors, and these private mirrors will not even respond without authentication.

### Motivation
I found myself needing this kind of change at work. I would like to contribute this change so that I don't have to patch this into my Bazel workspace.