### PR TITLE
Toolchainize all testing toolchains

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -41,10 +41,12 @@ scala_config(enable_compiler_dependency_tracking = True)
 
 load("//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains(fetch_sources = True)
+scala_toolchains(
+    fetch_sources = True,
+    testing = True,
+)
 
 register_toolchains(
-    "//testing:testing_toolchain",
     "//scala:unused_dependency_checker_error_toolchain",
     "//test/proto:scalapb_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
@@ -78,14 +80,6 @@ jmh_repositories()
 load("//scala_proto:scala_proto.bzl", "scala_proto_repositories")
 
 scala_proto_repositories()
-
-load("//scalatest:scalatest.bzl", "scalatest_repositories")
-
-scalatest_repositories()
-
-load("//specs2:specs2_junit.bzl", "specs2_junit_repositories")
-
-specs2_junit_repositories()
 
 load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_default_config", "scalafmt_repositories")
 

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -40,7 +40,7 @@ scala_config(
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains()
+scala_toolchains(scalatest = True)
 
 register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
@@ -59,9 +59,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
-
-scalatest_repositories()
-
-scalatest_toolchain()

--- a/examples/testing/multi_frameworks_toolchain/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/BUILD
@@ -1,6 +1,4 @@
 load("@io_bazel_rules_scala//scala:scala.bzl", "setup_scala_testing_toolchain")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "version_suffix")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 setup_scala_testing_toolchain(
     name = "testing_toolchain",
@@ -8,7 +6,7 @@ setup_scala_testing_toolchain(
         "@io_bazel_rules_scala_junit_junit",
         "@io_bazel_rules_scala_org_hamcrest_hamcrest_core",
     ],
-    scalatest_classpath = [dep + version_suffix(SCALA_VERSION) for dep in [
+    scalatest_classpath = [
         "@io_bazel_rules_scala_scalactic",
         "@io_bazel_rules_scala_scalatest",
         "@io_bazel_rules_scala_scalatest_compatible",
@@ -21,7 +19,7 @@ setup_scala_testing_toolchain(
         "@io_bazel_rules_scala_scalatest_matchers_core",
         "@io_bazel_rules_scala_scalatest_mustmatchers",
         "@io_bazel_rules_scala_scalatest_shouldmatchers",
-    ]],
+    ],
     specs2_classpath = [
         "@io_bazel_rules_scala_org_specs2_specs2_common",
         "@io_bazel_rules_scala_org_specs2_specs2_core",

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -33,7 +33,10 @@ scala_config()
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains(fetch_sources = True)
+scala_toolchains(
+    fetch_sources = True,
+    testing = True,
+)
 
 register_toolchains(
     ":testing_toolchain",
@@ -55,13 +58,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories")
-load("@io_bazel_rules_scala//testing:junit.bzl", "junit_repositories")
-load("@io_bazel_rules_scala//testing:specs2_junit.bzl", "specs2_junit_repositories")
-
-scalatest_repositories()
-
-junit_repositories()
-
-specs2_junit_repositories()

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -33,7 +33,10 @@ scala_config()
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains(fetch_sources = True)
+scala_toolchains(
+    fetch_sources = True,
+    scalatest = True,
+)
 
 register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
@@ -52,9 +55,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
-
-scalatest_repositories()
-
-scalatest_toolchain()

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -33,7 +33,10 @@ scala_config()
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains(fetch_sources = True)
+scala_toolchains(
+    fetch_sources = True,
+    specs2 = True,
+)
 
 register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
@@ -52,9 +55,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//testing:specs2_junit.bzl", "specs2_junit_repositories", "specs2_junit_toolchain")
-
-specs2_junit_repositories()
-
-specs2_junit_toolchain()

--- a/junit/junit.bzl
+++ b/junit/junit.bzl
@@ -4,14 +4,17 @@ load(
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
 
+def junit_artifact_ids():
+    return [
+        "io_bazel_rules_scala_junit_junit",
+        "io_bazel_rules_scala_org_hamcrest_hamcrest_core",
+    ]
+
 def junit_repositories(
         maven_servers = _default_maven_server_urls(),
         fetch_sources = True):
     repositories(
-        for_artifact_ids = [
-            "io_bazel_rules_scala_junit_junit",
-            "io_bazel_rules_scala_org_hamcrest_hamcrest_core",
-        ],
+        for_artifact_ids = junit_artifact_ids(),
         fetch_sources = fetch_sources,
         maven_servers = maven_servers,
     )

--- a/scala/private/macros/toolchains_repo.bzl
+++ b/scala/private/macros/toolchains_repo.bzl
@@ -1,5 +1,40 @@
 """Repository rule to instantiate @io_bazel_rules_scala_toolchains"""
 
+def _generate_testing_toolchain_build_file_args(repo_attr):
+    framework_deps = {}
+
+    if repo_attr.testing:
+        framework_deps = {
+            "scalatest": "SCALATEST_DEPS",
+            "junit": "JUNIT_DEPS",
+            "specs2": "SPECS2_DEPS",
+            "specs2_junit": "SPECS2_JUNIT_DEPS",
+        }
+    if repo_attr.scalatest:
+        framework_deps["scalatest"] = "SCALATEST_DEPS"
+    if repo_attr.specs2:
+        framework_deps["specs2"] = "SPECS2_DEPS"
+        framework_deps["specs2_junit"] = "SPECS2_JUNIT_DEPS"
+        framework_deps["junit"] = "JUNIT_DEPS"
+    if repo_attr.junit:
+        framework_deps["junit"] = "JUNIT_DEPS"
+
+    if len(framework_deps) == 0:
+        return None
+
+    # The _TESTING_TOOLCHAIN_BUILD template expects that all framework keys are
+    # present in the dictionary, so it can set unset framework classpath
+    # parameters to `None`.
+    return {
+        "deps_symbols": "\",\n    \"".join(
+            [s for s in framework_deps.values()],
+        ),
+        "scalatest": framework_deps.get("scalatest"),
+        "junit": framework_deps.get("junit"),
+        "specs2": framework_deps.get("specs2"),
+        "specs2_junit": framework_deps.get("specs2_junit"),
+    }
+
 def _scala_toolchains_repo_impl(repository_ctx):
     repo_attr = repository_ctx.attr
     format_args = {
@@ -9,6 +44,11 @@ def _scala_toolchains_repo_impl(repository_ctx):
 
     if repo_attr.scala:
         toolchains["scala"] = _SCALA_TOOLCHAIN_BUILD
+
+    testing_build_args = _generate_testing_toolchain_build_file_args(repo_attr)
+    if testing_build_args != None:
+        format_args.update(testing_build_args)
+        toolchains["testing"] = _TESTING_TOOLCHAIN_BUILD
 
     if len(toolchains) == 0:
         fail("no toolchains specified")
@@ -22,8 +62,13 @@ def _scala_toolchains_repo_impl(repository_ctx):
 
 _scala_toolchains_repo = repository_rule(
     implementation = _scala_toolchains_repo_impl,
+    doc = "Creates a repo containing Scala toolchain packages",
     attrs = {
         "scala": attr.bool(default = True),
+        "scalatest": attr.bool(),
+        "junit": attr.bool(),
+        "specs2": attr.bool(),
+        "testing": attr.bool(),
     },
 )
 
@@ -71,5 +116,27 @@ load(
         "scala_macro_classpath",
         "semanticdb",
     ]
+]
+"""
+
+_TESTING_TOOLCHAIN_BUILD = """
+load("@@{rules_scala_repo}//scala:scala.bzl", "setup_scala_testing_toolchain")
+load("@@{rules_scala_repo}//scala:scala_cross_version.bzl", "version_suffix")
+load(
+    "@@{rules_scala_repo}//testing:deps.bzl",
+    "{deps_symbols}",
+)
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
+
+[
+    setup_scala_testing_toolchain(
+        name = "testing_toolchain" + version_suffix(scala_version),
+        scala_version = scala_version,
+        scalatest_classpath = {scalatest},
+        junit_classpath = {junit},
+        specs2_classpath = {specs2},
+        specs2_junit_classpath = {specs2_junit},
+    )
+    for scala_version in SCALA_VERSIONS
 ]
 """

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -2,15 +2,15 @@
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
 load(
-    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "//scala/private:common_attributes.bzl",
     "common_attrs",
     "implicit_deps",
     "launcher_template",
 )
-load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+load("//scala/private:common_outputs.bzl", "common_outputs")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
+    "//scala/private:phases/phases.bzl",
     "extras_phases",
     "phase_collect_jars_junit_test",
     "phase_compile_junit_test",
@@ -85,12 +85,10 @@ _scala_junit_test_attrs = {
     "env": attr.string_dict(default = {}),
     "env_inherit": attr.string_list(),
     "_junit_classpath": attr.label(
-        default = Label("@io_bazel_rules_scala//testing/toolchain:junit_classpath"),
+        default = Label("//testing/toolchain:junit_classpath"),
     ),
     "_bazel_test_runner": attr.label(
-        default = Label(
-            "@io_bazel_rules_scala//scala:bazel_test_runner_deploy",
-        ),
+        default = Label("//scala:bazel_test_runner_deploy"),
         allow_files = True,
     ),
     "_lcov_merger": attr.label(
@@ -103,10 +101,8 @@ _scala_junit_test_attrs = {
 _junit_resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [
-            Label(
-                "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
-            ),
-            Label("@io_bazel_rules_scala//testing/toolchain:junit_classpath"),
+            Label("//scala/private/toolchain_deps:scala_library_classpath"),
+            Label("//testing/toolchain:junit_classpath"),
         ],
         allow_files = False,
     ),
@@ -140,7 +136,8 @@ def make_scala_junit_test(*extras):
         ),
         test = True,
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
+            Label("//testing/toolchain:testing_toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -126,7 +126,8 @@ def make_scala_test(*extras):
         ),
         test = True,
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
+            Label("//testing/toolchain:testing_toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -1,9 +1,6 @@
-load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
+load("//scala/private:rule_impls.bzl", "specified_java_compile_toolchain")
 load("//scala/settings:stamp_settings.bzl", "StampScalaImport")
-load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    "specified_java_compile_toolchain",
-)
+load("//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
 
 def _stamp_jar(ctx, jar):
     stamped_jar_filename = "%s.stamp/%s" % (ctx.label.name, jar.basename)
@@ -139,11 +136,13 @@ scala_import = rule(
         "srcjar": attr.label(allow_single_file = True),
         "_placeholder_jar": attr.label(
             allow_single_file = True,
-            default = Label("@io_bazel_rules_scala//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar"),
+            default = Label(
+                "//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar",
+            ),
         ),
         "stamp": attr.label(
             doc = "Adds Target-Label attribute to MANIFEST.MF for dep tracking",
-            default = Label("@io_bazel_rules_scala//scala/settings:stamp_scala_import"),
+            default = Label("//scala/settings:stamp_scala_import"),
         ),
         "java_compile_toolchain": attr.label(
             default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),

--- a/scalatest/scalatest.bzl
+++ b/scalatest/scalatest.bzl
@@ -5,30 +5,33 @@ load(
 load("//third_party/repositories:repositories.bzl", "repositories")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
+def scalatest_artifact_ids():
+    return [
+        "io_bazel_rules_scala_scalactic",
+        "io_bazel_rules_scala_scalatest",
+        "io_bazel_rules_scala_scalatest_compatible",
+        "io_bazel_rules_scala_scalatest_core",
+        "io_bazel_rules_scala_scalatest_diagrams",
+        "io_bazel_rules_scala_scalatest_featurespec",
+        "io_bazel_rules_scala_scalatest_flatspec",
+        "io_bazel_rules_scala_scalatest_freespec",
+        "io_bazel_rules_scala_scalatest_funspec",
+        "io_bazel_rules_scala_scalatest_funsuite",
+        "io_bazel_rules_scala_scalatest_matchers_core",
+        "io_bazel_rules_scala_scalatest_mustmatchers",
+        "io_bazel_rules_scala_scalatest_propspec",
+        "io_bazel_rules_scala_scalatest_refspec",
+        "io_bazel_rules_scala_scalatest_shouldmatchers",
+        "io_bazel_rules_scala_scalatest_wordspec",
+    ]
+
 def scalatest_repositories(
         maven_servers = _default_maven_server_urls(),
         fetch_sources = True):
     for scala_version in SCALA_VERSIONS:
         repositories(
             scala_version = scala_version,
-            for_artifact_ids = [
-                "io_bazel_rules_scala_scalactic",
-                "io_bazel_rules_scala_scalatest",
-                "io_bazel_rules_scala_scalatest_compatible",
-                "io_bazel_rules_scala_scalatest_core",
-                "io_bazel_rules_scala_scalatest_diagrams",
-                "io_bazel_rules_scala_scalatest_featurespec",
-                "io_bazel_rules_scala_scalatest_flatspec",
-                "io_bazel_rules_scala_scalatest_freespec",
-                "io_bazel_rules_scala_scalatest_funspec",
-                "io_bazel_rules_scala_scalatest_funsuite",
-                "io_bazel_rules_scala_scalatest_matchers_core",
-                "io_bazel_rules_scala_scalatest_mustmatchers",
-                "io_bazel_rules_scala_scalatest_propspec",
-                "io_bazel_rules_scala_scalatest_refspec",
-                "io_bazel_rules_scala_scalatest_shouldmatchers",
-                "io_bazel_rules_scala_scalatest_wordspec",
-            ],
+            for_artifact_ids = scalatest_artifact_ids(),
             maven_servers = maven_servers,
             fetch_sources = fetch_sources,
         )

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -7,20 +7,23 @@ load("//third_party/repositories:repositories.bzl", "repositories")
 def specs2_version():
     return "4.4.1"
 
+def specs2_artifact_ids():
+    return [
+        "io_bazel_rules_scala_org_specs2_specs2_common",
+        "io_bazel_rules_scala_org_specs2_specs2_core",
+        "io_bazel_rules_scala_org_specs2_specs2_fp",
+        "io_bazel_rules_scala_org_specs2_specs2_matcher",
+    ]
+
 def specs2_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {}):
     repositories(
-        for_artifact_ids = [
-            "io_bazel_rules_scala_org_specs2_specs2_common",
-            "io_bazel_rules_scala_org_specs2_specs2_core",
-            "io_bazel_rules_scala_org_specs2_specs2_fp",
-            "io_bazel_rules_scala_org_specs2_specs2_matcher",
-        ],
+        for_artifact_ids = specs2_artifact_ids(),
         maven_servers = maven_servers,
         fetch_sources = True,
         overriden_artifacts = overriden_artifacts,
     )
 
 def specs2_dependencies():
-    return ["@io_bazel_rules_scala//specs2:specs2"]
+    return [Label("//specs2:specs2")]

--- a/specs2/specs2_junit.bzl
+++ b/specs2/specs2_junit.bzl
@@ -10,6 +10,11 @@ load(
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
 
+def specs2_junit_artifact_ids():
+    return [
+        "io_bazel_rules_scala_org_specs2_specs2_junit",
+    ]
+
 def specs2_junit_repositories(
         maven_servers = _default_maven_server_urls(),
         overriden_artifacts = {}):
@@ -17,9 +22,7 @@ def specs2_junit_repositories(
     junit_repositories()
 
     repositories(
-        for_artifact_ids = [
-            "io_bazel_rules_scala_org_specs2_specs2_junit",
-        ],
+        for_artifact_ids = specs2_junit_artifact_ids(),
         maven_servers = maven_servers,
         fetch_sources = True,
         overriden_artifacts = overriden_artifacts,
@@ -27,5 +30,5 @@ def specs2_junit_repositories(
 
 def specs2_junit_dependencies():
     return specs2_dependencies() + [
-        "@io_bazel_rules_scala//testing/toolchain:specs2_junit_classpath",
+        Label("//testing/toolchain:specs2_junit_classpath"),
     ]

--- a/test_cross_build/WORKSPACE
+++ b/test_cross_build/WORKSPACE
@@ -74,15 +74,11 @@ scala_config(
 # loads other rules Rules Scala depends on
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains()
+scala_toolchains(
+    scalatest = True,
+)
 
 register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
-
-load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
-
-scalatest_repositories()
-
-scalatest_toolchain()
 
 load("@io_bazel_rules_scala//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_repositories")
 

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -61,7 +61,11 @@ load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "extract_major_vers
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains(fetch_sources = True)
+scala_toolchains(
+    fetch_sources = True,
+    scalatest = True,
+    specs2 = True,
+)
 
 register_toolchains(
     "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
@@ -81,11 +85,3 @@ scala_proto_repositories()
 load("@io_bazel_rules_scala//scala_proto:toolchains.bzl", "scala_proto_register_toolchains")
 
 scala_proto_register_toolchains()
-
-load("@io_bazel_rules_scala//specs2:specs2_junit.bzl", "specs2_junit_repositories")
-
-specs2_junit_repositories()
-
-load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
-
-scalatest_repositories()

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -1,82 +1,19 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "setup_scala_testing_toolchain")
 load("//scala:scala_cross_version.bzl", "version_suffix")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
-
-_SPECS2_DEPS = [
-    "@io_bazel_rules_scala_org_specs2_specs2_common",
-    "@io_bazel_rules_scala_org_specs2_specs2_core",
-    "@io_bazel_rules_scala_org_specs2_specs2_fp",
-    "@io_bazel_rules_scala_org_specs2_specs2_matcher",
-]
-
-_SPECS2_JUNIT_DEPS = [
-    "@io_bazel_rules_scala_org_specs2_specs2_junit",
-]
-
-_JUNIT_DEPS = [
-    "@io_bazel_rules_scala_junit_junit",
-    "@io_bazel_rules_scala_org_hamcrest_hamcrest_core",
-]
-
-_SCALATEST_DEPS = [
-    "@io_bazel_rules_scala_scalactic",
-    "@io_bazel_rules_scala_scalatest",
-    "@io_bazel_rules_scala_scalatest_compatible",
-    "@io_bazel_rules_scala_scalatest_core",
-    "@io_bazel_rules_scala_scalatest_featurespec",
-    "@io_bazel_rules_scala_scalatest_flatspec",
-    "@io_bazel_rules_scala_scalatest_freespec",
-    "@io_bazel_rules_scala_scalatest_funspec",
-    "@io_bazel_rules_scala_scalatest_funsuite",
-    "@io_bazel_rules_scala_scalatest_matchers_core",
-    "@io_bazel_rules_scala_scalatest_mustmatchers",
-    "@io_bazel_rules_scala_scalatest_shouldmatchers",
-]
-
-[
-    setup_scala_testing_toolchain(
-        name = "testing_toolchain" + version_suffix(scala_version),
-        junit_classpath = _JUNIT_DEPS,
-        scala_version = scala_version,
-        scalatest_classpath = [dep + version_suffix(scala_version) for dep in _SCALATEST_DEPS],
-        specs2_classpath = _SPECS2_DEPS,
-        specs2_junit_classpath = _SPECS2_JUNIT_DEPS,
-        visibility = ["//visibility:public"],
-    )
-    for scala_version in SCALA_VERSIONS
-]
-
-[
-    setup_scala_testing_toolchain(
-        name = "scalatest_toolchain" + version_suffix(scala_version),
-        scala_version = scala_version,
-        scalatest_classpath = [dep + version_suffix(scala_version) for dep in _SCALATEST_DEPS],
-        visibility = ["//visibility:public"],
-    )
-    for scala_version in SCALA_VERSIONS
-]
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 # Aliases for backward compatibility:
-alias(
-    name = "testing_toolchain",
-    actual = "testing_toolchain" + version_suffix(SCALA_VERSION),
-)
-
-alias(
-    name = "scalatest_toolchain",
-    actual = "scalatest_toolchain" + version_suffix(SCALA_VERSION),
-)
-
-setup_scala_testing_toolchain(
-    name = "specs2_junit_toolchain",
-    junit_classpath = _JUNIT_DEPS,
-    specs2_classpath = _SPECS2_DEPS,
-    specs2_junit_classpath = _SPECS2_JUNIT_DEPS,
-    visibility = ["//visibility:public"],
-)
-
-setup_scala_testing_toolchain(
-    name = "junit_toolchain",
-    junit_classpath = _JUNIT_DEPS,
-    visibility = ["//visibility:public"],
-)
+[
+    alias(
+        name = framework + "_toolchain",
+        actual = (
+            "@io_bazel_rules_scala_toolchains//testing:testing_toolchain" +
+            version_suffix(SCALA_VERSION)
+        ),
+    )
+    for framework in [
+        "testing",
+        "scalatest",
+        "specs2_junit",
+        "junit",
+    ]
+]

--- a/testing/deps.bzl
+++ b/testing/deps.bzl
@@ -1,0 +1,15 @@
+load("//junit:junit.bzl", "junit_artifact_ids")
+load("//scalatest:scalatest.bzl", "scalatest_artifact_ids")
+load("//specs2:specs2.bzl", "specs2_artifact_ids")
+load("//specs2:specs2_junit.bzl", "specs2_junit_artifact_ids")
+
+def _repoize(ids):
+    return ["@" + id for id in ids]
+
+JUNIT_DEPS = _repoize(junit_artifact_ids())
+
+SCALATEST_DEPS = _repoize(scalatest_artifact_ids())
+
+SPECS2_DEPS = _repoize(specs2_artifact_ids())
+
+SPECS2_JUNIT_DEPS = _repoize(specs2_junit_artifact_ids())

--- a/testing/scalatest.bzl
+++ b/testing/scalatest.bzl
@@ -7,4 +7,7 @@ def scalatest_repositories():
 
 def scalatest_toolchain():
     for scala_version in SCALA_VERSIONS:
-        native.register_toolchains("@io_bazel_rules_scala//testing:scalatest_toolchain" + version_suffix(scala_version))
+        native.register_toolchains(str(Label(
+            "//testing:scalatest_toolchain" +
+            version_suffix(scala_version),
+        )))

--- a/testing/testing.bzl
+++ b/testing/testing.bzl
@@ -1,7 +1,14 @@
-load("@io_bazel_rules_scala//scala:providers.bzl", "declare_deps_provider")
-load("@io_bazel_rules_scala//testing/toolchain:toolchain.bzl", "scala_testing_toolchain")
-load("//scala:scala_cross_version.bzl", "version_suffix")
+load("//scala:providers.bzl", "declare_deps_provider")
+load("//scala:scala_cross_version.bzl", "repositories", "version_suffix")
+load("//testing/toolchain:toolchain.bzl", "scala_testing_toolchain")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+
+DEP_PROVIDERS = [
+    "junit_classpath",
+    "scalatest_classpath",
+    "specs2_classpath",
+    "specs2_junit_classpath",
+]
 
 def _declare_deps_provider(macro_name, deps_id, deps, visibility):
     label = "%s_%s_provider" % (macro_name, deps_id)
@@ -11,7 +18,7 @@ def _declare_deps_provider(macro_name, deps_id, deps, visibility):
         visibility = visibility,
         deps = deps,
     )
-    return label
+    return ":%s" % label
 
 def setup_scala_testing_toolchain(
         name,
@@ -28,7 +35,7 @@ def setup_scala_testing_toolchain(
             _declare_deps_provider(
                 name,
                 "junit_classpath",
-                junit_classpath,
+                repositories(scala_version, junit_classpath),
                 visibility,
             ),
         )
@@ -38,7 +45,7 @@ def setup_scala_testing_toolchain(
             _declare_deps_provider(
                 name,
                 "specs2_junit_classpath",
-                specs2_junit_classpath,
+                repositories(scala_version, specs2_junit_classpath),
                 visibility,
             ),
         )
@@ -48,7 +55,7 @@ def setup_scala_testing_toolchain(
             _declare_deps_provider(
                 name,
                 "specs2_classpath",
-                specs2_classpath,
+                repositories(scala_version, specs2_classpath),
                 visibility,
             ),
         )
@@ -58,7 +65,7 @@ def setup_scala_testing_toolchain(
             _declare_deps_provider(
                 name,
                 "scalatest_classpath",
-                scalatest_classpath,
+                repositories(scala_version, scalatest_classpath),
                 visibility,
             ),
         )
@@ -72,7 +79,12 @@ def setup_scala_testing_toolchain(
     native.toolchain(
         name = name,
         toolchain = ":" + name + "_impl",
-        toolchain_type = "@io_bazel_rules_scala//testing/toolchain:testing_toolchain_type",
-        target_settings = ["@io_bazel_rules_scala_config//:scala_version" + version_suffix(scala_version)],
+        toolchain_type = Label("//testing/toolchain:testing_toolchain_type"),
+        target_settings = [
+            Label(
+                "@io_bazel_rules_scala_config//:scala_version" +
+                version_suffix(scala_version),
+            ),
+        ],
         visibility = visibility,
     )

--- a/testing/toolchain/BUILD
+++ b/testing/toolchain/BUILD
@@ -1,30 +1,16 @@
-load("@io_bazel_rules_scala//testing/toolchain:toolchain_deps.bzl", "testing_toolchain_deps")
+load(":toolchain_deps.bzl", "testing_toolchain_deps")
+load("//testing:testing.bzl", "DEP_PROVIDERS")
 
 toolchain_type(
     name = "testing_toolchain_type",
     visibility = ["//visibility:public"],
 )
 
-testing_toolchain_deps(
-    name = "junit_classpath",
-    deps_id = "junit_classpath",
-    visibility = ["//visibility:public"],
-)
-
-testing_toolchain_deps(
-    name = "scalatest_classpath",
-    deps_id = "scalatest_classpath",
-    visibility = ["//visibility:public"],
-)
-
-testing_toolchain_deps(
-    name = "specs2_classpath",
-    deps_id = "specs2_classpath",
-    visibility = ["//visibility:public"],
-)
-
-testing_toolchain_deps(
-    name = "specs2_junit_classpath",
-    deps_id = "specs2_junit_classpath",
-    visibility = ["//visibility:public"],
-)
+[
+    testing_toolchain_deps(
+        name = dep,
+        deps_id = dep,
+        visibility = ["//visibility:public"],
+    )
+    for dep in DEP_PROVIDERS
+]

--- a/testing/toolchain/toolchain.bzl
+++ b/testing/toolchain/toolchain.bzl
@@ -10,8 +10,6 @@ scala_testing_toolchain = rule(
     _scala_toolchain_impl,
     attrs = {
         "dep_providers": attr.label_list(
-            default = [
-            ],
             providers = [_DepsInfo],
         ),
     },

--- a/testing/toolchain/toolchain_deps.bzl
+++ b/testing/toolchain/toolchain_deps.bzl
@@ -3,7 +3,7 @@ load(
     "expose_toolchain_deps",
 )
 
-_toolchain_type = "@io_bazel_rules_scala//testing/toolchain:testing_toolchain_type"
+_toolchain_type = Label("//testing/toolchain:testing_toolchain_type")
 
 def _testing_toolchain_deps(ctx):
     return expose_toolchain_deps(ctx, _toolchain_type)

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -78,6 +78,7 @@ def repositories(
         maven_servers = default_maven_server_urls(),
         overriden_artifacts = {},
         fetch_sources = True,
+        fetch_sources_by_id = {},
         validate_scala_version = False):
     """
     Downloads given artifacts.
@@ -121,7 +122,7 @@ def repositories(
                 for dep in artifacts[id].get("runtime_deps", [])
             ],
             testonly_ = artifacts[id].get("testonly", False),
-            fetch_sources = fetch_sources,
+            fetch_sources = fetch_sources_by_id.get(id, fetch_sources),
         )
 
         # For backward compatibility: non-suffixed repo pointing to the suffixed one,

--- a/third_party/test/example_external_workspace/WORKSPACE
+++ b/third_party/test/example_external_workspace/WORKSPACE
@@ -33,7 +33,10 @@ scala_config()
 
 load("@io_bazel_rules_scala//scala:scala.bzl", "scala_toolchains")
 
-scala_toolchains(fetch_sources = True)
+scala_toolchains(
+    fetch_sources = True,
+    scalatest = True,
+)
 
 register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
 
@@ -52,9 +55,3 @@ rules_proto_toolchains()
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
-
-load("@io_bazel_rules_scala//testing:scalatest.bzl", "scalatest_repositories", "scalatest_toolchain")
-
-scalatest_repositories()
-
-scalatest_toolchain()


### PR DESCRIPTION
### Description

Moves the Scalatest, JUnit, and Specs2 toolchains into `@io_bazel_rules_scala_toolchains//testing`. Part of #1482.

Introduces more macros to return a framework's Maven artifact dependencies, rather than inlining them in a `repositories` call. These inlined lists are replaced by macro invocations, and now the `scala_toolchains` macro can invoke these macros to collect artifact IDs to pass to `repositories`. This also allows for future changes to introduce a `scala_version` parameter if necessary, similar to how `scalafmt_artifact_ids` already works.

Updates all `WORKSPACE` files to set the appropriate `scala_toolchains` parameters and to remove the unnecessary repository import and toolchain registration macros.

Adds a `fetch_sources_by_id` parameter to `repositories` from `third_party/repositories/repositories.bzl`.

Updates `scala/scala_maven_import_external.bzl` to generate a `load` line for `//scala:scala_import.bzl` based on the repo's canonical name, not `@io_bazel_rules_scala`.

As usual, includes several other opportunistic removals of the `@io_bazel_rules_scala` repo name prefix to avoid an internal dependency on that name.

### Motivation

The macros returning artifact ID lists help avoid collisions when creating repositories dependencies upon which multiple frameworks depend under Bzlmod. `WORKSPACE` doesn't seem affected by these collisions, but Bzlmod will produce errors like the following, where both `scala_proto` and `twitter_scrooge` depend upon `io_bazel_rules_scala_guava`:

```txt
$ bazel build //src/...

ERROR: .../scala/scala_maven_import_external.bzl:299:24:
  Traceback (most recent call last):
    File ".../scala/extensions/deps.bzl",
      line 140, column 21, in _scala_deps_impl
        scala_toolchains(
    File ".../scala/private/macros/toolchains.bzl",
      line 140, column 17, in scala_toolchains
        _scrooge(
    File ".../twitter_scrooge/twitter_scrooge.bzl",
      line 96, column 17, in twitter_scrooge
        repositories(
    File ".../third_party/repositories/repositories.bzl",
      line 113, column 37, in repositories
        _scala_maven_import_external(
    File ".../scala/scala_maven_import_external.bzl",
      line 263, column 30, in scala_maven_import_external
        jvm_maven_import_external(
    File ".../scala/scala_maven_import_external.bzl",
      line 299, column 24, in jvm_maven_import_external
        jvm_import_external(jar_urls = jar_urls, srcjar_urls = srcjar_urls, coordinates = artifact, **kwargs)

Error in repository_rule: A repo named
  io_bazel_rules_scala_guava_2_13_15
  is already generated by this module extension at
  .../scala/scala_maven_import_external.bzl:299:24

ERROR: Analysis of target
  '//src/java/io/bazel/rulesscala/worker:worker_test'
  failed; build aborted:
  error evaluating module extension scala_deps in
  //scala/extensions:deps.bzl
```

Recent updates to `scripts/create_repository.py` (#1639, #1642) make it easy to emit full direct dependency lists for artifacts included in `third_party/repositories/scala_*.bzl`. This increases the likelihood of collisions, since this expanded metadata forces the macros that instantiate artifact repos to instantiate even more repos.

By fetching lists of artifact IDs from these macros, `scala_toolchains` can now consolidate them into dictionary keys. Then it passes these unique keys to `repositories` directly, avoiding the problem of instantiating the same repo multiple times in the same module extension.

This, in turn, also avoids the need to add parameters to the original `WORKSPACE` macros that instantiate dependencies to avoid collisions under Bzlmod. The `scala_toolchains` macro never needs to call these original macros, under either `WORKSPACE` or Bzlmod.

Finally, it also reduces duplication between these artifact ID lists and the `_*_DEPS` symbols originally from `testing/BUILD` (and now in `testing/deps.bzl`). The dependency labels are now generated programatically.

(Aside: As I mentioned, we may eventually need to pass a Scala version argument to these macros. It will be possible to cross that bridge without too much trouble if and when that day comes. Or I can try to future proof it in a follow up pull request.)

Adding the `fetch_sources_by_id` parameter to `repositories()` enables `scala_toolchains` to build the `artifact_ids_to_fetch_sources` mapping from artifact ID lists returned by these new macros. The values assigned to each id match the original `fetch_sources` settings in the corresponding original `WORKSPACE` macros.

Removing `@io_bazel_rules_scala` target prefixes means Bzlmod users won't necessarily have to set the `repo_name` parameter of `bazel_dep` when using `rules_scala`.