### PR TITLE
Update repo name handling for Bzlmod compatibility

### DIFF
--- a/scala/private/macros/bzlmod.bzl
+++ b/scala/private/macros/bzlmod.bzl
@@ -67,7 +67,9 @@ def apparent_repo_label_string(label):
     label_str = "@" + str(label).lstrip("@")
     return label_str.replace(label.repo_name, apparent_repo_name(label))
 
-_MAIN_REPO_PREFIX = str(Label("//:all")).split(":")[0]
+_IS_BZLMOD_ENABLED = str(Label("//:all")).startswith("@@")
+
+_MAIN_REPO_PREFIX = "@@//" if _IS_BZLMOD_ENABLED else "@//"
 
 def adjust_main_repo_prefix(target_pattern):
     """Updates the main repo prefix to match the current Bazel version.

--- a/scala/private/macros/bzlmod.bzl
+++ b/scala/private/macros/bzlmod.bzl
@@ -1,22 +1,8 @@
 """Utilities for working with Bazel modules"""
 
-def _repo_name(label_or_name):
-    """Utility to provide Label compatibility with Bazel 5.
-
-    Under Bazel 5, calls `Label.workspace_name`. Otherwise calls
-    `Label.repo_name`.
-
-    Args:
-        label_or_name: a Label or repository name string
-
-    Returns:
-        The repository name returned directly from the Label API, or the
-            original string if not a Label
-    """
-    if hasattr(label_or_name, "repo_name"):
-        return label_or_name.repo_name
-
-    return getattr(label_or_name, "workspace_name", label_or_name)
+_repo_attr = (
+    "repo_name" if hasattr(Label("//:all"), "repo_name") else "workspace_name"
+)
 
 def apparent_repo_name(label_or_name):
     """Return a repository's apparent repository name.
@@ -30,7 +16,7 @@ def apparent_repo_name(label_or_name):
     Returns:
         The apparent repository name
     """
-    repo_name = _repo_name(label_or_name).lstrip("@")
+    repo_name = getattr(label_or_name, _repo_attr, label_or_name).lstrip("@")
     delimiter_indices = []
 
     # Bazed on this pattern from the Bazel source:
@@ -49,44 +35,3 @@ def apparent_repo_name(label_or_name):
         return repo_name[:delimiter_indices[0]]
 
     return repo_name[delimiter_indices[-1] + 1:]
-
-def apparent_repo_label_string(label):
-    """Return a Label string starting with its apparent repo name.
-
-    Args:
-        label: a Label instance
-
-    Returns:
-        str(label) with its canonical repository name replaced with its apparent
-            repository name
-    """
-    repo_name = _repo_name(label)
-    if len(repo_name) == 0:
-        return str(label)
-
-    label_str = "@" + str(label).lstrip("@")
-    return label_str.replace(label.repo_name, apparent_repo_name(label))
-
-_IS_BZLMOD_ENABLED = str(Label("//:all")).startswith("@@")
-
-_MAIN_REPO_PREFIX = "@@//" if _IS_BZLMOD_ENABLED else "@//"
-
-def adjust_main_repo_prefix(target_pattern):
-    """Updates the main repo prefix to match the current Bazel version.
-
-    The main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel
-    >= 7.1.0 under Bzlmod. This macro automatically updates strings representing
-    include/exclude target patterns so that they match actual main repository
-    target Labels correctly.
-
-    Args:
-        target_pattern: a string used to match a BUILD target pattern
-
-    Returns:
-        the string with any main repository prefix updated to match the current
-            Bazel version
-    """
-    if target_pattern.startswith("@//") or target_pattern.startswith("@@//"):
-        return _MAIN_REPO_PREFIX + target_pattern.lstrip("@/")
-
-    return target_pattern

--- a/scala/private/macros/bzlmod.bzl
+++ b/scala/private/macros/bzlmod.bzl
@@ -1,5 +1,23 @@
 """Utilities for working with Bazel modules"""
 
+def _repo_name(label_or_name):
+    """Utility to provide Label compatibility with Bazel 5.
+
+    Under Bazel 5, calls `Label.workspace_name`. Otherwise calls
+    `Label.repo_name`.
+
+    Args:
+        label_or_name: a Label or repository name string
+
+    Returns:
+        The repository name returned directly from the Label API, or the
+            original string if not a Label
+    """
+    if hasattr(label_or_name, "repo_name"):
+        return label_or_name.repo_name
+
+    return getattr(label_or_name, "workspace_name", label_or_name)
+
 def apparent_repo_name(label_or_name):
     """Return a repository's apparent repository name.
 
