### PR TITLE
Use custom repo rule to generate @scalafmt_default

### DIFF
--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -16,14 +16,14 @@ def _scalafmt_config_impl(repository_ctx):
     build.append("    visibility = [\"//visibility:public\"],")
     build.append(")\n")
 
-    repository_ctx.file('BUILD', "\n".join(build), executable = False)
+    repository_ctx.file("BUILD", "\n".join(build), executable = False)
     repository_ctx.symlink(repository_ctx.path(config_path), config_path.name)
 
 scalafmt_config = repository_rule(
     implementation = _scalafmt_config_impl,
     attrs = {
         "path": attr.label(mandatory = True, allow_single_file = True),
-    }
+    },
 )
 
 def scalafmt_default_config(path = ".scalafmt.conf", **kwargs):

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -7,14 +7,27 @@ load(
 load("//third_party/repositories:repositories.bzl", "repositories")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
-def scalafmt_default_config(path = ".scalafmt.conf"):
+def _scalafmt_config_impl(repository_ctx):
+    config_path = repository_ctx.attr.path
     build = []
     build.append("filegroup(")
     build.append("    name = \"config\",")
-    build.append("    srcs = [\"{}\"],".format(path))
+    build.append("    srcs = [\"{}\"],".format(config_path.name))
     build.append("    visibility = [\"//visibility:public\"],")
-    build.append(")")
-    native.new_local_repository(name = "scalafmt_default", build_file_content = "\n".join(build), path = "")
+    build.append(")\n")
+
+    repository_ctx.file('BUILD', "\n".join(build), executable = False)
+    repository_ctx.symlink(repository_ctx.path(config_path), config_path.name)
+
+scalafmt_config = repository_rule(
+    implementation = _scalafmt_config_impl,
+    attrs = {
+        "path": attr.label(mandatory = True, allow_single_file = True),
+    }
+)
+
+def scalafmt_default_config(path = ".scalafmt.conf", **kwargs):
+    scalafmt_config(name = "scalafmt_default", path = "//:" + path, **kwargs)
 
 _SCALAFMT_DEPS = [
     "org_scalameta_common",
@@ -60,6 +73,7 @@ def scalafmt_repositories(
 
 def _register_scalafmt_toolchains():
     for scala_version in SCALA_VERSIONS:
-        native.register_toolchains(
-            "@io_bazel_rules_scala//scala/scalafmt:scalafmt_toolchain" + version_suffix(scala_version),
-        )
+        native.register_toolchains(str(Label(
+            "//scala/scalafmt:scalafmt_toolchain" +
+            version_suffix(scala_version),
+        )))


### PR DESCRIPTION
### Description

Replaces `native.new_local_repository` in `scalafmt_default_config` with the new `scalafmt_config` repo rule. Also updates the `native.register_toolchains` call with a stringified `Label` to remove the hardcoding of `@io_bazel_rules_scala`.

Resolves an incompatibility between Bazel 6.5.0 and 7.3.2, while creating a much smaller `@scalafmt_default` repo. The problem is that under Bazel 7.3.2, calling `scalafmt_default_config` from a module extension produces this error:

```txt
$ bazel test //test/scalafmt/...

ERROR: Traceback (most recent call last):
  File ".../scala/extensions/deps.bzl",
    line 218, column 32, in _scala_deps_impl
    scalafmt_default_config()
  File ".../scala/scalafmt/scalafmt_repositories.bzl",
    line 18, column 32, in scalafmt_default_config
    native.new_local_repository(

Error in new_local_repository: The native module can be accessed only
  from a BUILD thread. Wrap the function in a macro and call it from a
  BUILD file
```

Ostensibly the solution is to replace `native.new_local_repository` with:

```py
load(
  "@bazel_tools//tools/build_defs/repo:local.bzl",
  "new_local_repository",
)
```

However, `local.bzl` isn't available in Bazel 6.5.0:

```txt
$ bazel test //test/scalafmt/...

ERROR: Error computing the main repository mapping:
  at .../scala/scalafmt/scalafmt_repositories.bzl:8:6:
cannot load '@bazel_tools//tools/build_defs/repo:local.bzl':
  no such file
```

The new `scalafmt_config` repository rule works under both Bazel 6.5.0 and 7.3.2, `WORKSPACE` and Bzlmod. Also, it symlinks only the single Scalafmt config file, instead of every top level file and directory in the project, as `new_local_repository` did.

### Motivation

Part of the Bzlmodification effort from #1482, to make `scalafmt_default_config` compatible with both `WORKSPACE` and `MODULE.bazel` under both Bazel 6 and 7.

Also, removing instances of `@io_bazel_rules_scala` with `Label`s reduces the project's dependency on this name. Bzlmod consumers will then be able to call `bazel_dep(name = "rules_scala", ...)` without having to set `repo_name = "io_bazel_rules_scala"`.