### PR TITLE
Create the `@scala_compiler_sources` repo

### DIFF
--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -25,6 +25,36 @@ dt_patched_compiler = repository_rule(
     implementation = _dt_patched_compiler_impl,
 )
 
+_PACKAGE_VISIBILITY_PUBLIC = """package(
+    default_visibility = [\"//visibility:public\"],
+)
+"""
+
+_COMPILER_SOURCE_ALIAS_FORMAT = """alias(
+    name   = "src{scala_version_suffix}",
+    actual = "@scala_compiler_source{scala_version_suffix}//:src",
+    visibility = ["//visibility:public"],
+)
+"""
+
+def _compiler_sources_repo_impl(rctx):
+    build_content = [_PACKAGE_VISIBILITY_PUBLIC]
+    build_content.extend([
+        _COMPILER_SOURCE_ALIAS_FORMAT.format(
+            scala_version_suffix = version_suffix(scala_version),
+        )
+        for scala_version in SCALA_VERSIONS
+    ])
+
+    rctx.file("BUILD", content = "\n".join(build_content), executable = False)
+
+compiler_sources_repo = repository_rule(
+    implementation = _compiler_sources_repo_impl,
+    attrs = {
+        "scala_versions": attr.string_list(mandatory = True),
+    },
+)
+
 def _validate_scalac_srcjar(srcjar):
     if type(srcjar) != "dict":
         return False
@@ -49,7 +79,8 @@ def dt_patched_compiler_setup(scala_version, scala_compiler_srcjar = None):
             patch = "@io_bazel_rules_scala//dt_patches:dt_compiler_%s.8.patch" % scala_major_version
 
     build_file_content = "\n".join([
-        "package(default_visibility = [\"//visibility:public\"])",
+        _PACKAGE_VISIBILITY_PUBLIC,
+        "",
         "filegroup(",
         "    name = \"src\",",
         "    srcs=[\"scala/tools/nsc/symtab/SymbolLoaders.scala\"],",
@@ -136,6 +167,11 @@ def rules_scala_setup(scala_compiler_srcjar = None):
 
     for scala_version in SCALA_VERSIONS:
         dt_patched_compiler_setup(scala_version, scala_compiler_srcjar)
+
+    compiler_sources_repo(
+        name = "scala_compiler_sources",
+        scala_versions = SCALA_VERSIONS,
+    )
 
 def _artifact_ids(scala_version):
     return [

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
@@ -1,15 +1,8 @@
 load("//scala:scala.bzl", "scala_library_for_plugin_bootstrapping")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
 
 scala_library_for_plugin_bootstrapping(
     name = "dep_reporting_compiler",
-    srcs = select({
-        "@io_bazel_rules_scala_config//:scala_version" + version_suffix(v): [
-            "@scala_compiler_sources//:src%s" % version_suffix(v),
-        ]
-        for v in SCALA_VERSIONS
-    }),
+    srcs = ["@scala_compiler_sources//:src"],
     scalac_jvm_flags = ["-Xmx128M"],  # fixme - workaround for a failing test
     visibility = ["//visibility:public"],
     deps = ["//scala/private/toolchain_deps:scala_compile_classpath"],

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
@@ -5,7 +5,9 @@ load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
 scala_library_for_plugin_bootstrapping(
     name = "dep_reporting_compiler",
     srcs = select({
-        "@io_bazel_rules_scala_config//:scala_version" + version_suffix(v): ["@scala_compiler_source%s//:src" % version_suffix(v)]
+        "@io_bazel_rules_scala_config//:scala_version" + version_suffix(v): [
+            "@scala_compiler_sources//:src%s" % version_suffix(v),
+        ]
         for v in SCALA_VERSIONS
     }),
     scalac_jvm_flags = ["-Xmx128M"],  # fixme - workaround for a failing test


### PR DESCRIPTION
### Description

Contains aliases to versioned Scala compiler source repository targets. Part of #1482.

Updates the version specific repo references in the srcs attribute of `//third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler:dep_reporting_compiler`. Now these are references to versioned targets in
`@scala_compiler_sources//`, which are aliases to those versioned compiler source repos.

### Motivation

In a Bzlmod world, this enables `rules_scala` to import only the `scala_compiler_sources` repo in `MODULE.bazel`, instead of importing each individual versioned compiler source repo.

This then allows `rules_scala` clients to set multiple `SCALA_VERSIONS` without requiring them to import this repo or any versioned compiler source repo. The Bzlmodifcation of the test repos under `dt_patches` (coming in a future change) revealed the need for this flexibility.