@@ -12,7 +30,7 @@ def apparent_repo_name(label_or_name):
     Returns:
         The apparent repository name
     """
-    repo_name = getattr(label_or_name, "repo_name", label_or_name).lstrip("@")
+    repo_name = _repo_name(label_or_name).lstrip("@")
     delimiter_indices = []
 
     # Bazed on this pattern from the Bazel source:
@@ -42,13 +60,14 @@ def apparent_repo_label_string(label):
         str(label) with its canonical repository name replaced with its apparent
             repository name
     """
-    if len(label.repo_name) == 0:
+    repo_name = _repo_name(label)
+    if len(repo_name) == 0:
         return str(label)
 
     label_str = "@" + str(label).lstrip("@")
     return label_str.replace(label.repo_name, apparent_repo_name(label))
 
-_MAIN_REPO_PREFIX = str(Label("@@//:all")).split(":")[0]
+_MAIN_REPO_PREFIX = str(Label("//:all")).split(":")[0]
 
 def adjust_main_repo_prefix(target_pattern):
     """Updates the main repo prefix to match the current Bazel version.

--- a/scala/private/macros/bzlmod.bzl
+++ b/scala/private/macros/bzlmod.bzl
@@ -1,37 +1,21 @@
 """Utilities for working with Bazel modules"""
 
-_repo_attr = (
-    "repo_name" if hasattr(Label("//:all"), "repo_name") else "workspace_name"
-)
-
-def apparent_repo_name(label_or_name):
-    """Return a repository's apparent repository name.
-
-    Can be replaced with a future bazel-skylib implementation, if accepted into
-    that repo.
+def apparent_repo_name(repository_ctx):
+    """Generates a repository's apparent name from a repository_ctx object.
 
     Args:
-        label_or_name: a Label or repository name string
+        repository_ctx: a repository_ctx object
 
     Returns:
-        The apparent repository name
+        An apparent repo name derived from repository_ctx.name
     """
-    repo_name = getattr(label_or_name, _repo_attr, label_or_name).lstrip("@")
-    delimiter_indices = []
+    repo_name = repository_ctx.name
 
     # Bazed on this pattern from the Bazel source:
     # com.google.devtools.build.lib.cmdline.RepositoryName.VALID_REPO_NAME
-    for i in range(len(repo_name)):
+    for i in range(len(repo_name) - 1, -1, -1):
         c = repo_name[i]
         if not (c.isalnum() or c in "_-."):
-            delimiter_indices.append(i)
+            return repo_name[i + 1:]
 
-    if len(delimiter_indices) == 0:
-        # Already an apparent repo name, apparently.
-        return repo_name
-
-    if len(delimiter_indices) == 1:
-        # The name is for a top level module, possibly containing a version ID.
-        return repo_name[:delimiter_indices[0]]
-
-    return repo_name[delimiter_indices[-1] + 1:]
+    return repo_name

