### PR TITLE
Bump to com.google.protobuf:protobuf-java:4.28.2

### DIFF
--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -288,8 +288,8 @@ artifacts = {
         ],
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.8.0",
-        "sha256": "94ba90a869ddad07eb49afaa8f39e676c2554b5b1c417ad9e1188257e79be60f",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.11:0.9.10",

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -285,8 +285,8 @@ artifacts = {
         "sha256": "52a8e02b1c90de686994a5f9818987cec44c5df97118e4b59fe2414227099c6a",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.12:0.9.14",

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -292,8 +292,8 @@ artifacts = {
         "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -272,8 +272,8 @@ artifacts = {
         "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.7.0",
-        "sha256": "dc7f93e3a3dc2c11be5ba9672af3e26410f0a3289312dbf2260d4d8a0c711a51",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -272,8 +272,8 @@ artifacts = {
         "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.7.0",
-        "sha256": "dc7f93e3a3dc2c11be5ba9672af3e26410f0a3289312dbf2260d4d8a0c711a51",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -272,8 +272,8 @@ artifacts = {
         "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",

--- a/third_party/repositories/scala_3_4.bzl
+++ b/third_party/repositories/scala_3_4.bzl
@@ -273,8 +273,8 @@ artifacts = {
         "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",

--- a/third_party/repositories/scala_3_5.bzl
+++ b/third_party/repositories/scala_3_5.bzl
@@ -273,8 +273,8 @@ artifacts = {
         "sha256": "a639a90e2d21bbafd8a5e213c65442aad200ee086951605cbda8835bc6ef11d3",
     },
     "com_google_protobuf_protobuf_java": {
-        "artifact": "com.google.protobuf:protobuf-java:3.10.0",
-        "sha256": "161d7d61a8cb3970891c299578702fd079646e032329d6c2cabf998d191437c9",
+        "artifact": "com.google.protobuf:protobuf-java:4.28.2",
+        "sha256": "707bccf406f4fc61b841d4700daa8d3e84db8ab499ef3481a060fa6a0f06e627",
     },
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.13:0.9.14",


### PR DESCRIPTION
### Description

Bumps every Scala version up to use protobuf-java:4.28.2. Part of #1482.

### Motivation

As part of my [Bzlmod exploration in my rules_scala fork](https://github.com/mbland/rules_scala/tree/bzlmod), I found that `//test/scalafmt/...` wouldn't build under Scala 2.13.14 due to using an outdated Scalafmt version (which I'll describe in a future PR). However, bumping to [Scalafmt 3.8.3](org.scalameta:scalafmt-core_2.13:3.8.3) produced:

```txt
$ bazel test //test/scalafmt/...

INFO: Analyzed 9 targets (80 packages loaded, 3307 targets configured).
ERROR: .../test/scalafmt/BUILD:43:20: ScalaFmt
  test/scalafmt/test/scalafmt/formatted/formatted-test.scala.fmt.output
  failed: Worker process did not return a WorkResponse:

---8<---8<--- Start of log, file at .../bazel-workers/worker-134-ScalaFmt.log ---8<---8<---
Exception in thread "main" java.lang.NoSuchMethodError:
  'boolean com.google.protobuf.GeneratedMessageV3.isStringEmpty(java.lang.Object)'
  [ ...snip... ]
```

This issue seemed to suggest a protobuf-java version bump might fix it, and it did:

- https://github.com/protocolbuffers/protobuf/issues/9236

Fortunately, even though this is a major version bump from 3.10.0 to 4.28.2, there were no compatibility issues, per:

> Protobuf major version releases may also be backwards-compatible with the last release of the previous major version. See the release notice for more details.
>
> - <https://github.com/protocolbuffers/protobuf/tree/main/java#compatibility-notice>

cc: @BillyAutrey @jayconrod @benjaminp @TheGrizzlyDev