### PR TITLE
Make scala_xxx rules declare that they provide JavaInfo

### DIFF
--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -92,6 +92,7 @@ def make_scala_binary(*extras):
         ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_binary_impl,
     )
 

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -142,7 +142,7 @@ def make_scala_junit_test(*extras):
         toolchains = [
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
-        ],        
+        ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
         provides = [JavaInfo],

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -142,9 +142,10 @@ def make_scala_junit_test(*extras):
         toolchains = [
             "@io_bazel_rules_scala//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
-        ],
+        ],        
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_junit_test_impl,
     )
 

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -108,6 +108,7 @@ def make_scala_library(*extras):
         ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_library_impl,
     )
 
@@ -209,6 +210,7 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
         ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_library_for_plugin_bootstrapping_impl,
     )
 
@@ -284,6 +286,7 @@ def make_scala_macro_library(*extras):
         ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_macro_library_impl,
     )
 

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -87,6 +87,7 @@ def make_scala_repl(*extras):
         ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_repl_impl,
     )
 

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -131,6 +131,7 @@ def make_scala_test(*extras):
         ],
         cfg = scala_version_transition,
         incompatible_use_toolchain_transition = True,
+        provides = [JavaInfo],
         implementation = _scala_test_impl,
     )
 

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -150,4 +150,5 @@ scala_import = rule(
         ),
     },
     toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],
+    provides = [JavaInfo],
 )

--- a/test/aspect/A.scala
+++ b/test/aspect/A.scala
@@ -1,0 +1,7 @@
+package scalarules.test
+
+object A {
+  def main(args: Array[String]) {
+    println("4 8 15 16 23 42")
+  }
+}

--- a/test/aspect/B.scala
+++ b/test/aspect/B.scala
@@ -1,0 +1,7 @@
+package scalarules.test
+
+object B {
+  def main(args: Array[String]) {
+    println("4 8 15 16 23 42")
+  }
+}

--- a/test/aspect/BUILD
+++ b/test/aspect/BUILD
@@ -1,4 +1,5 @@
 load(":aspect.bzl", "aspect_testscript")