--- a/scala/private/macros/bzlmod.bzl
+++ b/scala/private/macros/bzlmod.bzl
@@ -1,0 +1,71 @@
+"""Utilities for working with Bazel modules"""
+
+def apparent_repo_name(label_or_name):
+    """Return a repository's apparent repository name.
+
+    Can be replaced with a future bazel-skylib implementation, if accepted into
+    that repo.
+
+    Args:
+        label_or_name: a Label or repository name string
+
+    Returns:
+        The apparent repository name
+    """
+    repo_name = getattr(label_or_name, "repo_name", label_or_name).lstrip("@")
+    delimiter_indices = []
+
+    # Bazed on this pattern from the Bazel source:
+    # com.google.devtools.build.lib.cmdline.RepositoryName.VALID_REPO_NAME
+    for i in range(len(repo_name)):
+        c = repo_name[i]
+        if not (c.isalnum() or c in "_-."):
+            delimiter_indices.append(i)
+
+    if len(delimiter_indices) == 0:
+        # Already an apparent repo name, apparently.
+        return repo_name
+
+    if len(delimiter_indices) == 1:
+        # The name is for a top level module, possibly containing a version ID.
+        return repo_name[:delimiter_indices[0]]
+
+    return repo_name[delimiter_indices[-1] + 1:]
+
+def apparent_repo_label_string(label):
+    """Return a Label string starting with its apparent repo name.
+
+    Args:
+        label: a Label instance
+
+    Returns:
+        str(label) with its canonical repository name replaced with its apparent
+            repository name
+    """
+    if len(label.repo_name) == 0:
+        return str(label)
+
+    label_str = "@" + str(label).lstrip("@")
+    return label_str.replace(label.repo_name, apparent_repo_name(label))
+
+_MAIN_REPO_PREFIX = str(Label("@@//:all")).split(":")[0]
+
+def adjust_main_repo_prefix(target_pattern):
+    """Updates the main repo prefix to match the current Bazel version.
+
+    The main repo prefix will be "@//" for Bazel < 7.1.0, and "@@//" for Bazel
+    >= 7.1.0 under Bzlmod. This macro automatically updates strings representing
+    include/exclude target patterns so that they match actual main repository
+    target Labels correctly.
+
+    Args:
+        target_pattern: a string used to match a BUILD target pattern
+
+    Returns:
+        the string with any main repository prefix updated to match the current
+            Bazel version
+    """
+    if target_pattern.startswith("@//") or target_pattern.startswith("@@//"):
+        return _MAIN_REPO_PREFIX + target_pattern.lstrip("@/")
+
+    return target_pattern

--- a/scala/private/macros/bzlmod.bzl
+++ b/scala/private/macros/bzlmod.bzl
@@ -11,7 +11,7 @@ def apparent_repo_name(repository_ctx):
     """
     repo_name = repository_ctx.name
 
-    # Bazed on this pattern from the Bazel source:
+    # Based on this pattern from the Bazel source:
     # com.google.devtools.build.lib.cmdline.RepositoryName.VALID_REPO_NAME
     for i in range(len(repo_name) - 1, -1, -1):
         c = repo_name[i]

--- a/scala/private/phases/phase_dependency.bzl
+++ b/scala/private/phases/phase_dependency.bzl
@@ -6,7 +6,6 @@ load(
     "get_strict_deps_mode",
     "new_dependency_info",
 )
-load("//scala/private:macros/bzlmod.bzl", "apparent_repo_label_string")
 load(
     "//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
@@ -38,7 +37,7 @@ def _phase_dependency(
         strict_deps_always_off):
     toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
 
-    target_label = apparent_repo_label_string(ctx.label)
+    target_label = str(ctx.label)
 
     included_in_strict_deps_analysis = _is_target_included(
         target_label,

--- a/scala/private/phases/phase_dependency.bzl
+++ b/scala/private/phases/phase_dependency.bzl
@@ -1,13 +1,14 @@
 # Gathers information about dependency mode and analysis
 
 load(
-    "@io_bazel_rules_scala//scala/private:dependency.bzl",
+    "//scala/private:dependency.bzl",
     "get_compiler_deps_mode",
     "get_strict_deps_mode",
     "new_dependency_info",
 )
+load("//scala/private:macros/bzlmod.bzl", "apparent_repo_label_string")
 load(
-    "@io_bazel_rules_scala//scala/private:paths.bzl",
+    "//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
     _java_extension = "java_extension",
 )
@@ -35,9 +36,9 @@ def _phase_dependency(
         p,
         unused_deps_always_off,
         strict_deps_always_off):
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
+    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
 
-    target_label = str(ctx.label)
+    target_label = apparent_repo_label_string(ctx.label)
 
     included_in_strict_deps_analysis = _is_target_included(
         target_label,

--- a/scala/private/resources.bzl
+++ b/scala/private/resources.bzl
@@ -1,3 +1,5 @@
+load(":macros/bzlmod.bzl", "apparent_repo_name")
+
 def paths(resources, resource_strip_prefix):
     """Return a list of path tuples (target, source) where:
         target - is a path in the archive (with given prefix stripped off)
@@ -13,7 +15,13 @@ def paths(resources, resource_strip_prefix):
 
 def _target_path(resource, resource_strip_prefix):
     path = _target_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else _target_path_by_default_prefixes(resource)
-    return _strip_prefix(path, "/")
+    return _update_external_target_path(_strip_prefix(path, "/"))
+
+def _update_external_target_path(target_path):
+    if not target_path.startswith("external/"):
+        return target_path
+    prefix, repo_name, rest = target_path.split("/")
+    return "/".join([prefix, apparent_repo_name(repo_name), rest])
 
 def _target_path_by_strip_prefix(resource, resource_strip_prefix):
     # Start from absolute resource path and then strip roots so we get to correct short path

