### PR TITLE
Build against latest bazel version instead of last_green

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -29,10 +29,10 @@ tasks:
     # Install xmllint
     - sudo apt update && sudo apt install --reinstall libxml2-utils -y
     - "./test_rules_scala.sh"
-  test_rules_scala_linux_last_green:
-    name: "./test_rules_scala (Bazel green head)"
+  test_rules_scala_linux_latest:
+    name: "./test_rules_scala (latest Bazel)"
     platform: ubuntu2004
-    bazel: last_green
+    bazel: latest
     shell_commands:
     # Install xmllint
     - sudo apt update && sudo apt install --reinstall libxml2-utils -y


### PR DESCRIPTION
### Description
Reverts https://github.com/bazelbuild/rules_scala/pull/1349

This task should be optional however it fails all builds because failing `bazel info`.

Error is related to workspace setup. Since we are in the process of moving to bzlmod I think we should not bother with that now. Especially when reproducing locally it gives different error.

### Motivation
Unblock pull requests.
