### PR TITLE
Toolchainize //scala:toolchain_type

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,11 +39,18 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
-load("//scala:scala.bzl", "rules_scala_setup", "rules_scala_toolchain_deps_repositories")
+load(
+    "//scala:scala.bzl",
+    "rules_scala_setup",
+    "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
+)
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -39,18 +39,16 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
-load(
-    "//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
+load("//scala:scala.bzl", "scala_toolchains")
+
+scala_toolchains(fetch_sources = True)
+
+register_toolchains(
+    "//testing:testing_toolchain",
+    "//scala:unused_dependency_checker_error_toolchain",
+    "//test/proto:scalapb_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-rules_scala_setup()
-
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -89,8 +87,6 @@ load("//specs2:specs2_junit.bzl", "specs2_junit_repositories")
 
 specs2_junit_repositories()
 
-register_toolchains("//testing:testing_toolchain")
-
 load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_default_config", "scalafmt_repositories")
 
 scalafmt_default_config()
@@ -121,12 +117,6 @@ local_repository(
     name = "example_external_workspace",
     path = "third_party/test/example_external_workspace",
 )
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_toolchains")
-
-scala_register_unused_deps_toolchains()
-
-register_toolchains("@io_bazel_rules_scala//test/proto:scalapb_toolchain")
 
 load("//scala:scala_maven_import_external.bzl", "java_import_external")
 

--- a/dt_patches/test_dt_patches/WORKSPACE
+++ b/dt_patches/test_dt_patches/WORKSPACE
@@ -35,6 +35,7 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
@@ -110,6 +111,8 @@ rules_scala_toolchain_deps_repositories(
     fetch_sources = True,
     validate_scala_version = False,
 )
+
+scala_toolchains_repo()
 
 register_toolchains(":dt_scala_toolchain")
 

--- a/dt_patches/test_dt_patches/WORKSPACE
+++ b/dt_patches/test_dt_patches/WORKSPACE
@@ -31,12 +31,7 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
@@ -105,16 +100,15 @@ scala_maven_import_external(
     server_urls = default_maven_server_urls(),
 )
 
-rules_scala_setup()
-
-rules_scala_toolchain_deps_repositories(
+scala_toolchains(
     fetch_sources = True,
     validate_scala_version = False,
 )
 
-scala_toolchains_repo()
-
-register_toolchains(":dt_scala_toolchain")
+register_toolchains(
+    ":dt_scala_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
+)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -31,12 +31,7 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
@@ -183,16 +178,16 @@ srcjars_by_version = {
     },
 }
 
-rules_scala_setup(scala_compiler_srcjar = srcjars_by_version[SCALA_VERSION])
-
-rules_scala_toolchain_deps_repositories(
+scala_toolchains(
     fetch_sources = True,
+    scala_compiler_srcjars = srcjars_by_version,
     validate_scala_version = False,
 )
 
-scala_toolchains_repo()
-
-register_toolchains(":dt_scala_toolchain")
+register_toolchains(
+    ":dt_scala_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
+)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -209,7 +204,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -35,6 +35,7 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 load(
     "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
@@ -188,6 +189,8 @@ rules_scala_toolchain_deps_repositories(
     fetch_sources = True,
     validate_scala_version = False,
 )
+
+scala_toolchains_repo()
 
 register_toolchains(":dt_scala_toolchain")
 

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -42,11 +42,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories()
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -38,18 +38,11 @@ scala_config(
     ],
 )
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-rules_scala_setup()
+scala_toolchains()
 
-rules_scala_toolchain_deps_repositories()
-
-scala_toolchains_repo()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -60,10 +60,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()
-
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
 
 scalatest_repositories()

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -31,18 +31,11 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(scala_version = "3.5.2")
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-rules_scala_setup()
+scala_toolchains(fetch_sources = True)
 
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -52,7 +52,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -35,11 +35,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/semanticdb/WORKSPACE
+++ b/examples/semanticdb/WORKSPACE
@@ -34,18 +34,15 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(scala_version = "2.13.15")
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
+
+scala_toolchains(fetch_sources = True)
+
+register_toolchains(
+    #Register and use the custom toolchain that has semanticdb enabled
+    "//:semanticdb_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-rules_scala_setup()
-
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -62,8 +59,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-#Register and use the custom toolchain that has semanticdb enabled
-register_toolchains(
-    "//:semanticdb_toolchain",
-)

--- a/examples/semanticdb/WORKSPACE
+++ b/examples/semanticdb/WORKSPACE
@@ -38,11 +38,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -35,11 +35,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -56,10 +56,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()
-
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories")
 load("@io_bazel_rules_scala//testing:junit.bzl", "junit_repositories")
 load("@io_bazel_rules_scala//testing:specs2_junit.bzl", "specs2_junit_repositories")

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -31,18 +31,14 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
+
+scala_toolchains(fetch_sources = True)
+
+register_toolchains(
+    ":testing_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-rules_scala_setup()
-
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -73,5 +69,3 @@ scalatest_repositories()
 junit_repositories()
 
 specs2_junit_repositories()
-
-register_toolchains(":testing_toolchain")

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -31,18 +31,11 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-rules_scala_setup()
+scala_toolchains(fetch_sources = True)
 
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -35,11 +35,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -53,10 +53,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()
-
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
 
 scalatest_repositories()

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -31,18 +31,11 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-rules_scala_setup()
+scala_toolchains(fetch_sources = True)
 
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -35,11 +35,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -53,10 +53,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()
-
 load("@io_bazel_rules_scala//testing:specs2_junit.bzl", "specs2_junit_repositories", "specs2_junit_toolchain")
 
 specs2_junit_repositories()

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -1,4 +1,5 @@
-load("//scala:scala.bzl", "scala_binary", "scala_library")
+load("//scala/private:rules/scala_binary.bzl", "scala_binary")
+load("//scala/private:rules/scala_library.bzl", "scala_library")
 load(
     "//scala:scala_cross_version.bzl",
     "default_maven_server_urls",

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -1,42 +1,48 @@
-load("@rules_java//java:defs.bzl", "java_import", "java_library")
-load("//scala:providers.bzl", "declare_deps_provider")
 load("//scala:scala_cross_version.bzl", "version_suffix")
-load("//scala/private:macros/setup_scala_toolchain.bzl", "default_deps", "setup_scala_toolchain")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
+load("//scala:scala_toolchain.bzl", "scala_toolchain")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+load("@rules_java//java:defs.bzl", "java_import", "java_library")
 
 toolchain_type(
     name = "toolchain_type",
     visibility = ["//visibility:public"],
 )
 
-[
-    setup_scala_toolchain(
-        name = "toolchain" + version_suffix(scala_version),
-        scala_version = scala_version,
-        use_argument_file_in_runner = True,
-    )
-    for scala_version in SCALA_VERSIONS
-]
-
 # Alias for backward compatibility
 alias(
     name = "default_toolchain",
-    actual = "toolchain" + version_suffix(SCALA_VERSION),
+    actual = (
+        "@io_bazel_rules_scala_toolchains//scala:toolchain" +
+        version_suffix(SCALA_VERSION)
+    ),
 )
 
-setup_scala_toolchain(
-    name = "unused_dependency_checker_error_toolchain",
+scala_toolchain(
+    name = "unused_dependency_checker_error_toolchain_impl",
     dependency_tracking_method = "ast-plus",
     unused_dependency_checker_mode = "error",
 )
 
-setup_scala_toolchain(
-    name = "minimal_direct_source_deps",
+scala_toolchain(
+    name = "minimal_direct_source_deps_impl",
     dependency_mode = "plus-one",
     dependency_tracking_method = "ast",
     strict_deps_mode = "error",
     unused_dependency_checker_mode = "error",
 )
+
+[
+    toolchain(
+        name = tc,
+        toolchain = tc + "_impl",
+        toolchain_type = "//scala:toolchain_type",
+        visibility = ["//visibility:public"],
+    )
+    for tc in [
+        "unused_dependency_checker_error_toolchain",
+        "minimal_direct_source_deps",
+    ]
+]
 
 java_import(
     name = "bazel_test_runner_deploy",
@@ -48,46 +54,4 @@ java_library(
     name = "PlaceHolderClassToCreateEmptyJarForScalaImport",
     srcs = ["PlaceHolderClassToCreateEmptyJarForScalaImport.java"],
     visibility = ["//visibility:public"],
-)
-
-declare_deps_provider(
-    name = "scala_compile_classpath_provider",
-    deps_id = "scala_compile_classpath",
-    visibility = ["//visibility:public"],
-    deps = default_deps("scala_compile_classpath", SCALA_VERSION),
-)
-
-declare_deps_provider(
-    name = "scala_library_classpath_provider",
-    deps_id = "scala_library_classpath",
-    visibility = ["//visibility:public"],
-    deps = default_deps("scala_library_classpath", SCALA_VERSION),
-)
-
-declare_deps_provider(
-    name = "scala_macro_classpath_provider",
-    deps_id = "scala_macro_classpath",
-    visibility = ["//visibility:public"],
-    deps = default_deps("scala_macro_classpath", SCALA_VERSION),
-)
-
-declare_deps_provider(
-    name = "scala_xml_provider",
-    deps_id = "scala_xml",
-    visibility = ["//visibility:public"],
-    deps = default_deps("scala_xml", SCALA_VERSION),
-)
-
-declare_deps_provider(
-    name = "parser_combinators_provider",
-    deps_id = "parser_combinators",
-    visibility = ["//visibility:public"],
-    deps = default_deps("parser_combinators", SCALA_VERSION),
-)
-
-declare_deps_provider(
-    name = "semanticdb_provider",
-    deps_id = "semanticdb",
-    visibility = ["//visibility:public"],
-    deps = default_deps("semanticdb", SCALA_VERSION),
 )

--- a/scala/private/extensions/toolchains.bzl
+++ b/scala/private/extensions/toolchains.bzl
@@ -1,0 +1,75 @@
+"""Creates a repo containing Scala toolchain packages"""
+
+def _scala_toolchains_repo_impl(repository_ctx):
+    repo_attr = repository_ctx.attr
+    format_args = {
+        "rules_scala_repo": Label("//:all").repo_name,
+    }
+    toolchains = {}
+
+    if repo_attr.scala:
+        toolchains["scala"] = _SCALA_TOOLCHAIN_BUILD
+
+    if len(toolchains) == 0:
+        fail("no toolchains specified")
+
+    for pkg, build in toolchains.items():
+        repository_ctx.file(
+            pkg + "/BUILD",
+            content = build.format(**format_args),
+            executable = False,
+        )
+
+_scala_toolchains_repo = repository_rule(
+    implementation = _scala_toolchains_repo_impl,
+    attrs = {
+        "scala": attr.bool(default = True),
+    },
+)
+
+def scala_toolchains_repo(**kwargs):
+    _scala_toolchains_repo(
+        name = "io_bazel_rules_scala_toolchains",
+        **kwargs
+    )
+
+_SCALA_TOOLCHAIN_BUILD = """
+load(
+    "@@{rules_scala_repo}//scala/private:macros/setup_scala_toolchain.bzl",
+    "default_deps",
+    "setup_scala_toolchain",
+)
+load("@@{rules_scala_repo}//scala:providers.bzl", "declare_deps_provider")
+load("@@{rules_scala_repo}//scala:scala_cross_version.bzl", "version_suffix")
+load(
+    "@io_bazel_rules_scala_config//:config.bzl",
+    "SCALA_VERSION",
+    "SCALA_VERSIONS",
+)
+
+[
+    setup_scala_toolchain(
+        name = "toolchain" + version_suffix(scala_version),
+        scala_version = scala_version,
+        use_argument_file_in_runner = True,
+    )
+    for scala_version in SCALA_VERSIONS
+]
+
+[
+    declare_deps_provider(
+        name = deps_id + "_provider",
+        deps_id = deps_id,
+        visibility = ["//visibility:public"],
+        deps = default_deps(deps_id, SCALA_VERSION),
+    )
+    for deps_id in [
+        "scala_xml",
+        "parser_combinators",
+        "scala_compile_classpath",
+        "scala_library_classpath",
+        "scala_macro_classpath",
+        "semanticdb",
+    ]
+]
+"""

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -193,11 +193,6 @@ def _setup_scala_compiler_sources(srcjars = {}):
         scala_versions = SCALA_VERSIONS,
     )
 
-    compiler_sources_repo(
-        name = "scala_compiler_sources",
-        scala_versions = SCALA_VERSIONS,
-    )
-
 def _artifact_ids(scala_version):
     result = [
         "io_bazel_rules_scala_scala_compiler",

--- a/scala/private/macros/setup_scala_toolchain.bzl
+++ b/scala/private/macros/setup_scala_toolchain.bzl
@@ -1,6 +1,6 @@
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//scala:providers.bzl", "declare_deps_provider")
-load("//scala:scala_cross_version.bzl", "version_suffix")
+load("//scala:scala_cross_version.bzl", "repositories", "version_suffix")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 def setup_scala_toolchain(
@@ -97,7 +97,7 @@ def setup_scala_toolchain(
     native.toolchain(
         name = name,
         toolchain = ":%s_impl" % name,
-        toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+        toolchain_type = Label("//scala:toolchain_type"),
         target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(scala_version)],
         visibility = visibility,
     )
@@ -155,4 +155,4 @@ _DEFAULT_DEPS = {
 def default_deps(deps_id, scala_version):
     versions = _DEFAULT_DEPS[deps_id]
     deps = versions.get("any", []) + versions.get(scala_version[0], [])
-    return [dep + version_suffix(scala_version) for dep in deps]
+    return repositories(scala_version, deps)

--- a/scala/private/macros/toolchains.bzl
+++ b/scala/private/macros/toolchains.bzl
@@ -11,8 +11,7 @@ def scala_toolchains(
         load_scala_toolchain_dependencies = True,
         fetch_sources = False,
         validate_scala_version = True,
-        scala_compiler_srcjars = {},
-        scala = True):
+        scala_compiler_srcjars = {}):
     """Instantiates @io_bazel_rules_scala_toolchains and all its dependencies.
 
     Provides a unified interface to configuring rules_scala both directly in a
@@ -52,24 +51,16 @@ def scala_toolchains(
             compiler srcjar metadata dictionaries containing:
             - exactly one "label", "url", or "urls" key
             - optional "integrity" or "sha256" keys
-        scala: whether to instantiate the core Scala toolchain
     """
-    num_toolchains = 0
+    scala_repositories(
+        maven_servers = maven_servers,
+        # Note the internal macro parameter misspells "overriden".
+        overriden_artifacts = overridden_artifacts,
+        load_dep_rules = load_rules_scala_dependencies,
+        load_jar_deps = load_scala_toolchain_dependencies,
+        fetch_sources = fetch_sources,
+        validate_scala_version = validate_scala_version,
+        scala_compiler_srcjars = scala_compiler_srcjars,
+    )
 
-    if scala:
-        num_toolchains += 1
-        scala_repositories(
-            maven_servers = maven_servers,
-            # Note the internal macro parameter misspells "overriden".
-            overriden_artifacts = overridden_artifacts,
-            load_dep_rules = load_rules_scala_dependencies,
-            load_jar_deps = load_scala_toolchain_dependencies,
-            fetch_sources = fetch_sources,
-            validate_scala_version = validate_scala_version,
-            scala_compiler_srcjars = scala_compiler_srcjars,
-        )
-
-    if num_toolchains != 0:
-        scala_toolchains_repo(
-            scala = scala,
-        )
+    scala_toolchains_repo()

--- a/scala/private/macros/toolchains.bzl
+++ b/scala/private/macros/toolchains.bzl
@@ -1,0 +1,75 @@
+"""Macro to instantiate @io_bazel_rules_scala_toolchains"""
+
+load(":macros/toolchains_repo.bzl", "scala_toolchains_repo")
+load("//scala/private:macros/scala_repositories.bzl", "scala_repositories")
+load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
+
+def scala_toolchains(
+        maven_servers = default_maven_server_urls(),
+        overridden_artifacts = {},
+        load_rules_scala_dependencies = True,
+        load_scala_toolchain_dependencies = True,
+        fetch_sources = False,
+        validate_scala_version = True,
+        scala_compiler_srcjars = {},
+        scala = True):
+    """Instantiates @io_bazel_rules_scala_toolchains and all its dependencies.
+
+    Provides a unified interface to configuring rules_scala both directly in a
+    `WORKSPACE` file and in a Bazel module extension.
+
+    Instantiates the `@io_bazel_rules_scala_toolchains` repository. Under
+    `WORKSPACE`, you will need to call `register_toolchains` at some point.
+    Under Bzlmod, rules_scala does this automatically.
+
+    ```starlark
+    register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+    ```
+
+    All arguments are optional.
+
+    Args:
+        maven_servers: Maven servers used to fetch dependency jar files
+        overridden_artifacts: specific dependency jar files to use instead of
+            those from `maven_servers`, in the format:
+            ```starlark
+            "repo_name": {
+                "artifact": "<maven coordinates>",
+                "sha256": "<checksum>",
+                "deps": [
+                    "repository_names_of_dependencies",
+                ],
+            }
+            ```
+        load_rules_scala_dependencies: whether load rules_scala repository
+            dependencies
+        load_scala_toolchain_dependencies: whether to load repository
+            dependencies of the core Scala language toolchain
+        fetch_sources: whether to download dependency source jars
+        validate_scala_version: whether to check if the configured Scala version
+            matches the default version supported by rules_scala
+        scala_compiler_srcjars: optional dictionary of Scala version string to
+            compiler srcjar metadata dictionaries containing:
+            - exactly one "label", "url", or "urls" key
+            - optional "integrity" or "sha256" keys
+        scala: whether to instantiate the core Scala toolchain
+    """
+    num_toolchains = 0
+
+    if scala:
+        num_toolchains += 1
+        scala_repositories(
+            maven_servers = maven_servers,
+            # Note the internal macro parameter misspells "overriden".
+            overriden_artifacts = overridden_artifacts,
+            load_dep_rules = load_rules_scala_dependencies,
+            load_jar_deps = load_scala_toolchain_dependencies,
+            fetch_sources = fetch_sources,
+            validate_scala_version = validate_scala_version,
+            scala_compiler_srcjars = scala_compiler_srcjars,
+        )
+
+    if num_toolchains != 0:
+        scala_toolchains_repo(
+            scala = scala,
+        )

--- a/scala/private/macros/toolchains_repo.bzl
+++ b/scala/private/macros/toolchains_repo.bzl
@@ -1,4 +1,4 @@
-"""Creates a repo containing Scala toolchain packages"""
+"""Repository rule to instantiate @io_bazel_rules_scala_toolchains"""
 
 def _scala_toolchains_repo_impl(repository_ctx):
     repo_attr = repository_ctx.attr

--- a/scala/private/macros/toolchains_repo.bzl
+++ b/scala/private/macros/toolchains_repo.bzl
@@ -27,9 +27,9 @@ _scala_toolchains_repo = repository_rule(
     },
 )
 
-def scala_toolchains_repo(**kwargs):
+def scala_toolchains_repo(name = "io_bazel_rules_scala_toolchains", **kwargs):
     _scala_toolchains_repo(
-        name = "io_bazel_rules_scala_toolchains",
+        name = name,
         **kwargs
     )
 

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -3,7 +3,11 @@ load(
     _specs2_junit_dependencies = "specs2_junit_dependencies",
 )
 load(
-    "//scala/private/extensions:toolchains.bzl",
+    "//scala/private:macros/toolchains.bzl",
+    _scala_toolchains = "scala_toolchains",
+)
+load(
+    "//scala/private:macros/toolchains_repo.bzl",
     _scala_toolchains_repo = "scala_toolchains_repo",
 )
 load(
@@ -85,4 +89,5 @@ scala_test = _scala_test
 scala_test_suite = _scala_test_suite
 setup_scala_testing_toolchain = _setup_scala_testing_toolchain
 setup_scala_toolchain = _setup_scala_toolchain
+scala_toolchains = _scala_toolchains
 scala_toolchains_repo = _scala_toolchains_repo

--- a/scala/scala.bzl
+++ b/scala/scala.bzl
@@ -1,49 +1,53 @@
 load(
-    "@io_bazel_rules_scala//specs2:specs2_junit.bzl",
+    "//specs2:specs2_junit.bzl",
     _specs2_junit_dependencies = "specs2_junit_dependencies",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:macros/scala_repositories.bzl",
+    "//scala/private/extensions:toolchains.bzl",
+    _scala_toolchains_repo = "scala_toolchains_repo",
+)
+load(
+    "//scala/private:macros/scala_repositories.bzl",
     _rules_scala_setup = "rules_scala_setup",
     _rules_scala_toolchain_deps_repositories = "rules_scala_toolchain_deps_repositories",
     _scala_repositories = "scala_repositories",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:macros/setup_scala_toolchain.bzl",
+    "//scala/private:macros/setup_scala_toolchain.bzl",
     _setup_scala_toolchain = "setup_scala_toolchain",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_binary.bzl",
+    "//scala/private:rules/scala_binary.bzl",
     _scala_binary = "scala_binary",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_doc.bzl",
+    "//scala/private:rules/scala_doc.bzl",
     _ScaladocAspectInfo = "ScaladocAspectInfo",
     _make_scala_doc_rule = "make_scala_doc_rule",
     _scaladoc_intransitive_aspect = "scaladoc_intransitive_aspect",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_junit_test.bzl",
+    "//scala/private:rules/scala_junit_test.bzl",
     _scala_junit_test = "scala_junit_test",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_library.bzl",
+    "//scala/private:rules/scala_library.bzl",
     _scala_library = "scala_library",
     _scala_library_for_plugin_bootstrapping = "scala_library_for_plugin_bootstrapping",
     _scala_library_suite = "scala_library_suite",
     _scala_macro_library = "scala_macro_library",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_repl.bzl",
+    "//scala/private:rules/scala_repl.bzl",
     _scala_repl = "scala_repl",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_test.bzl",
+    "//scala/private:rules/scala_test.bzl",
     _scala_test = "scala_test",
     _scala_test_suite = "scala_test_suite",
 )
 load(
-    "@io_bazel_rules_scala//testing:testing.bzl",
+    "//testing:testing.bzl",
     _setup_scala_testing_toolchain = "setup_scala_testing_toolchain",
 )
 
@@ -81,3 +85,4 @@ scala_test = _scala_test
 scala_test_suite = _scala_test_suite
 setup_scala_testing_toolchain = _setup_scala_testing_toolchain
 setup_scala_toolchain = _setup_scala_toolchain
+scala_toolchains_repo = _scala_toolchains_repo

--- a/scala/scala_cross_version.bzl
+++ b/scala/scala_cross_version.bzl
@@ -52,6 +52,11 @@ def sanitize_version(scala_version):
 def version_suffix(scala_version):
     return "_" + sanitize_version(scala_version)
 
+def repositories(scala_version, repos):
+    """Adds the Scala version suffix to a list of repository IDs."""
+    suffix = version_suffix(scala_version)
+    return [repo + suffix for repo in repos]
+
 def _scala_version_transition_impl(settings, attr):
     if attr.scala_version:
         return {"@io_bazel_rules_scala_config//:scala_version": attr.scala_version}

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -113,7 +113,10 @@ def _default_dep_providers():
     ]
     if SCALA_MAJOR_VERSION.startswith("2."):
         dep_providers.append("semanticdb")
-    return [Label("//scala:%s_provider" % p) for p in dep_providers]
+    return [
+        "@io_bazel_rules_scala_toolchains//scala:%s_provider" % p
+        for p in dep_providers
+    ]
 
 _scala_toolchain = rule(
     _scala_toolchain_impl,

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -1,12 +1,5 @@
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
-
 def scala_register_toolchains():
-    for scala_version in SCALA_VERSIONS:
-        native.register_toolchains(
-            "@io_bazel_rules_scala_toolchains//scala:toolchain" +
-            version_suffix(scala_version),
-        )
+    native.register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 def scala_register_unused_deps_toolchains():
     native.register_toolchains(

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -4,10 +4,11 @@ load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
 def scala_register_toolchains():
     for scala_version in SCALA_VERSIONS:
         native.register_toolchains(
-            "@io_bazel_rules_scala//scala:toolchain" + version_suffix(scala_version),
+            "@io_bazel_rules_scala_toolchains//scala:toolchain" +
+            version_suffix(scala_version),
         )
 
 def scala_register_unused_deps_toolchains():
     native.register_toolchains(
-        "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
+        str(Label("//scala:unused_dependency_checker_error_toolchain")),
     )

--- a/test/shell/test_scala_binary.sh
+++ b/test/shell/test_scala_binary.sh
@@ -21,17 +21,16 @@ test_scala_binary_expect_failure_on_missing_direct_deps_located_in_dependency_wh
 test_scala_binary_allows_opt_in_to_use_of_argument_file_in_runner_for_improved_performance() {
 
   bazel run --extra_toolchains="//test/toolchains:use_argument_file_in_runner" //test/src/main/scala/scalarules/test/large_classpath:largeClasspath
-  grep "\"argsfile\" == \"argsfile\"" bazel-bin/test/src/main/scala/scalarules/test/large_classpath/largeClasspath
-  RESPONSE_CODE=$?
-  if [ $RESPONSE_CODE -ne 0 ]; then
+  local classpath_file="bazel-bin/test/src/main/scala/scalarules/test/large_classpath/largeClasspath"
+  local expected="\"argsfile\" == \"argsfile\""
+  if [[ ! "$(< $classpath_file)" =~ $expected ]]; then
     echo -e "${RED} Binary script does not use the argument file. $NC"
     exit -1
   fi
 
   bazel run //test/src/main/scala/scalarules/test/large_classpath:largeClasspath
-  grep "\"manifest\" == \"argsfile\"" bazel-bin/test/src/main/scala/scalarules/test/large_classpath/largeClasspath
-  RESPONSE_CODE=$?
-  if [ $RESPONSE_CODE -ne 0 ]; then
+  expected="\"manifest\" == \"argsfile\""
+  if [[ ! "$(< $classpath_file)" =~ $expected ]]; then
     echo -e "${RED} Binary script does not use the classpath jar. $NC"
     exit -1
   fi
@@ -41,7 +40,7 @@ test_scala_binary_allows_opt_in_to_use_of_argument_file_in_runner_for_improved_p
 $runner test_scala_binary_expect_failure_on_missing_direct_deps
 $runner test_scala_binary_expect_failure_on_missing_direct_deps_located_in_dependency_which_is_scala_binary
 
-if !  is_windows; then 
+if !  is_windows; then
   #rules_scala doesn't support argfiles on windows yet
   $runner test_scala_binary_allows_opt_in_to_use_of_argument_file_in_runner_for_improved_performance
 fi

--- a/test/shell/test_scala_proto_library.sh
+++ b/test/shell/test_scala_proto_library.sh
@@ -28,7 +28,6 @@ test_scala_proto_show_generator_exception() {
     --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_toolchain
 }
 
-export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat $dir/../../.bazelversion)}
 $runner test_scala_proto_library_action_label
 $runner test_scala_proto_custom_generator
 $runner test_scala_proto_show_generator_exception

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -33,7 +33,7 @@ scala_toolchain(
 toolchain(
     name = "ast_plus_one_deps_unused_deps_warn",
     toolchain = "ast_plus_one_deps_unused_deps_warn_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -48,7 +48,7 @@ scala_toolchain(
 toolchain(
     name = "ast_plus_one_deps_unused_deps_error",
     toolchain = "ast_plus_one_deps_unused_deps_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -63,7 +63,7 @@ scala_toolchain(
 toolchain(
     name = "ast_plus_one_deps_strict_deps_warn",
     toolchain = "ast_plus_one_deps_strict_deps_warn_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -78,7 +78,7 @@ scala_toolchain(
 toolchain(
     name = "ast_plus_one_deps_strict_deps_error",
     toolchain = "ast_plus_one_deps_strict_deps_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -93,7 +93,7 @@ scala_toolchain(
 toolchain(
     name = "high_level_transitive_deps_strict_deps_warn",
     toolchain = "high_level_transitive_deps_strict_deps_warn_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -108,7 +108,7 @@ scala_toolchain(
 toolchain(
     name = "high_level_transitive_deps_strict_deps_error",
     toolchain = "high_level_transitive_deps_strict_deps_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -123,7 +123,7 @@ scala_toolchain(
 toolchain(
     name = "high_level_direct_deps",
     toolchain = "high_level_direct_deps_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -136,7 +136,7 @@ scala_toolchain(
 toolchain(
     name = "enable_stats_file_disabled_toolchain",
     toolchain = "enable_stats_file_disabled_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -149,6 +149,6 @@ scala_toolchain(
 toolchain(
     name = "use_argument_file_in_runner",
     toolchain = "use_argument_file_in_runner_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )

--- a/test_cross_build/WORKSPACE
+++ b/test_cross_build/WORKSPACE
@@ -72,9 +72,15 @@ scala_config(
 )
 
 # loads other rules Rules Scala depends on
-load("@io_bazel_rules_scala//scala:scala.bzl", "rules_scala_toolchain_deps_repositories")
+load(
+    "@io_bazel_rules_scala//scala:scala.bzl",
+    "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
+)
 
 rules_scala_toolchain_deps_repositories()
+
+scala_toolchains_repo()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
 

--- a/test_cross_build/WORKSPACE
+++ b/test_cross_build/WORKSPACE
@@ -72,19 +72,11 @@ scala_config(
 )
 
 # loads other rules Rules Scala depends on
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-rules_scala_toolchain_deps_repositories()
+scala_toolchains()
 
-scala_toolchains_repo()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
 

--- a/test_expect_failure/plus_one_deps/BUILD.bazel
+++ b/test_expect_failure/plus_one_deps/BUILD.bazel
@@ -9,7 +9,7 @@ scala_toolchain(
 toolchain(
     name = "plus_one_deps",
     toolchain = "plus_one_deps_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -23,6 +23,6 @@ scala_toolchain(
 toolchain(
     name = "plus_one_deps_with_unused_error",
     toolchain = "plus_one_deps_with_unused_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -59,9 +59,15 @@ scala_config(enable_compiler_dependency_tracking = True)
 
 load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "extract_major_version")
 
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+load(
+    "@io_bazel_rules_scala//scala:scala.bzl",
+    "scala_repositories",
+    "scala_toolchains_repo",
+)
 
 scala_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load(":scrooge_repositories.bzl", "scrooge_repositories")
 ${twitter_scrooge_repositories}

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -63,18 +63,10 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
 scala_toolchains(fetch_sources = True)
 
-register_toolchains()
 register_toolchains(
     "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
     "@io_bazel_rules_scala//testing:testing_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
-)
-
-
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "scala_repositories",
-    "scala_toolchains_repo",
 )
 
 load(":scrooge_repositories.bzl", "scrooge_repositories")

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -59,15 +59,23 @@ scala_config(enable_compiler_dependency_tracking = True)
 
 load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "extract_major_version")
 
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
+
+scala_toolchains(fetch_sources = True)
+
+register_toolchains()
+register_toolchains(
+    "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
+    "@io_bazel_rules_scala//testing:testing_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
+)
+
+
 load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "scala_repositories",
     "scala_toolchains_repo",
 )
-
-scala_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
 
 load(":scrooge_repositories.bzl", "scrooge_repositories")
 ${twitter_scrooge_repositories}
@@ -89,9 +97,3 @@ specs2_junit_repositories()
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
 
 scalatest_repositories()
-
-register_toolchains("@io_bazel_rules_scala//testing:testing_toolchain")
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_toolchains")
-
-scala_register_unused_deps_toolchains()

--- a/third_party/test/example_external_workspace/WORKSPACE
+++ b/third_party/test/example_external_workspace/WORKSPACE
@@ -31,18 +31,11 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "rules_scala_setup",
-    "rules_scala_toolchain_deps_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-rules_scala_setup()
+scala_toolchains(fetch_sources = True)
 
-rules_scala_toolchain_deps_repositories(fetch_sources = True)
-
-scala_toolchains_repo()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/third_party/test/example_external_workspace/WORKSPACE
+++ b/third_party/test/example_external_workspace/WORKSPACE
@@ -35,11 +35,14 @@ load(
     "@io_bazel_rules_scala//scala:scala.bzl",
     "rules_scala_setup",
     "rules_scala_toolchain_deps_repositories",
+    "scala_toolchains_repo",
 )
 
 rules_scala_setup()
 
 rules_scala_toolchain_deps_repositories(fetch_sources = True)
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/third_party/test/example_external_workspace/WORKSPACE
+++ b/third_party/test/example_external_workspace/WORKSPACE
@@ -53,10 +53,6 @@ load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_toolchains")
-
-scala_register_toolchains()
-
 load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
 
 scalatest_repositories()

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -31,9 +31,15 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_repositories")
+load(
+    "@io_bazel_rules_scala//scala:scala.bzl",
+    "scala_repositories",
+    "scala_toolchains_repo",
+)
 
 scala_repositories()
+
+scala_toolchains_repo()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -35,7 +35,10 @@ load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
 scala_toolchains()
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+register_toolchains(
+    "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
+)
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -60,7 +63,3 @@ scala_proto_repositories()
 load("@io_bazel_rules_scala//scala_proto:toolchains.bzl", "scala_proto_register_toolchains")
 
 scala_proto_register_toolchains()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_register_unused_deps_toolchains")
-
-scala_register_unused_deps_toolchains()

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -31,15 +31,11 @@ load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "scala_repositories",
-    "scala_toolchains_repo",
-)
+load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_repositories()
+scala_toolchains()
 
-scala_toolchains_repo()
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 


### PR DESCRIPTION
### Description

Moves the `toolchain` targets for `//scala:toolchain_type` to a new `@io_bazel_rules_scala_toolchains` repository as a step towards Bzlmodification. Part of #1482.

### Motivation

Instantiating toolchains in their own repository enables module extensions to define the the repositories required by those toolchains within the extension's own namespace. Bzlmod users can then register the toolchains from this repository without having to import all the toolchains' dependencies into their own namespace via `use_repo()`.

---

The `scala_toolchains_repo()` macro wraps the underlying repository rule and assigns it the standard name `io_bazel_rules_scala_toolchains`. Right now it's only instantiating the main Scala toolchain via the default `scala = True` parameter. Future changes will expand this macro and repository rule with more boolean parameters to instantiate other toolchains, specifically:

- `scalatest`
- `junit`
- `specs2`
- `twitter_scrooge`
- `jmh`
- `scala_proto` and `scala_proto_enable_all_options`
- `testing` (includes all of `scalatest`, `junit`, and `specs2`)
- `scalafmt`

---

`WORKSPACE` users will now have to import and call the `scala_toolchains_repo()` macro to instantiate
`@io_bazel_rules_scala_toolchains`.

```py
load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")

scala_config()

load(
    "//scala:scala.bzl",
    "rules_scala_setup",
    "rules_scala_toolchain_deps_repositories",
    "scala_toolchains_repo",
)

rules_scala_setup()

rules_scala_toolchain_deps_repositories()

scala_toolchains_repo()

register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
```

Or, they can use the new single `scala_toolchains()` macro to elide most of the calls:

```py
load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")

scala_config()

load("//scala:scala.bzl", "scala_toolchains")

scala_toolchains()

register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
```

This is what the corresponding `MODULE.bazel` setup would look like:

```py
module(name = "rules_scala", version = "7.0.0")

scala_config = use_extension(
    "//scala/extensions:config.bzl", "scala_config"
)
scala_config.settings(scala_version = "2.13.14")

scala_deps = use_extension("//scala/extensions:deps.bzl", "scala_deps")
scala_deps.toolchains()
```

The `register_toolchains()` call in `WORKSPACE` isn't strictly required at this point, but is recommended. All the `WORKSPACE` files in this repo already registered their required toolchains using existing macros. However, they've been updated to use `register_toolchains(...)` instead.

These `register_toolchains()` calls maintain the order of previous toolchain registrations to avoid the following breakages:

- `test_compilation_fails_with_plus_one_deps_undefined` from `test/shell/test_compilation.sh` depends on `//scala:unused_dependency_checker_error_toolchain` resolving first. This toolchains sets the `scala_toolchain()` parameters `dependency_tracking_method = "ast-plus"` and `unused_dependency_checker_mode = "error"`, and the `@io_bazel_rules_scala_toolchains//scala` toolchains don't.

- `test_scala_binary_allows_opt_in_to_use_of_argument_file_in_runner_for_improved_performance` from `test/shell/test_scala_binary.sh` depends on the `use_argument_file_in_runner` parameter of `scala_toolchain` being `False`. This is the default, but the `@io_bazel_rules_scala_toolchains//scala` toolchains explicitly set this to `True` instead.

In the Bzlmod case, the `register_toolchains()` call isn't necessary at all. This is because `@io_bazel_rules_scala_toolchains` includes one package per set of toolchains, and the rules_scala `MODULE.bazel` calls `register_toolchains("@io_bazel_rules_scala_toolchains//...:all")`. This will automatically register all configured rules_scala toolchains, while allowing users to override any of them using `register_toolchains()` in their own `MODULE.bazel` files.

Technically, the `scala_deps.toolchains()` call isn't required when only using the default `scala = True` parameter; the rules_scala `MODULE.bazel` will instantiate this automatically, too.