### PR TITLE
Update test scripts for Bzlmod compatibility

### DIFF
--- a/test/shell/test_coverage_equals_in_target.sh
+++ b/test/shell/test_coverage_equals_in_target.sh
@@ -4,8 +4,12 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
+
 test_coverage_target_name_contains_equals_sign() {
-    bazel coverage //test/coverage_filename_encoding:name-with-equals
+    bazel coverage \
+      --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+      //test/coverage_filename_encoding:name-with-equals
     diff test/coverage_filename_encoding/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_filename_encoding/name-with-equals/coverage.dat
 }
 

--- a/test/shell/test_coverage_equals_in_target.sh
+++ b/test/shell/test_coverage_equals_in_target.sh
@@ -4,6 +4,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.19 for `diff` tests because other versions change the output.
 SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
 
 test_coverage_target_name_contains_equals_sign() {

--- a/test/shell/test_coverage_scalatest.sh
+++ b/test/shell/test_coverage_scalatest.sh
@@ -4,15 +4,19 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
+
 test_coverage_on() {
-    bazel coverage //test/coverage_scalatest:test-scalatest
+    bazel coverage \
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        //test/coverage_scalatest:test-scalatest
     diff test/coverage_scalatest/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest/test-scalatest/coverage.dat
 }
 
 test_coverage_includes_test_targets() {
     bazel coverage \
-          --instrument_test_targets=True \
-          //test/coverage_scalatest:test-scalatest
+        --instrument_test_targets=True \
+        //test/coverage_scalatest:test-scalatest
     grep -q "SF:test/coverage_scalatest/TestWithScalaTest.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest/test-scalatest/coverage.dat
 }
 

--- a/test/shell/test_coverage_scalatest.sh
+++ b/test/shell/test_coverage_scalatest.sh
@@ -4,6 +4,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.19 for `diff` tests because other versions change the output.
 SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
 
 test_coverage_on() {

--- a/test/shell/test_coverage_scalatest_resources.sh
+++ b/test/shell/test_coverage_scalatest_resources.sh
@@ -4,17 +4,21 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
+
 test_coverage_succeeds_resource_call() {
     bazel coverage \
-          --instrumentation_filter=^//test/coverage_scalatest_resources[:/] \
-          //test/coverage_scalatest_resources/consumer:tests
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        --instrumentation_filter=^//test/coverage_scalatest_resources[:/] \
+        //test/coverage_scalatest_resources/consumer:tests
     diff test/coverage_scalatest_resources/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 
 test_coverage_includes_resource_test_targets() {
     bazel coverage \
-          --instrument_test_targets=True \
-          //test/coverage_scalatest_resources/consumer:tests
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        --instrument_test_targets=True \
+        //test/coverage_scalatest_resources/consumer:tests
     grep -q "SF:test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat
 }
 

--- a/test/shell/test_coverage_scalatest_resources.sh
+++ b/test/shell/test_coverage_scalatest_resources.sh
@@ -4,6 +4,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.19 for `diff` tests because other versions change the output.
 SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
 
 test_coverage_succeeds_resource_call() {
@@ -16,7 +17,6 @@ test_coverage_succeeds_resource_call() {
 
 test_coverage_includes_resource_test_targets() {
     bazel coverage \
-        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
         --instrument_test_targets=True \
         //test/coverage_scalatest_resources/consumer:tests
     grep -q "SF:test/coverage_scalatest_resources/consumer/src/test/scala/com/example/consumer/ConsumerSpec.scala" $(bazel info bazel-testlogs)/test/coverage_scalatest_resources/consumer/tests/coverage.dat

--- a/test/shell/test_coverage_specs2_with_junit.sh
+++ b/test/shell/test_coverage_specs2_with_junit.sh
@@ -4,15 +4,20 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
+
 test_coverage_on() {
-    bazel coverage //test/coverage_specs2_with_junit:test-specs2-with-junit
+    bazel coverage \
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        //test/coverage_specs2_with_junit:test-specs2-with-junit
     diff test/coverage_specs2_with_junit/expected-coverage.dat $(bazel info bazel-testlogs)/test/coverage_specs2_with_junit/test-specs2-with-junit/coverage.dat
 }
 
 test_coverage_includes_test_targets() {
     bazel coverage \
-          --instrument_test_targets=True \
-          //test/coverage_specs2_with_junit:test-specs2-with-junit
+        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
+        --instrument_test_targets=True \
+        //test/coverage_specs2_with_junit:test-specs2-with-junit
     grep -q "SF:test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala" $(bazel info bazel-testlogs)/test/coverage_specs2_with_junit/test-specs2-with-junit/coverage.dat
 }
 

--- a/test/shell/test_coverage_specs2_with_junit.sh
+++ b/test/shell/test_coverage_specs2_with_junit.sh
@@ -4,6 +4,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
+# Default to 2.12.19 for `diff` tests because other versions change the output.
 SCALA_VERSION="${SCALA_VERSION:-2.12.19}"
 
 test_coverage_on() {
@@ -15,7 +16,6 @@ test_coverage_on() {
 
 test_coverage_includes_test_targets() {
     bazel coverage \
-        --repo_env="SCALA_VERSION=${SCALA_VERSION}" \
         --instrument_test_targets=True \
         //test/coverage_specs2_with_junit:test-specs2-with-junit
     grep -q "SF:test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala" $(bazel info bazel-testlogs)/test/coverage_specs2_with_junit/test-specs2-with-junit/coverage.dat

--- a/test/shell/test_scala_config.sh
+++ b/test/shell/test_scala_config.sh
@@ -18,7 +18,8 @@ test_classpath_contains_2_13() {
 
 test_scala_config_content() {
   bazel build --repo_env=SCALA_VERSION=0.0.0 @io_bazel_rules_scala_config//:all 2> /dev/null
-  grep "SCALA_MAJOR_VERSION='0.0'" $(bazel info output_base)/external/io_bazel_rules_scala_config/config.bzl
+  grep "SCALA_MAJOR_VERSION='0.0'" \
+    "$(bazel info output_base)"/external/*io_bazel_rules_scala_config/config.bzl
 }
 
 $runner test_classpath_contains_2_12

--- a/test/shell/test_scala_library.sh
+++ b/test/shell/test_scala_library.sh
@@ -177,7 +177,7 @@ test_scala_library_expect_better_failure_with_target_label_from_stamped_jar_on_m
 
 test_scala_library_expect_better_failure_message_on_missing_transitive_dependency_labels_from_other_jvm_rules() {
   transitive_target='.*transitive_dependency_without_manifest.jar'
-  direct_target='@//test_expect_failure/missing_direct_deps/internal_deps:unstamped_direct_java_provider_dependency'
+  direct_target='@@?//test_expect_failure/missing_direct_deps/internal_deps:unstamped_direct_java_provider_dependency'
   test_target='//test_expect_failure/missing_direct_deps/internal_deps:unstamped_jar_dependent_on_some_java_provider'
 
   expected_message="Unknown label of file $transitive_target which came from $direct_target"

--- a/test/shell/test_semanticdb.sh
+++ b/test/shell/test_semanticdb.sh
@@ -24,7 +24,7 @@ test_produces_semanticdb(){
 
 
   if [ $is_bundle -eq 1 ]; then
-    local toolchain="--extra_toolchains=//test/semanticdb:semanticdb_bundle_toolchain"  
+    local toolchain="--extra_toolchains=//test/semanticdb:semanticdb_bundle_toolchain"
   else
     local toolchain="--extra_toolchains=//test/semanticdb:semanticdb_nobundle_toolchain"
   fi
@@ -36,7 +36,7 @@ test_produces_semanticdb(){
 
   bazel build //test/semanticdb:semantic_provider_vars_all  ${toolchain}  ${version_opt}
 
-  #semantic_provider_vars.sh contains the SemanticdbInfo data  
+  #semantic_provider_vars.sh contains the SemanticdbInfo data
   . $(bazel info bazel-bin)/test/semanticdb/semantic_provider_vars_all.sh
 
   #Check the Provider variables
@@ -61,7 +61,7 @@ test_produces_semanticdb(){
       echo "Error: SemanticdbInfo.target_root expected to be empty string"
       exit 1
     fi
-  fi 
+  fi
 
   if [[ $scala_majver == 3 ]] && [[ $semanticdb_pluginjarpath != "" ]]; then
     echo "Error: SemanticdbInfo.pluginjarpath expected to be empty for scala 3"
@@ -73,7 +73,7 @@ test_produces_semanticdb(){
   fi
 
   if [ $is_bundle -eq 0 ]; then
-    
+
     semanticdb_path="$(bazel info execution_root)/${semanticdb_target_root}/META-INF/semanticdb/test/semanticdb/"
 
     for arg in $FILES
@@ -85,8 +85,8 @@ test_produces_semanticdb(){
         fi
       done
   fi
-  
-  local JAR="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar" 
+
+  local JAR="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar"
 
   if [ $is_bundle -eq 0 ]; then
     if jar_contains_files $JAR $FILES; then
@@ -110,11 +110,11 @@ test_empty_semanticdb(){
 }
 
 test_no_semanticdb() {
-  #verify no semanticdb files have been generated in the bin dir or bundled in the jar 
+  #verify no semanticdb files have been generated in the bin dir or bundled in the jar
 
   set -e
 
-  local jar="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar" 
+  local jar="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar"
   local targetout_path="$(bazel info bazel-bin)/test/semanticdb"
 
   rm -rf $targetout_path #clean out the output dir for clean slate
@@ -137,7 +137,7 @@ test_no_semanticdb() {
 
 test_semanticdb_handles_removed_sourcefiles() {
   #Ensure absense of bug where bazel failed with 'access denied' on Windows when a source file was removed.
-  
+
   #First add the new scala file, build it, then remove the new scala file, and ensure it builds.
   set -e
 
@@ -151,7 +151,7 @@ test_semanticdb_handles_removed_sourcefiles() {
   mkdir -p $newfile_dir && echo "class D{ val a = 1; }" > $newfilepath
 
 
-  #make sure D.scala was added to the target (sanity check)      
+  #make sure D.scala was added to the target (sanity check)
   local query_result1=$(bazel query "labels(srcs, $rule_label)")
   if [[ $query_result1 != *"$newfilename"* ]] ; then
     echo "$newfilename was not properly added as src for target $rule_label"
@@ -162,30 +162,30 @@ test_semanticdb_handles_removed_sourcefiles() {
 
   #remove the new source file and build it
   rm $newfilepath
-  
+
   #make sure D.scala was properly removed from the target(sanity check)
   local query_result2=$(bazel query "labels(srcs, $rule_label)")
-  if  [[ $query_result2 == *"$newfilename"* ]] ; then    
+  if  [[ $query_result2 == *"$newfilename"* ]] ; then
     echo "$newfilename was not properly removed as src for target $rule_label"
     exit 1
   fi
-  
+
   bazel build $rule_label $toolchainArg
 
-  
+
 }
 
 run_semanticdb_tests() {
   local bundle=1;   local nobundle=0
   local scala3=3;    local scala2=2
-  
-  $runner test_produces_semanticdb $scala2 $bundle 
-  $runner test_produces_semanticdb $scala2 $nobundle 
-  
+
+  $runner test_produces_semanticdb $scala2 $bundle
+  $runner test_produces_semanticdb $scala2 $nobundle
+
   $runner test_empty_semanticdb
 
-  $runner test_produces_semanticdb $scala3 $bundle 
-  $runner test_produces_semanticdb $scala3 $nobundle 
+  $runner test_produces_semanticdb $scala3 $bundle
+  $runner test_produces_semanticdb $scala3 $nobundle
 
   $runner test_no_semanticdb
   $runner test_semanticdb_handles_removed_sourcefiles

--- a/test/shell/test_strict_dependency.sh
+++ b/test/shell/test_strict_dependency.sh
@@ -44,7 +44,8 @@ test_plus_one_ast_analyzer_strict_deps() {
 
 test_stamped_target_label_loading() {
   local test_target="//test_expect_failure/missing_direct_deps/external_deps:java_lib_with_a_transitive_external_dep"
-  local expected_message="buildozer 'add deps @io_bazel_rules_scala_guava//:io_bazel_rules_scala_guava' ${test_target}"
+  local missing_dep="@@?[a-z_.~+-]*io_bazel_rules_scala_guava[_0-9]*//:io_bazel_rules_scala_guava[_0-9]*"
+  local expected_message="buildozer 'add deps ${missing_dep}' ${test_target}"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message \
     "${expected_message}" ${test_target} \
@@ -69,7 +70,7 @@ test_strict_deps_filter_included_target() {
 
 test_demonstrate_INCORRECT_scala_proto_library_stamp() {
   local test_target="//test_expect_failure/missing_direct_deps/scala_proto_deps:uses_transitive_scala_proto"
-  local incorrectly_stamped_expected_message="buildozer 'add deps @//test_expect_failure/missing_direct_deps/scala_proto_deps:some_proto' ${test_target}"
+  local incorrectly_stamped_expected_message="buildozer 'add deps @@?//test_expect_failure/missing_direct_deps/scala_proto_deps:some_proto' ${test_target}"
 
   # When stamping is fixed, expected stamp is:
   # local correctly_stamped_expected_message="buildozer 'add deps //test_expect_failure/missing_direct_deps/scala_proto_deps:some_scala_proto' ${test_target}"
@@ -82,7 +83,7 @@ test_demonstrate_INCORRECT_scala_proto_library_stamp() {
 
 test_scala_proto_library_stamp_by_convention() {
   local test_target="//test_expect_failure/missing_direct_deps/scala_proto_deps:uses_transitive_scala_proto"
-  local expected_message="buildozer 'add deps @//test_expect_failure/missing_direct_deps/scala_proto_deps:some_scala_proto' ${test_target}"
+  local expected_message="buildozer 'add deps @@?//test_expect_failure/missing_direct_deps/scala_proto_deps:some_scala_proto' ${test_target}"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message \
     "${expected_message}" ${test_target} \
@@ -92,7 +93,7 @@ test_scala_proto_library_stamp_by_convention() {
 
 test_scala_proto_library_custom_phase_stamping() {
   local test_target="//test_expect_failure/missing_direct_deps/scala_proto_deps:uses_transitive_some_proto_custom_suffix"
-  local expected_message="buildozer 'add deps @//test_expect_failure/missing_direct_deps/scala_proto_deps:some_proto_custom_suffix' ${test_target}"
+  local expected_message="buildozer 'add deps @@?//test_expect_failure/missing_direct_deps/scala_proto_deps:some_proto_custom_suffix' ${test_target}"
 
   test_expect_failure_or_warning_on_missing_direct_deps_with_expected_message \
     "${expected_message}" ${test_target} \

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -54,7 +54,6 @@ scala_repositories(fetch_sources = True)
 
 load(":scrooge_repositories.bzl", "scrooge_repositories")
 ${twitter_scrooge_repositories}
-
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
 twitter_scrooge()
 


### PR DESCRIPTION
### Description

These are mostly small changes to make test assertions more flexible between `WORKSPACE` and Bzlmod runs.

For Bzlmod runs:

- Fixed `test_scala_config_content` from `test_scala_config.sh` by changing a path from `external/io_bazel_rules_scala_config` to `external/*io_bazel_rules_scala_config`.

- Fixed a number of tests by updating expected output messages to allow them to start with either `@//` or `@@//`.

- Fixed `test_stamped_target_label_loading` from `test/shell/test_strict_dependency.sh` by accommodating the canonical `io_bazel_rules_scala_guava` repo name. Also allows for the optional current Scala version suffix.

Also made these other important changes:

- Updated all the assertions in `test_helper.sh` to use Bash builtin regex matching via `_expect_failure_with_messages` instead of `grep`. This allows the expected message patterns to use full regular expressions while avoiding forking a new process. This new function helped reduce duplication in that file at the same time.

- Added `--repo_env="SCALA_VERSION=..."` to each test script called from `./test_coverage.sh`, and set `SCALA_VERSION` to 2.12.19 in each of these files. Using other Scala versions technically works, but the output is slightly different, causing the `diff` commands in the test cases to fail.

- Updated `test_version.sh` to copy the top level `.bazelversion` file into its test repo.

- Changed how `test_version.sh` handles injecting `twitter_scrooge` repos into the `WORKSPACE` file. This will make it easy to do the equivalent for `MODULE.bazel` when the time comes.

Also includes a few minor, opportunistic formatting cleanups.

### Motivation

Part of adding Bzlmod support per #1482.

I'm breaking this out to make sure the current default build configuration continues to pass as I carve off more of [my fork's Bzlmod working branch](https://github.com/mbland/rules_scala/commits/bzlmod/). At the same time, the later changes can land without including so many test changes.

cc: @BillyAutrey @jayconrod @benjaminp @TheGrizzlyDev