### PR TITLE
Pass rlocationpaths to Test Runner

### DIFF
--- a/scala/private/phases/phase_runfiles.bzl
+++ b/scala/private/phases/phase_runfiles.bzl
@@ -15,7 +15,7 @@ def phase_runfiles_library(ctx, p):
 def phase_runfiles_scalatest(ctx, p):
     args = "\n".join([
         "-R",
-        rlocationpath_from_file(ctx, ctx.outputs.jar),        
+        rlocationpath_from_file(ctx, ctx.outputs.jar),
         _scala_test_flags(ctx),
         "-C",
         ctx.attr.reporter_class,

--- a/scala/private/phases/phase_runfiles.bzl
+++ b/scala/private/phases/phase_runfiles.bzl
@@ -1,3 +1,5 @@
+load("@io_bazel_rules_scala//scala/private:common.bzl", "rlocationpath_from_file")
+
 #
 # PHASE: runfiles
 #
@@ -13,7 +15,7 @@ def phase_runfiles_library(ctx, p):
 def phase_runfiles_scalatest(ctx, p):
     args = "\n".join([
         "-R",
-        ctx.outputs.jar.short_path.replace("../", "external/"),
+        rlocationpath_from_file(ctx, ctx.outputs.jar),        
         _scala_test_flags(ctx),
         "-C",
         ctx.attr.reporter_class,

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -14,6 +14,7 @@ load(
     "runfiles_root",
     "specified_java_runtime",
 )
+load("@io_bazel_rules_scala//scala/private:common.bzl", "rlocationpath_from_file")
 
 def phase_write_executable_scalatest(ctx, p):
     # jvm_flags passed in on the target override scala_test_jvm_flags passed in on the
@@ -27,7 +28,7 @@ def phase_write_executable_scalatest(ctx, p):
         rjars = p.coverage_runfiles.rjars,
         jvm_flags = [
             "-DRULES_SCALA_MAIN_WS_NAME=%s" % ctx.workspace_name,
-            "-DRULES_SCALA_ARGS_FILE=%s" % p.runfiles.args_file.short_path.replace("../", "external/"),
+            "-DRULES_SCALA_ARGS_FILE=%s" % rlocationpath_from_file(ctx, p.runfiles.args_file),
         ] + expand_location(ctx, final_jvm_flags) + _allow_security_manager_for_specified_java_runtime(ctx),
         use_jacoco = ctx.configuration.coverage_enabled,
     )

--- a/src/java/io/bazel/rulesscala/scala_test/Runner.java
+++ b/src/java/io/bazel/rulesscala/scala_test/Runner.java
@@ -5,7 +5,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
@@ -49,9 +48,7 @@ public class Runner {
     if (workspace == null || workspace.trim().isEmpty())
       throw new IllegalArgumentException(RULES_SCALA_MAIN_WS_NAME + " is null or empty.");
 
-
-    Path runnerArgsUnresolvedFileLocation = Paths.get(workspace + "/" + runnerArgsFileKey).normalize();
-    String runnerArgsFilePath = Runfiles.create().rlocation(runnerArgsUnresolvedFileLocation.toString());
+    String runnerArgsFilePath = Runfiles.create().rlocation(runnerArgsFileKey);
     if (runnerArgsFilePath == null)
       throw new IllegalArgumentException("rlocation value is null for key: " + runnerArgsFileKey);
 
@@ -92,9 +89,8 @@ public class Runner {
     if (runpathFlag >= 0) {
       String[] runpathElements = runnerArgs.get(runpathFlag + 1).split(File.pathSeparator);
       Runfiles runfiles = Runfiles.create();
-      for (int i = 0; i < runpathElements.length; i++) {
-        Path runPathElementPath = Paths.get(rulesWorkspace + "/" + runpathElements[i]).normalize();
-        runpathElements[i] = runfiles.rlocation(runPathElementPath.toString());
+      for (int i = 0; i < runpathElements.length; i++) { 
+        runpathElements[i] = runfiles.rlocation(runpathElements[i].toString());
       }
       String runpath = String.join(File.separator, runpathElements);
       runnerArgs.set(runpathFlag + 1, runpath);


### PR DESCRIPTION
### Description
Changed so that paths passed to the Test Runner are in "rlocationpath" form. This should be more correct way to handle these paths as that is what rlocation() expects.  

This fixes issue where we couldn't test external repo tests on Windows. 

Note: seems to have been chasing this issue in the past (#1598. #1500), hopefully this solves for good.

### Motivation
Handle paths in more robust way. And run scalatests from external repos on windows again.
