### PR TITLE
Fix `dt_patches/dt_patch_test.sh` for Scala 2.13.0

### DIFF
--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -65,9 +65,6 @@ test_compiler_srcjar_error() {
   run_in_test_repo "bazel build //... --repo_env=SCALA_VERSION=${SCALA_VERSION} //..." "test_dt_patches_user_srcjar" 2>&1 | grep "$EXPECTED_ERROR"
 }
 
-run_test_local test_compiler_patch 2.12.1
-
-
 #run_test_local test_compiler_patch 2.11.0
 #run_test_local test_compiler_patch 2.11.1
 #run_test_local test_compiler_patch 2.11.2
@@ -122,9 +119,14 @@ run_test_local test_compiler_patch 2.13.15
 run_test_local test_compiler_srcjar_error 2.12.11
 run_test_local test_compiler_srcjar_error 2.12.12
 run_test_local test_compiler_srcjar_error 2.12.13
+
 # These tests are semi-stateful, if two tests are run sequentially with the
 # same Scala version, the DEBUG message about a canonical reproducible form
 # that we grep for will only be outputted the first time (on Bazel >= 6).
+# So we clean the repo first to ensure consistency.
+
+run_in_test_repo "bazel clean --expunge" "test_dt_patches_user_srcjar"
+
 run_test_local test_compiler_srcjar 2.12.14
 run_test_local test_compiler_srcjar 2.12.15
 run_test_local test_compiler_srcjar 2.12.16

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/BUILD
@@ -3,10 +3,12 @@ load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 filegroup(
     name = "deps_tracking_reporter",
     srcs = select_for_scala_version(
+        any_2_13_0 = ["before_2_12_13/DepsTrackingReporter.java"],
         any_3 = ["scala_3/DepsTrackingReporter.java"],
         before_2_12_13 = ["before_2_12_13/DepsTrackingReporter.java"],
-        between_2_12_13_and_2_13_12 = ["after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java"],
+        between_2_12_13_and_2_13 = ["after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java"],
         between_2_13_12_and_3 = ["after_2_13_12/DepsTrackingReporter.java"],
+        between_2_13_1_and_2_13_12 = ["after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java"],
     ),
     visibility = ["//visibility:public"],
 )

--- a/src/java/io/bazel/rulesscala/scalac/reporter/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/reporter/BUILD
@@ -5,27 +5,28 @@ load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 java_library(
     name = "reporter",
     srcs = select_for_scala_version(
-        before_2_12_13 = [
-            "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter",
+        any_2_13_0 = [
             "before_2_12_13/ProtoReporter.java",
         ],
-        between_2_12_13_and_2_13_12 = [
-            "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter",
+        before_2_12_13 = [
+            "before_2_12_13/ProtoReporter.java",
+        ],
+        between_2_12_13_and_2_13 = [
             "after_2_12_13_and_before_2_13_12/ProtoReporter.java",
         ],
         between_2_13_12_and_3 = [
-            "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter",
             "after_2_13_12/ProtoReporter.java",
+        ],
+        between_2_13_1_and_2_13_12 = [
+            "after_2_12_13_and_before_2_13_12/ProtoReporter.java",
         ],
         between_3_0_and_3_3 = glob(["scala_3/*.java"]) + [
             "since_3_before_3_3/CompilerCompat.java",
-            "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter",
         ],
         since_3_3 = glob(["scala_3/*.java"]) + [
             "since_3_3/CompilerCompat.java",
-            "//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter",
         ],
-    ),
+    ) + ["//src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter"],
     visibility = ["//visibility:public"],
     deps = [
         ":scala_deps_java_proto",


### PR DESCRIPTION
### Description

Updates targets broken under the Scala 2.13.0 test. Also removes the redundant 2.12.1 test, and cleans the `test_dt_patches_user_srcjar` repo before the `test_compiler_srcjar{,_nonhermetic}` tests. Part of #1482.

This fix and the `.bazelversion` sync from #1629 can land in either order. Both are required for `dt_patches/dt_patch_test.sh` to be fully functional.

### Motivation

The equivalent standalone command in `dt_patches/test_dt_patches` produced the error:

```txt
$ bazel build //... --repo_env=SCALA_VERSION=2.13.0 //...

ERROR: .../rules_scala~/src/java/io/bazel/rulesscala/scalac/reporter/BUILD:5:13:
  Building external/rules_scala~/src/java/io/bazel/rulesscala/scalac/reporter/libreporter.jar
  (2 source files) [for tool] failed: (Exit 1): java failed:
  error executing Javac command
  (from target @@rules_scala~//src/java/io/bazel/rulesscala/scalac/reporter:reporter)
  external/rules_java~~toolchains~remotejdk21_macos_aarch64/bin/java
    '--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED'
    '--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED' ...
    (remaining 19 arguments skipped)

external/rules_scala~/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/
  after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java:85:
  error: method does not override or implement a method from a supertype
  @Override
  ^

external/rules_scala~/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/
  after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java:94:
  error: cannot find symbol
    ((FilteringReporter) delegateReporter).doReport(pos, msg, severity);
                                          ^
  symbol:   method doReport(Position,String,Reporter.Severity)
  location: interface FilteringReporter

external/rules_scala~/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java:99:
  error: cannot find symbol
    super.doReport(pos, msg, severity);
         ^
  symbol: method doReport(Position,String,Reporter.Severity)

external/rules_scala~/src/java/io/bazel/rulesscala/scalac/reporter/after_2_12_13_and_before_2_13_12/ProtoReporter.java:49:
  error: method does not override or implement a method from a supertype
    @Override
    ^

external/rules_scala~/src/java/io/bazel/rulesscala/scalac/reporter/after_2_12_13_and_before_2_13_12/ProtoReporter.java:51:
  error: cannot find symbol
    super.doReport(pos, msg, severity);
         ^
  symbol: method doReport(Position,String,Reporter.Severity)

Target //dummy:dummy failed to build
```

I had the thought that maybe 2.13.0 could use the same `srcs` as the `before_2_12_13` targets. So I abused the `any` matcher to pick exactly 2.13.0 and assign it the same values as `before_2_12_13`. Now it works, and `dt_patches/dt_patch_test.sh` fully passes.

---

Cleaning the `test_dt_patches_user_srcjar` repository helps ensure that the `test_compiler_srcjar_nonhermetic` runs, in particular, don't fail after the first run.