+load(":javainfo_from_aspect_test.bzl", "javainfo_from_aspect_test")
 load(
     "//scala:scala.bzl",
     "scala_junit_test",
@@ -6,6 +7,7 @@ load(
     "scala_specs2_junit_test",
     "scala_test",
 )
+load("//scala:scala_import.bzl", "scala_import")
 
 aspect_testscript(
     name = "aspect_testscript",
@@ -38,4 +40,31 @@ scala_specs2_junit_test(
     name = "scala_specs2_junit_test",
     srcs = ["FakeJunitTest.scala"],
     suffixes = ["Test"],
+)
+
+#####################################
+#use ensure_javainfo_from_aspect_test() to make sure scala_xxx can be visited in an aspect that has required_aspects=[JavaInfo]
+
+scala_import(
+    name = "com_google_guava_guava_21_0",
+    jars = ["@com_google_guava_guava_21_0_with_file//:guava-21.0.jar"]
+)
+
+scala_library(
+    name = "A",
+    srcs = ["A.scala"],
+)
+
+#This library depends on a scala_library and a scala_import
+scala_library(
+    name = "B",
+    deps = ["A",  "com_google_guava_guava_21_0"]
+)
+
+javainfo_from_aspect_test(
+    name = "javainfo_from_aspect_test",    
+    target_under_test = "B",
+    target = "B",
+    expected = ["A", "com_google_guava_guava_21_0"],
+    
 )

--- a/test/aspect/BUILD
+++ b/test/aspect/BUILD
@@ -47,7 +47,7 @@ scala_specs2_junit_test(
 
 scala_import(
     name = "com_google_guava_guava_21_0",
-    jars = ["@com_google_guava_guava_21_0_with_file//:guava-21.0.jar"]
+    jars = ["@com_google_guava_guava_21_0_with_file//:guava-21.0.jar"],
 )
 
 scala_library(
@@ -58,13 +58,18 @@ scala_library(
 #This library depends on a scala_library and a scala_import
 scala_library(
     name = "B",
-    deps = ["A",  "com_google_guava_guava_21_0"]
+    deps = [
+        "A",
+        "com_google_guava_guava_21_0",
+    ],
 )
 
 javainfo_from_aspect_test(
-    name = "javainfo_from_aspect_test",    
-    target_under_test = "B",
+    name = "javainfo_from_aspect_test",
+    expected = [
+        "A",
+        "com_google_guava_guava_21_0",
+    ],
     target = "B",
-    expected = ["A", "com_google_guava_guava_21_0"],
-    
+    target_under_test = "B",
 )

--- a/test/aspect/javainfo_from_aspect_test.bzl
+++ b/test/aspect/javainfo_from_aspect_test.bzl
@@ -1,15 +1,14 @@
-load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+load("@bazel_skylib//lib:unittest.bzl", "analysistest")
 
 _VisitedRulesInfo = provider()
 
 def _aspect_with_javainfo_required_imp(target, ctx):
-
     visited = dict([(target.label.name, "")])
     for dep in ctx.rule.attr.deps:
-        visited.update(dep[_VisitedRulesInfo].visited)        
-    
+        visited.update(dep[_VisitedRulesInfo].visited)
+
     return [
-        _VisitedRulesInfo(visited = visited)
+        _VisitedRulesInfo(visited = visited),
     ]
 
 #An aspect that has "required_providers = [JavaInfo]."
@@ -20,20 +19,18 @@ _aspect_with_javainfo_required = aspect(
     implementation = _aspect_with_javainfo_required_imp,
 )
 
-
 def _javainfo_from_aspect_test_imp(ctx):
     testenv = analysistest.begin(ctx)
 
     for expected in ctx.attr.expected:
-        if(expected not in ctx.attr.target[_VisitedRulesInfo].visited):
-            analysistest.fail(testenv, "Aspect did not visit expected target %s"%ctx.attr.expected)
+        if (expected not in ctx.attr.target[_VisitedRulesInfo].visited):
+            analysistest.fail(testenv, "Aspect did not visit expected target %s" % ctx.attr.expected)
     return analysistest.end(testenv)
-
 
 javainfo_from_aspect_test = analysistest.make(
     impl = _javainfo_from_aspect_test_imp,
     attrs = {
         "target": attr.label(aspects = [_aspect_with_javainfo_required]),
-        "expected": attr.string_list(), #The targets we expect to be visited by the aspect
-    }        
+        "expected": attr.string_list(),  #The targets we expect to be visited by the aspect
+    },
 )

--- a/test/aspect/javainfo_from_aspect_test.bzl
+++ b/test/aspect/javainfo_from_aspect_test.bzl
@@ -1,0 +1,39 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+_VisitedRulesInfo = provider()
+
+def _aspect_with_javainfo_required_imp(target, ctx):
+
+    visited = dict([(target.label.name, "")])
+    for dep in ctx.rule.attr.deps:
+        visited.update(dep[_VisitedRulesInfo].visited)        
+    
+    return [
+        _VisitedRulesInfo(visited = visited)
+    ]
+
+#An aspect that has "required_providers = [JavaInfo]."
+#This is used to test that an aspect that has required_providers can access the JavaInfo provided by the scala_xxx targets
+_aspect_with_javainfo_required = aspect(
+    attr_aspects = ["deps"],
+    required_providers = [JavaInfo],
+    implementation = _aspect_with_javainfo_required_imp,
+)
+
+
+def _javainfo_from_aspect_test_imp(ctx):
+    testenv = analysistest.begin(ctx)
+
+    for expected in ctx.attr.expected:
+        if(expected not in ctx.attr.target[_VisitedRulesInfo].visited):
+            analysistest.fail(testenv, "Aspect did not visit expected target %s"%ctx.attr.expected)
+    return analysistest.end(testenv)
+
+
+javainfo_from_aspect_test = analysistest.make(
+    impl = _javainfo_from_aspect_test_imp,
+    attrs = {
+        "target": attr.label(aspects = [_aspect_with_javainfo_required]),
+        "expected": attr.string_list(), #The targets we expect to be visited by the aspect
+    }        
+)


### PR DESCRIPTION
### Description
Made most scala_xxxx rules declare that they provide JavaInfo (setting the "provides" attribute).
This allows these targets to be visited by aspects that use "required_providers=[JavaInfo]". 

This matches behavior in java_xxx rules, and goal was to address all the equivelant scala_xxx rules.

rules updated are: scala_import, scala_library, scala_binary, scala_test, scala_junit_test, scala_proto, and scala_repl. (scala_proto_library was already correct).

### Motivation
Allows scala_xxx rules to be visited by aspects that use "required_providers=[JavaInfo]"
