### PR TITLE
Update dependencyanalyzer3 for Scala 3.5

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala
@@ -18,7 +18,7 @@ class DependencyAnalyzer extends StandardPlugin:
     "dependencies which are directly included in the code, or " +
     "including unused dependencies."
 
-  def init(options: List[String]): List[PluginPhase] =
+  override def init(options: List[String]): List[PluginPhase] =
     (new DependencyAnalyzerPhase) :: Nil
 
 class DependencyAnalyzerPhase extends PluginPhase:


### PR DESCRIPTION
### Description

Avoids a future Scala 3.5 compatibility issue under Bzlmod. Part of #1482.

### Motivation

PR #1604 added Scala 3.5 suppport. I updated [my Bzlmod working branch](https://github.com/mbland/rules_scala/commits/bzlmod/) to include those changes, and updated `scala_3_5.bzl` with dependencies I'd added or updated from `scala_3_4.bzl`. `./test_examples.sh` then failed with the following error, which I recreated in the local `examples/scala3` repo:

```txt
$ bazel build --repo_env=SCALA_VERSION=3.5.0 //...

ERROR: .../external/rules_scala~/third_party/dependency_analyzer/src/main/BUILD:4:39:
  scala @@rules_scala~//third_party/dependency_analyzer/src/main:dependency_analyzer
  failed: (Exit 1): scalac_bootstrap failed:
  error executing Scalac command
  (from target @@rules_scala~//third_party/dependency_analyzer/src/main:dependency_analyzer)
  bazel-out/.../bin/external/rules_scala~/src/java/io/bazel/rulesscala/scalac/scalac_bootstrap
    ... (remaining 1 argument skipped)

-- [E164] Declaration Error:
    external/rules_scala~/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala:21:6
21 |  def init(options: List[String]): List[PluginPhase] =
   |      ^
   |error overriding method init in trait StandardPlugin of type (options: List[String]): List[dotty.tools.dotc.plugins.PluginPhase];
   |  method init of type (options: List[String]): List[dotty.tools.dotc.plugins.PluginPhase] needs `override` modifier
```

This may be because I bumped `io_bazel_rules_scala_scala_library_2` from `org.scala-lang:scala-library:2.13.12` to 2.13.14 in my Bzlmod branch. That's my guess based on information about the `dotty` packages from the following files:

- `third_party/utils/src/test/io/bazel/rulesscala/utils/Scala3CompilerUtils.scala`
- `third_party/dependency_analyzer/src/test/analyzer_test_scala_3.bzl`

It's interesting that Scala 3.{1,2,3,4} all passed with that `scala-library` version bump, but without this change, but I can't explain why.