### PR TITLE
Set latest Bazel build to 7.x after 8.0.0 release

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -32,7 +32,8 @@ tasks:
   test_rules_scala_linux_latest:
     name: "./test_rules_scala (latest Bazel)"
     platform: ubuntu2004
-    bazel: latest
+    # Restore `bazel: latest` once Bazel 8 compatibility lands (#1625, #1652).
+    bazel: 7.x
     shell_commands:
     # Install xmllint
     - sudo apt update && sudo apt install --reinstall libxml2-utils -y


### PR DESCRIPTION
### Description

Replaces the `latest` Bazel version specifier with `7.x`. Part of #1625 and #1652.

- https://github.com/bazelbuild/bazelisk?tab=readme-ov-file#how-does-bazelisk-know-which-bazel-version-to-run

### Motivation

This fixes CI builds because Bazel 8.0.0 just came out, but `rules_scala` is not yet Bazel 8 compatible, causing `latest Bazel` builds to fail.