### PR TITLE
extra javac opts should override default ones

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -157,10 +157,9 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
         output = output,
         javac_opts = expand_location(
             ctx,
-            extra_javac_opts +
             java_common.default_javac_opts(
                 java_toolchain = java_toolchain,
-            ),
+            ) + extra_javac_opts,
         ),
         deps = providers_of_dependencies,
         #exports can be empty since the manually created provider exposes exports

--- a/test/shell/test_toolchain.sh
+++ b/test/shell/test_toolchain.sh
@@ -15,5 +15,13 @@ java_toolchain_javacopts_are_used(){
       --verbose_failures //test_expect_failure/compilers_javac_opts:can_configure_jvm_flags_for_javac_via_javacopts
 }
 
+java_toolchain_javacopts_can_be_overridden(){
+  action_should_fail_with_message \
+    "invalid target release: InvalidTarget" \
+    build \
+      --verbose_failures //test_expect_failure/compilers_javac_opts:can_override_default_toolchain_flags_for_javac_via_javacopts
+}
+
 $runner test_scalaopts_from_scala_toolchain
 $runner java_toolchain_javacopts_are_used
+$runner java_toolchain_javacopts_can_be_overridden

--- a/test_expect_failure/compilers_javac_opts/BUILD
+++ b/test_expect_failure/compilers_javac_opts/BUILD
@@ -4,3 +4,9 @@ scala_library(
     name = "can_configure_jvm_flags_for_javac_via_javacopts",
     srcs = ["WillNotCompileSinceJavaToolchainAddsAnInvalidJvmFlag.java"],
 )
+
+scala_library(
+    name = "can_override_default_toolchain_flags_for_javac_via_javacopts",
+    srcs = ["WillNotCompileSinceJavaToolchainAddsAnInvalidJvmFlag.java"],
+    javacopts = ["-target InvalidTarget"],
+)


### PR DESCRIPTION
### Description
<!-- Mandatory: A crisp one or two line description of your proposed change. -->
Fixes https://github.com/bazelbuild/rules_scala/issues/1550

Currently the default javac flags will be appended last, overriding the manual ones.  

<!-- Optional:
  A longer explanation of your proposed changes..
  This includes listing any breaking changes, if there are any.
-->

### Motivation
<!-- Mandatory: A summary of why you are making this change. -->
