### PR TITLE
Fix windows Buildkit CI 

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -49,6 +49,7 @@ tasks:
     environment:      
       MSYS2_ARG_CONV_EXCL: "*"
     batch_commands:
+    - "set PATH=/usr/bin;%PATH%" #Make sure bash uses msys commands over windows commands. (i.e. find).
     - "bash test_rules_scala.sh"
   test_coverage_linux_6_5_0:
     name: "./test_coverage"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -50,6 +50,7 @@ tasks:
       MSYS2_ARG_CONV_EXCL: "*"
     batch_commands:
     - "set PATH=/usr/bin;%PATH%" #Make sure bash uses msys commands over windows commands. (i.e. find).
+    - "bash -lc \"pacman --noconfirm --needed -S libxml2\"" #tests require xmllint
     - "bash test_rules_scala.sh"
   test_coverage_linux_6_5_0:
     name: "./test_coverage"

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -46,6 +46,8 @@ tasks:
   test_rules_scala_win:
     name: "./test_rules_scala"
     platform: windows
+    environment:      
+      MSYS2_ARG_CONV_EXCL: "*"
     batch_commands:
     - "bash test_rules_scala.sh"
   test_coverage_linux_6_5_0:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -46,7 +46,7 @@ tasks:
   test_rules_scala_win:
     name: "./test_rules_scala"
     platform: windows
-    shell_commands:
+    batch_commands:
     - "bash test_rules_scala.sh"
   test_coverage_linux_6_5_0:
     name: "./test_coverage"

--- a/test/src/main/scala/scalarules/test/duplicated_resources/child/ScalaLibResourcesDuplicatedTest.scala
+++ b/test/src/main/scala/scalarules/test/duplicated_resources/child/ScalaLibResourcesDuplicatedTest.scala
@@ -5,8 +5,8 @@ import org.scalatest.funsuite._
 class ScalaLibResourcesDuplicatedTest extends AnyFunSuite {
 
   test("Scala library depends on resource + deps that contains same name resources, have higher priority on this target's resource.") {
-    //Using platform dependent newline (%n)
-    assert(get("/resource.txt") === String.format("I am a text resource from child!%n"))
+    
+    assert(get("/resource.txt") === String.format("I am a text resource from child!\n"))
   }
 
   private def get(s: String): String =

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
@@ -7,7 +7,7 @@ class ScalaLibResourcesFromExternalDepTest extends SpecWithJUnit {
   "Scala library depending on resources from external resource-only jar" >> {
     "allow to load resources" >> {
 
-      val expectedString = String.format("A resource%n"); //Using platform dependent newline (%n)
+      val expectedString = String.format("A resource\n");
       get("/resource.txt") must beEqualTo(expectedString)
   
     }

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalScalaTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalScalaTest.scala
@@ -5,7 +5,7 @@ import org.scalatest.funsuite._
 class ScalaLibResourcesFromExternalScalaTest extends AnyFunSuite {
 
   test("Scala library depending on resources from external resource-only jar should allow to load resources") {
-    val expectedString = String.format("A resource%n"); //Using platform dependent newline (%n)
+    val expectedString = String.format("A resource\n");
     assert(get("/resource.txt") === expectedString)
   }
 


### PR DESCRIPTION
Apparently windows CI hasn't been running for a long time (or ever?)

The issue seems to be that for windows, buildkite needs "batch_commands" instead of "shell_commands".

(Update)
Also made minor fixes to tests regarding line endings. _I originally (#1529) had the system work with autocrlf=true, but this isn't handled by BazelCI. And after thinking bout it, its probably best to keep autocrlf=false, since that is what is distributed to users.. even windows users._ 

### Motivation
Make windows CI work so we don't accidently break windows support.
