### PR TITLE
Move `rules_scala_dependencies` to scala/deps.bzl

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,10 +95,10 @@ local_repository(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
+    sha256 = "0936c9bc3c4321ee372cb8f66dd972d368cb940ed01a9ba9fd7debcf0093f09b",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -95,10 +95,10 @@ local_repository(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "0936c9bc3c4321ee372cb8f66dd972d368cb940ed01a9ba9fd7debcf0093f09b",
+    sha256 = "90fe8fb402dee957a375f3eb8511455bd738c7ed562695f4dd117ac7d2d833b1",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.51.0/rules_go-v0.51.0.zip",
+        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip",
+        "https://github.com/bazel-contrib/rules_go/releases/download/v0.52.0/rules_go-v0.52.0.zip",
     ],
 )
 

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,15 +1,13 @@
 workspace(name = "io_bazel_rules_scala")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("//scala:deps.bzl", "rules_scala_dependencies")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
-)
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
 
 load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
 
@@ -17,14 +15,32 @@ bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
+
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
@@ -42,22 +58,6 @@ register_toolchains(
     "//test/proto:scalapb_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
 
 load("//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
 
@@ -95,10 +95,10 @@ local_repository(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "6dc2da7ab4cf5d7bfc7c949776b1b7c733f05e56edc4bcd9022bb249d2e2a996",
+    sha256 = "f4a9314518ca6acfa16cc4ab43b0b8ce1e4ea64b81c38d8a3772883f153346b8",
     urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
-        "https://github.com/bazelbuild/rules_go/releases/download/v0.39.1/rules_go-v0.39.1.zip",
+        "https://mirror.bazel.build/github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
+        "https://github.com/bazelbuild/rules_go/releases/download/v0.50.1/rules_go-v0.50.1.zip",
     ],
 )
 
@@ -110,7 +110,7 @@ load(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.19.5")
+go_register_toolchains(version = "1.23.4")
 
 http_archive(
     name = "bazelci_rules",
@@ -129,17 +129,5 @@ rbe_preconfig(
 load("//scala/private/extensions:dev_deps.bzl", "dev_deps_repositories")
 
 dev_deps_repositories()
-
-# Copied from bazel_tools/tools/jdk/remote_java_repository.bzl.
-[
-    register_toolchains(
-        "@remotejdk21_" + platform + "_toolchain_config_repo//:all",
-    )
-    for platform in [
-        "linux",
-        "macos",
-        "win",
-    ]
-]
 
 register_toolchains("//test/toolchains:java21_toolchain_definition")

--- a/dt_patches/test_dt_patches/WORKSPACE
+++ b/dt_patches/test_dt_patches/WORKSPACE
@@ -2,30 +2,51 @@ workspace(name = "test_dt_patches")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
@@ -51,19 +72,3 @@ register_toolchains(
     ":dt_scala_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -2,30 +2,51 @@ workspace(name = "test_dt_patches")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
@@ -125,19 +146,3 @@ register_toolchains(
     ":dt_scala_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -2,30 +2,51 @@ workspace(name = "cross_build")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "d00f1389ee20b60018e92644e0948e16e350a7707219e7a390fb0a99b6ec9262",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
@@ -43,19 +64,3 @@ load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
 scala_toolchains(scalatest = True)
 
 register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -2,40 +2,39 @@ workspace(name = "specs2_junit_repositories")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+protobuf_deps()
 
-scala_config(scala_version = "3.6.2")
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
-
-scala_toolchains(fetch_sources = True)
-
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+rules_java_toolchains()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -49,6 +48,12 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-protobuf_deps()
+scala_config(scala_version = "3.6.2")
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+
+scala_toolchains(fetch_sources = True)
+
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")

--- a/examples/semanticdb/WORKSPACE
+++ b/examples/semanticdb/WORKSPACE
@@ -2,33 +2,51 @@ workspace(name = "specs2_junit_repositories")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-skylib_version = "1.4.1"
-
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    type = "tar.gz",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/{}/bazel-skylib-{}.tar.gz".format(skylib_version, skylib_version),
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
@@ -43,19 +61,3 @@ register_toolchains(
     "//:semanticdb_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -2,30 +2,51 @@ workspace(name = "multi_frameworks_toolchain")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+
+protobuf_deps()
+
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
@@ -42,19 +63,3 @@ register_toolchains(
     ":testing_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-
-rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -2,43 +2,39 @@ workspace(name = "scalatest_repositories")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+protobuf_deps()
 
-scala_config()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
-
-scala_toolchains(
-    fetch_sources = True,
-    scalatest = True,
-)
-
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+rules_java_toolchains()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -52,6 +48,15 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-protobuf_deps()
+scala_config()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+
+scala_toolchains(
+    fetch_sources = True,
+    scalatest = True,
+)
+
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -2,43 +2,39 @@ workspace(name = "specs2_junit_repositories")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+protobuf_deps()
 
-scala_config()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
-
-scala_toolchains(
-    fetch_sources = True,
-    specs2 = True,
-)
-
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+rules_java_toolchains()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -52,6 +48,15 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-protobuf_deps()
+scala_config()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+
+scala_toolchains(
+    fetch_sources = True,
+    specs2 = True,
+)
+
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -69,7 +69,7 @@ scala_generate_benchmark = rule(
             ),
         ),
         "runtime_jdk": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+            default = Label("@rules_java//toolchains:current_java_runtime"),
             providers = [java_common.JavaRuntimeInfo],
         ),
     },
@@ -90,7 +90,10 @@ def scala_benchmark_jmh(**kw):
     testonly = kw.get("testonly", False)
     scalacopts = kw.get("scalacopts", [])
     main_class = kw.get("main_class", "org.openjdk.jmh.Main")
-    runtime_jdk = kw.get("runtime_jdk", "@bazel_tools//tools/jdk:current_java_runtime")
+    runtime_jdk = kw.get(
+        "runtime_jdk",
+        "@rules_java//toolchains:current_java_runtime",
+    )
 
     scala_library(
         name = lib,

--- a/scala/deps.bzl
+++ b/scala/deps.bzl
@@ -1,0 +1,58 @@
+"""Macro for instantiating repos required for core functionality."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
+
+def rules_scala_dependencies():
+    """Instantiates repos needed by rules provided by `rules_scala`."""
+    maybe(
+        http_archive,
+        name = "bazel_skylib",
+        sha256 = "bc283cdfcd526a52c3201279cda4bc298652efa898b10b4db0837dc51652756f",
+        urls = [
+            "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+            "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.1/bazel-skylib-1.7.1.tar.gz",
+        ],
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_cc",
+        urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.9/rules_cc-0.0.9.tar.gz"],
+        sha256 = "2037875b9a4456dce4a79d112a8ae885bbc4aad968e6587dca6e64f3a0900cdf",
+        strip_prefix = "rules_cc-0.0.9",
+    )
+
+    # Needed by protobuf-21.7 and Bazel 6.5.0, as later versions require C++14.
+    maybe(
+        http_archive,
+        name = "com_google_absl",
+        sha256 = "91ac87d30cc6d79f9ab974c51874a704de9c2647c40f6932597329a282217ba8",
+        strip_prefix = "abseil-cpp-20220623.1",
+        url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.1.tar.gz",
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_java",
+        urls = [
+            "https://github.com/bazelbuild/rules_java/releases/download/7.12.3/rules_java-7.12.3.tar.gz",
+        ],
+        sha256 = "c0ee60f8757f140c157fc2c7af703d819514de6e025ebf70386d38bdd85fce83",
+    )
+
+    maybe(
+        http_archive,
+        name = "com_google_protobuf",
+        sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
+        strip_prefix = "protobuf-21.7",
+        url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.7.tar.gz",
+    )
+
+    maybe(
+        http_archive,
+        name = "rules_proto",
+        sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
+        strip_prefix = "rules_proto-6.0.2",
+        url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
+    )

--- a/scala/deps.bzl
+++ b/scala/deps.bzl
@@ -36,9 +36,9 @@ def rules_scala_dependencies():
         http_archive,
         name = "rules_java",
         urls = [
-            "https://github.com/bazelbuild/rules_java/releases/download/7.12.3/rules_java-7.12.3.tar.gz",
+            "https://github.com/bazelbuild/rules_java/releases/download/7.12.4/rules_java-7.12.4.tar.gz",
         ],
-        sha256 = "c0ee60f8757f140c157fc2c7af703d819514de6e025ebf70386d38bdd85fce83",
+        sha256 = "302bcd9592377bf9befc8e41aa97ec02df12813d47af9979e4764f3ffdcc5da8",
     )
 
     maybe(

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -29,7 +29,7 @@ common_attrs_for_plugin_bootstrapping = {
     "resource_strip_prefix": attr.string(),
     "resource_jars": attr.label_list(allow_files = True),
     "java_compile_toolchain": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+        default = Label("@rules_java//toolchains:current_java_toolchain"),
         providers = [java_common.JavaToolchainInfo],
     ),
     "scalacopts": attr.string_list(),
@@ -82,10 +82,10 @@ common_attrs.update({
 
 implicit_deps = {
     "_java_runtime": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        default = Label("@rules_java//toolchains:current_java_runtime"),
     ),
     "_java_host_runtime": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+        default = Label("@rules_java//toolchains:current_host_java_runtime"),
     ),
     "_scalac": attr.label(
         executable = True,

--- a/scala/private/extensions/dev_deps.bzl
+++ b/scala/private/extensions/dev_deps.bzl
@@ -2,10 +2,8 @@
 
 load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//scala:scala_maven_import_external.bzl", "java_import_external")
-load("//test/toolchains:jdk.bzl", "remote_jdk21_repositories")
 load("//third_party/repositories:repositories.bzl", "repositories")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
-load("@rules_java//java:repositories.bzl", "remote_jdk8_repos")
 
 _BUILD_TOOLS_RELEASE = "5.1.0"
 
@@ -45,10 +43,6 @@ def dev_deps_repositories(
         testonly_ = True,
     )
 
-    # We need to select based on platform when we use these
-    # https://github.com/bazelbuild/bazel/issues/11655
-    remote_jdk8_repos()
-
     repositories(
         fetch_sources = fetch_sources,
         for_artifact_ids = [
@@ -73,5 +67,3 @@ def dev_deps_repositories(
         ],
         maven_servers = maven_servers,
     )
-
-    remote_jdk21_repositories()

--- a/scala/private/macros/scala_repositories.bzl
+++ b/scala/private/macros/scala_repositories.bzl
@@ -1,3 +1,4 @@
+load("//scala:deps.bzl", "rules_scala_dependencies")
 load(
     "//scala:scala_cross_version.bzl",
     "extract_major_version",
@@ -117,59 +118,6 @@ def dt_patched_compiler_setup(scala_version, scala_compiler_srcjar = None):
             integrity = srcjar.get("integrity"),
         )
 
-def load_rules_dependencies():
-    if not native.existing_rule("bazel_skylib"):
-        http_archive(
-            name = "bazel_skylib",
-            sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-            urls = [
-                "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-                "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-            ],
-        )
-
-    # Needed by protobuf-21.7 and Bazel 6.5.0, as later versions require C++14.
-    if not native.existing_rule("com_google_absl"):
-        http_archive(
-            name = "com_google_absl",
-            sha256 = "91ac87d30cc6d79f9ab974c51874a704de9c2647c40f6932597329a282217ba8",
-            strip_prefix = "abseil-cpp-20220623.1",
-            url = "https://github.com/abseil/abseil-cpp/archive/refs/tags/20220623.1.tar.gz",
-        )
-
-    if not native.existing_rule("com_google_protobuf"):
-        http_archive(
-            name = "com_google_protobuf",
-            sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-            strip_prefix = "protobuf-21.7",
-            url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.7.tar.gz",
-        )
-
-    if not native.existing_rule("rules_cc"):
-        http_archive(
-            name = "rules_cc",
-            urls = ["https://github.com/bazelbuild/rules_cc/releases/download/0.0.6/rules_cc-0.0.6.tar.gz"],
-            sha256 = "3d9e271e2876ba42e114c9b9bc51454e379cbf0ec9ef9d40e2ae4cec61a31b40",
-            strip_prefix = "rules_cc-0.0.6",
-        )
-
-    if not native.existing_rule("rules_java"):
-        http_archive(
-            name = "rules_java",
-            urls = [
-                "https://github.com/bazelbuild/rules_java/releases/download/7.9.0/rules_java-7.9.0.tar.gz",
-            ],
-            sha256 = "41131de4417de70b9597e6ebd515168ed0ba843a325dc54a81b92d7af9a7b3ea",
-        )
-
-    if not native.existing_rule("rules_proto"):
-        http_archive(
-            name = "rules_proto",
-            sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
-            strip_prefix = "rules_proto-6.0.2",
-            url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
-        )
-
 def setup_scala_compiler_sources(srcjars = {}):
     """Generates Scala compiler source repos used internally by rules_scala.
 
@@ -188,7 +136,7 @@ def setup_scala_compiler_sources(srcjars = {}):
     )
 
 def rules_scala_setup(scala_compiler_srcjar = None):
-    load_rules_dependencies()
+    rules_scala_dependencies()
     setup_scala_compiler_sources({
         version: scala_compiler_srcjar
         for version in SCALA_VERSIONS
@@ -260,7 +208,7 @@ def scala_repositories(
         scala_compiler_srcjars = {}):
     if load_dep_rules:
         # When `WORKSPACE` goes away, so can this case.
-        load_rules_dependencies()
+        rules_scala_dependencies()
 
     setup_scala_compiler_sources(scala_compiler_srcjars)
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -14,7 +14,7 @@
 """Rules for supporting the Scala language."""
 
 load("@bazel_skylib//lib:paths.bzl", "paths")
-load("@bazel_tools//tools/jdk:toolchain_utils.bzl", "find_java_toolchain")
+load("@rules_java//toolchains:toolchain_utils.bzl", "find_java_toolchain")
 load(":common.bzl", "rlocationpath_from_rootpath", _collect_plugin_paths = "collect_plugin_paths")
 load(":resources.bzl", _resource_paths = "paths")
 

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -58,7 +58,7 @@ _scala_binary_attrs = {
     "classpath_resources": attr.label_list(allow_files = True),
     "jvm_flags": attr.string_list(),
     "runtime_jdk": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        default = Label("@rules_java//toolchains:current_java_runtime"),
         providers = [java_common.JavaRuntimeInfo],
     ),
 }

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -79,7 +79,7 @@ _scala_junit_test_attrs = {
     ),
     "jvm_flags": attr.string_list(),
     "runtime_jdk": attr.label(
-        default = Label("@bazel_tools//tools/jdk:current_java_runtime"),
+        default = Label("@rules_java//toolchains:current_java_runtime"),
         providers = [java_common.JavaRuntimeInfo],
     ),
     "env": attr.string_dict(default = {}),

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -145,7 +145,7 @@ scala_import = rule(
             default = Label("//scala/settings:stamp_scala_import"),
         ),
         "java_compile_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+            default = Label("@rules_java//toolchains:current_java_toolchain"),
         ),
     },
     toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],

--- a/scala/scalafmt/phase_scalafmt_ext.bzl
+++ b/scala/scalafmt/phase_scalafmt_ext.bzl
@@ -24,7 +24,9 @@ ext_scalafmt = {
             executable = True,
         ),
         "_java_host_runtime": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+            default = Label(
+                "@rules_java//toolchains:current_host_java_runtime",
+            ),
         ),
         "_runner": attr.label(
             allow_single_file = True,

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -209,10 +209,12 @@ def _scala_proto_aspect_impl(target, ctx):
 def make_scala_proto_aspect(*extras):
     attrs = {
         "_java_toolchain": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_java_toolchain"),
+            default = Label("@rules_java//toolchains:current_java_toolchain"),
         ),
         "_java_host_runtime": attr.label(
-            default = Label("@bazel_tools//tools/jdk:current_host_java_runtime"),
+            default = Label(
+                "@rules_java//toolchains:current_host_java_runtime",
+            ),
         ),
     }
     return aspect(

--- a/test/BUILD
+++ b/test/BUILD
@@ -488,7 +488,7 @@ scala_binary(
     name = "scala_binary_jdk_11",
     srcs = ["ScalaBinaryJdk11.scala"],
     main_class = "scalarules.test.ScalaBinaryJdk11",
-    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    runtime_jdk = "@rules_java//toolchains:remote_jdk11",
 )
 
 # Make sure scala_library respects java_compile_toolchain during builds
@@ -790,14 +790,14 @@ scala_library(
         "src/main/scala/scalarules/test/junit/runtime_platform/JunitRuntimePlatformTest.java",
     ],
     # make sure java compilation toolchain matches runtime toolchain ie --target
-    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java11",
+    java_compile_toolchain = "@rules_java//toolchains:toolchain_java11",
     deps = _JUNIT_DEPS,
 )
 
 scala_junit_test(
     name = "JunitRuntimePlatform_test_runner",
     size = "small",
-    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    runtime_jdk = "@rules_java//toolchains:remote_jdk11",
     suffixes = ["Test"],
     tests_from = [":JunitRuntimePlatform"],
     runtime_deps = [":JunitRuntimePlatform"],

--- a/test/jmh/BUILD
+++ b/test/jmh/BUILD
@@ -63,7 +63,7 @@ scala_benchmark_jmh(
 scala_benchmark_jmh(
     name = "test_jmh_jdk11",
     srcs = ["TestJmhRuntimeJdk11.scala"],
-    runtime_jdk = "@bazel_tools//tools/jdk:remote_jdk11",
+    runtime_jdk = "@rules_java//toolchains:remote_jdk11",
 )
 
 [sh_test(

--- a/test/shell/test_twitter_scrooge.sh
+++ b/test/shell/test_twitter_scrooge.sh
@@ -5,13 +5,7 @@ dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 runner=$(get_test_runner "${1:-local}")
 
 scrooge_compile_with_jdk_11() {
-    # javabase and java_toolchain parameters are deprecated and may be
-    # removed in Bazel >= 5.0.0
-    bazel build --javabase=@bazel_tools//tools/jdk:remote_jdk11 \
-        --host_javabase=@bazel_tools//tools/jdk:remote_jdk11 \
-        --host_java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
-        --java_toolchain=@bazel_tools//tools/jdk:toolchain_java11 \
-        --javacopt='--release 11' \
+    bazel build \
         --java_language_version=11 \
         --tool_java_language_version=11 \
         --java_runtime_version=remotejdk_11 \

--- a/test/src/main/resources/java_sources/BUILD
+++ b/test/src/main/resources/java_sources/BUILD
@@ -5,11 +5,11 @@ package(default_visibility = ["//visibility:public"])
 scala_library(
     name = "CompiledWithJava8",
     srcs = ["SimpleJavaSourceFileA.java"],
-    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java8",
+    java_compile_toolchain = "@rules_java//toolchains:toolchain_java8",
 )
 
 scala_library(
     name = "CompiledWithJava11",
     srcs = ["SimpleJavaSourceFileB.java"],
-    java_compile_toolchain = "@bazel_tools//tools/jdk:toolchain_java11",
+    java_compile_toolchain = "@rules_java//toolchains:toolchain_java11",
 )

--- a/test/toolchains/BUILD.bazel
+++ b/test/toolchains/BUILD.bazel
@@ -1,6 +1,6 @@
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load(
-    "@bazel_tools//tools/jdk:default_java_toolchain.bzl",
+    "@rules_java//toolchains:default_java_toolchain.bzl",
     "BASE_JDK9_JVM_OPTS",
     "DEFAULT_JAVACOPTS",
     "DEFAULT_TOOLCHAIN_CONFIGURATION",

--- a/test/toolchains/jdk.bzl
+++ b/test/toolchains/jdk.bzl
@@ -1,5 +1,8 @@
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
-load("@bazel_tools//tools/jdk:remote_java_repository.bzl", "remote_java_repository")
+load(
+    "@rules_java//toolchains:remote_java_repository.bzl",
+    "remote_java_repository",
+)
 
 def remote_jdk21_repositories():
     maybe(

--- a/test_cross_build/WORKSPACE
+++ b/test_cross_build/WORKSPACE
@@ -2,39 +2,39 @@
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "d00f1389ee20b60018e92644e0948e16e350a7707219e7a390fb0a99b6ec9262",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.7.0/bazel-skylib-1.7.0.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
-    strip_prefix = "rules_proto-6.0.2",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    strip_prefix = "protobuf-21.7",
-    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.7.tar.gz",
-)
+protobuf_deps()
+
+rules_java_toolchains()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -47,15 +47,6 @@ rules_proto_setup()
 load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
-
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
-
-protobuf_deps()
-
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "..",
-)
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -2,62 +2,55 @@ workspace(name = "io_bazel_rules_scala_test")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../../"
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-http_archive(
-    name = "rules_proto",
-    sha256 = "6fb6767d1bef535310547e03247f7518b03487740c11b6c6adb7952033fe1295",
-    strip_prefix = "rules_proto-6.0.2",
-    url = "https://github.com/bazelbuild/rules_proto/releases/download/6.0.2/rules_proto-6.0.2.tar.gz",
-)
-
-http_archive(
-    name = "com_google_protobuf",
-    sha256 = "75be42bd736f4df6d702a0e4e4d30de9ee40eac024c4b845d17ae4cc831fe4ae",
-    strip_prefix = "protobuf-21.7",
-    url = "https://github.com/protocolbuffers/protobuf/archive/refs/tags/v21.7.tar.gz",
-)
-
-load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
-rules_proto_dependencies()
-
-load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
-rules_proto_setup()
-
-load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
-rules_proto_toolchains()
-
 load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
 protobuf_deps()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../../"
-)
+rules_java_toolchains()
+
+load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
+
+rules_proto_dependencies()
+
+load("@rules_proto//proto:setup.bzl", "rules_proto_setup")
+
+rules_proto_setup()
+
+load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
+
+rules_proto_toolchains()
 
 load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
-scala_config(enable_compiler_dependency_tracking = True)
 
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "extract_major_version")
+scala_config(enable_compiler_dependency_tracking = True)
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
 

--- a/third_party/test/example_external_workspace/WORKSPACE
+++ b/third_party/test/example_external_workspace/WORKSPACE
@@ -2,43 +2,39 @@ workspace(name = "example_external_workspace")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../../..",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+protobuf_deps()
 
-scala_config()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
-
-scala_toolchains(
-    fetch_sources = True,
-    scalatest = True,
-)
-
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+rules_java_toolchains()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -52,6 +48,15 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-protobuf_deps()
+scala_config()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+
+scala_toolchains(
+    fetch_sources = True,
+    scalatest = True,
+)
+
+register_toolchains("@io_bazel_rules_scala_toolchains//...:all")

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -2,43 +2,39 @@ workspace(name = "proto")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
-http_archive(
-    name = "bazel_skylib",
-    sha256 = "b8a1527901774180afc798aeb28c4634bdccf19c4d98e7bdd1ce79d1fe9aaad7",
-    urls = [
-        "https://mirror.bazel.build/github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-        "https://github.com/bazelbuild/bazel-skylib/releases/download/1.4.1/bazel-skylib-1.4.1.tar.gz",
-    ],
+local_repository(
+    name = "io_bazel_rules_scala",
+    path = "../../..",
 )
+
+load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+
+rules_scala_dependencies()
+
+load("@rules_java//java:repositories.bzl", "rules_java_dependencies", "rules_java_toolchains")
+
+rules_java_dependencies()
+
+load("@bazel_skylib//:workspace.bzl", "bazel_skylib_workspace")
+
+bazel_skylib_workspace()
 
 http_archive(
     name = "rules_python",
-    sha256 = "ca77768989a7f311186a29747e3e95c936a41dffac779aff6b443db22290d913",
-    strip_prefix = "rules_python-0.36.0",
-    url = "https://github.com/bazelbuild/rules_python/releases/download/0.36.0/rules_python-0.36.0.tar.gz",
+    sha256 = "ca2671529884e3ecb5b79d6a5608c7373a82078c3553b1fa53206e6b9dddab34",
+    strip_prefix = "rules_python-0.38.0",
+    url = "https://github.com/bazelbuild/rules_python/releases/download/0.38.0/rules_python-0.38.0.tar.gz",
 )
 
 load("@rules_python//python:repositories.bzl", "py_repositories")
 
 py_repositories()
 
-local_repository(
-    name = "io_bazel_rules_scala",
-    path = "../../../",
-)
+load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+protobuf_deps()
 
-scala_config()
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
-
-scala_toolchains()
-
-register_toolchains(
-    "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
-)
+rules_java_toolchains()
 
 load("@rules_proto//proto:repositories.bzl", "rules_proto_dependencies")
 
@@ -52,9 +48,18 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@com_google_protobuf//:protobuf_deps.bzl", "protobuf_deps")
+load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
 
-protobuf_deps()
+scala_config()
+
+load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+
+scala_toolchains()
+
+register_toolchains(
+    "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
+    "@io_bazel_rules_scala_toolchains//...:all",
+)
 
 load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
 

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -435,7 +435,9 @@ common_attrs = {
             ),
         ],
     ),
-    "_java_host_runtime": attr.label(default = Label("@bazel_tools//tools/jdk:current_host_java_runtime")),
+    "_java_host_runtime": attr.label(
+        default = Label("@rules_java//toolchains:current_host_java_runtime"),
+    ),
 }
 
 common_aspect_providers = [
@@ -475,7 +477,9 @@ scrooge_java_aspect = aspect(
     attrs = dicts.add(
         common_attrs,
         {
-            "_java_toolchain": attr.label(default = Label("@bazel_tools//tools/jdk:current_java_toolchain")),
+            "_java_toolchain": attr.label(default = Label(
+                "@rules_java//toolchains:current_java_toolchain",
+            )),
         },
     ),
     provides = [ScroogeAspectInfo],


### PR DESCRIPTION
### Description

Moves `rules_scala_dependencies` to `scala/deps.bzl` and bumps several dependencies as high as they can go and still be compatible with Bazel 6.5.0 and 7.4.1.

- `bazel_skylib`: 1.4.1 => 1.7.1
- `go`: 1.19.5 => 1.23.4
- `rules_cc`: 0.0.6 => 0.0.9
- `rules_go`: 0.39.1 => 0.50.1
- `rules_java`: 7.9.0 => 7.12.3
- `rules_python`: 0.36.0 => 0.38.0

The `rules_java` 7.12.13 bump precipitated the following changes:

- Adds the `WORKSPACE` stanza for `rules_java` in every `WORKSPACE` file per https://github.com/bazelbuild/rules_java/releases/tag/7.12.3. This replaces previous calls to instantiate `rules_java` repos and to register `rules_java` toolchains.

- Rearranges the other `WORKSPACE` setup macros for dependencies to come before the `rules_scala` setup macros.

- Updates almost all dependencies on `@bazel_tools//tools/jdk:` toolchain targets and `.bzl` files to corresponding targets and files in `@rules_java//toolchains:`.

- Removes several deprecated flags from the `scrooge_compile_with_jdk_11` test case from `test/shell/test_twitter_scrooge.sh`, and one obsolete flag that caused it to break.

### Motivation

Moving `rules_scala_dependencies` to `scala/deps.bzl` ensures we get all the versions of dependencies we want in `WORKSPACE`, while providing a new API to consumers. It also prevents `WORKSPACE` from transitively loading any `.bzl` files that load `@rules_java`, ensuring Bazel 8 compatibility per #1652.

Reasons for the other `rules_java` related changes include:

- The `WORKSPACE` stanza for `rules_java` should've already been present while using the existing version 7.9.0. However, doing so would've broken Bazel 6 builds.

- Having the other `WORKSPACE` setup macros for dependencies come before the `rules_scala` setup macros helps ensure consistent, correct initialization before `rules_scala` initialization.

- Updating the toolchain specifiers to use `@rules_java//toolchains` fixed `WORKSPACE` build breakages when updating to `rules_java` 7.10.0 and later. __This is a potentially breaking change for consumers, but in the good kind of way, in that it requires an easy, futureproof update.__ (`@bazel_tools//tools/jdk:toolchain_type` dependencies remain, as there's not yet a corresponding `@rules_java//toolchains` target.)

The commit message contains extensive notes on why some dependency versions are capped where they are, and on some breakages fixed by these changes.

_As always, I'm happy to break this down further if desired. I've got a couple of branches with my original commits, so breaking it down wouldn't be a problem._