--- a/scala/private/resources.bzl
+++ b/scala/private/resources.bzl
@@ -1,5 +1,3 @@
-load(":macros/bzlmod.bzl", "apparent_repo_name")
-
 def paths(resources, resource_strip_prefix):
     """Return a list of path tuples (target, source) where:
         target - is a path in the archive (with given prefix stripped off)
@@ -15,13 +13,7 @@ def paths(resources, resource_strip_prefix):
 
 def _target_path(resource, resource_strip_prefix):
     path = _target_path_by_strip_prefix(resource, resource_strip_prefix) if resource_strip_prefix else _target_path_by_default_prefixes(resource)
-    return _update_external_target_path(_strip_prefix(path, "/"))
-
-def _update_external_target_path(target_path):
-    if not target_path.startswith("external/"):
-        return target_path
-    prefix, repo_name, rest = target_path.split("/")
-    return "/".join([prefix, apparent_repo_name(repo_name), rest])
+    return _strip_prefix(path, "/")
 
 def _target_path_by_strip_prefix(resource, resource_strip_prefix):
     # Start from absolute resource path and then strip roots so we get to correct short path
@@ -51,6 +43,13 @@ def _target_path_by_default_prefixes(resource):
     (dir_1, dir_2, rel_path) = path.partition("java")
     if rel_path:
         return rel_path
+
+    # Looking inside an external repository. Trim off both the "external/" and
+    # the repository name components. Especially important under Bzlmod, because
+    # the canonical repository name may change between versions.
+    (dir_1, dir_2, rel_path) = path.partition("external/")
+    if rel_path:
+        return rel_path[rel_path.index("/"):]
 
     # Both short_path and path have quirks we wish to avoid, in short_path there are times where
     # it is prefixed by `../` instead of `external/`. And in .path it will instead return the entire

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -35,6 +35,7 @@ the following macros are defined below that utilize jvm_import_external:
 - java_import_external - to demonstrate that the original functionality of `java_import_external` stayed intact.
 """
 
+load("//scala/private:macros/bzlmod.bzl", "apparent_repo_name")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "read_user_netrc", "use_netrc")
 
 # https://github.com/bazelbuild/bazel/issues/13709#issuecomment-1336699672
@@ -64,7 +65,10 @@ def _jvm_import_external(repository_ctx):
     if (repository_ctx.attr.generated_linkable_rule_name and
         not repository_ctx.attr.neverlink):
         fail("Only use generated_linkable_rule_name if neverlink is set")
-    name = repository_ctx.attr.generated_rule_name or repository_ctx.name
+    name = (
+        repository_ctx.attr.generated_rule_name or
+        apparent_repo_name(repository_ctx.name)
+    )
     urls = repository_ctx.attr.jar_urls
     if repository_ctx.attr.jar_sha256:
         print("'jar_sha256' is deprecated. Please use 'artifact_sha256'")
@@ -136,7 +140,7 @@ def _jvm_import_external(repository_ctx):
         "",
         "alias(",
         "    name = \"jar\",",
-        "    actual = \"@%s\"," % repository_ctx.name,
+        "    actual = \"@%s\"," % apparent_repo_name(repository_ctx.name),
         ")",
         "",
     ]))

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -65,22 +65,20 @@ def _jvm_import_external(repository_ctx):
     if (repository_ctx.attr.generated_linkable_rule_name and
         not repository_ctx.attr.neverlink):
         fail("Only use generated_linkable_rule_name if neverlink is set")
-    name = (
-        repository_ctx.attr.generated_rule_name or
-        apparent_repo_name(repository_ctx.name)
-    )
+    repo_name = apparent_repo_name(repository_ctx)
+    name = repository_ctx.attr.generated_rule_name or repo_name
     urls = repository_ctx.attr.jar_urls
     if repository_ctx.attr.jar_sha256:
         print("'jar_sha256' is deprecated. Please use 'artifact_sha256'")
     sha = repository_ctx.attr.jar_sha256 or repository_ctx.attr.artifact_sha256
-    path = repository_ctx.name + ".jar"
+    path = repo_name + ".jar"
     for url in urls:
         if url.endswith(".jar"):
             path = url[url.rindex("/") + 1:]
             break
     srcurls = repository_ctx.attr.srcjar_urls
     srcsha = repository_ctx.attr.srcjar_sha256
-    srcpath = repository_ctx.name + "-src.jar" if srcurls else ""
+    srcpath = repo_name + "-src.jar" if srcurls else ""
     coordinates = repository_ctx.attr.coordinates
     for url in srcurls:
         if url.endswith(".jar"):
@@ -140,7 +138,7 @@ def _jvm_import_external(repository_ctx):
         "",
         "alias(",
         "    name = \"jar\",",
-        "    actual = \"@%s\"," % apparent_repo_name(repository_ctx.name),
+        "    actual = \"@%s\"," % repo_name,
         ")",
         "",
     ]))

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -138,7 +138,7 @@ def _jvm_import_external(repository_ctx):
         "",
         "alias(",
         "    name = \"jar\",",
-        "    actual = \"@%s\"," % repo_name,
+        "    actual = \"//:%s\"," % repo_name,
         ")",
         "",
     ]))

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -1,7 +1,5 @@
-load(
-    "@io_bazel_rules_scala//scala:providers.bzl",
-    _DepsInfo = "DepsInfo",
-)
+load("//scala/private:macros/bzlmod.bzl", "adjust_main_repo_prefix")
+load("//scala:providers.bzl", _DepsInfo = "DepsInfo")
 load(
     "@io_bazel_rules_scala_config//:config.bzl",
     "ENABLE_COMPILER_DEPENDENCY_TRACKING",
@@ -31,12 +29,12 @@ def _compute_dependency_tracking_method(
 
 def _partition_patterns(patterns):
     includes = [
-        pattern
+        adjust_main_repo_prefix(pattern)
         for pattern in patterns
         if not pattern.startswith("-")
     ]
     excludes = [
-        pattern.lstrip("-")
+        adjust_main_repo_prefix(pattern.lstrip("-"))
         for pattern in patterns
         if pattern.startswith("-")
     ]
@@ -108,15 +106,15 @@ def _scala_toolchain_impl(ctx):
 
 def _default_dep_providers():
     dep_providers = [
-        "@io_bazel_rules_scala//scala:scala_xml_provider",
-        "@io_bazel_rules_scala//scala:parser_combinators_provider",
-        "@io_bazel_rules_scala//scala:scala_compile_classpath_provider",
-        "@io_bazel_rules_scala//scala:scala_library_classpath_provider",
-        "@io_bazel_rules_scala//scala:scala_macro_classpath_provider",
+        "scala_xml",
+        "parser_combinators",
+        "scala_compile_classpath",
+        "scala_library_classpath",
+        "scala_macro_classpath",
     ]
-    if SCALA_MAJOR_VERSION.startswith("2"):
-        dep_providers.append("@io_bazel_rules_scala//scala:semanticdb_provider")
-    return dep_providers
+    if SCALA_MAJOR_VERSION.startswith("2."):
+        dep_providers.append("semanticdb")
+    return [Label("//scala:%s_provider" % p) for p in dep_providers]
 
 scala_toolchain = rule(
     _scala_toolchain_impl,

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -202,5 +202,5 @@ def scala_toolchain(**kwargs):
     _scala_toolchain(
         dependency_tracking_strict_deps_patterns = _expand_patterns(strict),
         dependency_tracking_unused_deps_patterns = _expand_patterns(unused),
-        **kwargs,
+        **kwargs
     )

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
@@ -8,7 +8,7 @@ class ScalaLibResourcesFromExternalDepTest extends SpecWithJUnit {
     "allow to load resources" >> {
 
       val expectedString = String.format("A resource%n"); //Using platform dependent newline (%n)
-      get("/external/test_new_local_repo/resource.txt") must beEqualTo(expectedString)
+      get("/resource.txt") must beEqualTo(expectedString)
   
     }
   }

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalScalaTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalScalaTest.scala
@@ -6,7 +6,7 @@ class ScalaLibResourcesFromExternalScalaTest extends AnyFunSuite {
 
   test("Scala library depending on resources from external resource-only jar should allow to load resources") {
     val expectedString = String.format("A resource%n"); //Using platform dependent newline (%n)
-    assert(get("/external/test_new_local_repo/resource.txt") === expectedString)
+    assert(get("/resource.txt") === expectedString)
   }
 
   private def get(s: String): String =

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -1,3 +1,4 @@
+load("//scala/private:macros/bzlmod.bzl", "apparent_repo_name")
 load(
     "//third_party/repositories:scala_2_11.bzl",
     _artifacts_2_11 = "artifacts",
@@ -102,14 +103,25 @@ def repositories(
     default_artifacts = artifacts_by_major_scala_version[major_scala_version]
     artifacts = dict(default_artifacts.items() + overriden_artifacts.items())
     for id in for_artifact_ids:
+        if id not in artifacts:
+            fail("artifact %s not in third_party/repositories/scala_%s.bzl" % (
+                id,
+                major_scala_version.replace(".", "_"),
+            ))
+
+        generated_rule_name = apparent_repo_name(id) + suffix
         _scala_maven_import_external(
             name = id + suffix,
+            generated_rule_name = generated_rule_name,
             artifact = artifacts[id]["artifact"],
             artifact_sha256 = artifacts[id]["sha256"],
             licenses = ["notice"],
             server_urls = maven_servers,
             deps = [dep + suffix for dep in artifacts[id].get("deps", [])],
-            runtime_deps = artifacts[id].get("runtime_deps", []),
+            runtime_deps = [
+                dep + suffix
+                for dep in artifacts[id].get("runtime_deps", [])
+            ],
             testonly_ = artifacts[id].get("testonly", False),
             fetch_sources = fetch_sources,
         )
@@ -118,13 +130,13 @@ def repositories(
         # See: https://github.com/bazelbuild/rules_scala/pull/1573
         # Hopefully we can deprecate and remove it one day.
         if suffix and scala_version == SCALA_VERSION:
-            _alias_repository(name = id, target = id + suffix)
+            _alias_repository(name = id, target = generated_rule_name)
 
 def _alias_repository_impl(rctx):
     """ Builds a repository containing just two aliases to the Scala Maven artifacts in the `target` repository. """
 
     format_kwargs = {
-        "name": rctx.name,
+        "name": apparent_repo_name(rctx.name),
         "target": rctx.attr.target,
     }
     rctx.file("BUILD", """alias(

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -109,10 +109,9 @@ def repositories(
                 major_scala_version.replace(".", "_"),
             ))
 
-        generated_rule_name = apparent_repo_name(id) + suffix
+        artifact_repo_name = id + suffix
         _scala_maven_import_external(
-            name = id + suffix,
-            generated_rule_name = generated_rule_name,
+            name = artifact_repo_name,
             artifact = artifacts[id]["artifact"],
             artifact_sha256 = artifacts[id]["sha256"],
             licenses = ["notice"],
@@ -130,13 +129,13 @@ def repositories(
         # See: https://github.com/bazelbuild/rules_scala/pull/1573
         # Hopefully we can deprecate and remove it one day.
         if suffix and scala_version == SCALA_VERSION:
-            _alias_repository(name = id, target = generated_rule_name)
+            _alias_repository(name = id, target = artifact_repo_name)
 
 def _alias_repository_impl(rctx):
     """ Builds a repository containing just two aliases to the Scala Maven artifacts in the `target` repository. """
 
     format_kwargs = {
-        "name": apparent_repo_name(rctx.name),
+        "name": apparent_repo_name(rctx),
         "target": rctx.attr.target,
     }
     rctx.file("BUILD", """alias(


### PR DESCRIPTION
### Description

Fixes various repository name related errors when building under Bzlmod, while remaining backwards compatible with `WORKSPACE`. See the first commit message for details on the problems solved by this change.

This change also includes a couple of other minor touch-ups:

- Updated the `runtime_deps` attribute in `repositories()` to add the Scala version suffix, just like `deps`.

- Added a `fail()` message to `repositories()` to make it more clear which Scala version dictionary is missing an artifact.

- Removed unnecessary internal uses of the `@io_bazel_rules_scala` repo name, applying `Label()` where necessary.

- Updated the construction of `dep_providers` in `_default_dep_providers` to remove the repo name, reduce duplication, and make the upcoming toolchain update slightly cleaner.

### Motivation

Part of adding Bzlmod support per #1482.

I've created bazelbuild/bazel-skylib#548 containing the `apparent_repo_name` macro with full unit tests. If the maintainers accept that change, we can bump our bazel_skylib version to use the macro from there, and remove the `bzlmod.bzl` file.