### PR TITLE
refactor scalac java_binary target creation

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/BUILD
@@ -1,53 +1,15 @@
-load("@rules_java//java:defs.bzl", "java_binary")
-load("@io_bazel_rules_scala_config//:config.bzl", "ENABLE_COMPILER_DEPENDENCY_TRACKING")
 load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load("//src/java/io/bazel/rulesscala/scalac:definitions.bzl", "define_scalac", "define_scalac_bootstrap")
 
-SCALAC_DEPS = [
-    "//scala/private/toolchain_deps:scala_compile_classpath",
-    "//src/java/io/bazel/rulesscala/io_utils",
-    "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
-    "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/jar",
-    "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/worker",
-    "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
-    "//src/java/io/bazel/rulesscala/scalac/compileoptions",
-    "//src/java/io/bazel/rulesscala/scalac/reporter",
-]
+define_scalac()
 
-java_binary(
-    name = "scalac",
-    srcs = [
-        ":scalac_files",
-    ],
-    javacopts = [
-        "-source 1.8",
-        "-target 1.8",
-    ],
-    main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
-    visibility = ["//visibility:public"],
-    deps = ([
-        "//third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler:dep_reporting_compiler",
-    ] if ENABLE_COMPILER_DEPENDENCY_TRACKING else []) + SCALAC_DEPS,
-)
-
-java_binary(
-    name = "scalac_bootstrap",
-    srcs = [
-        ":scalac_files",
-    ],
-    javacopts = [
-        "-source 1.8",
-        "-target 1.8",
-    ],
-    main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
-    visibility = ["//visibility:public"],
-    deps = SCALAC_DEPS,
-)
+define_scalac_bootstrap()
 
 filegroup(
     name = "scalac_files",
     srcs = [
-        "ScalacWorker.java",
         "ScalacInvokerResults.java",
+        "ScalacWorker.java",
     ] + select_for_scala_version(
         any_2 = glob(["scala_2/*.java"]),
         any_3 = glob(["scala_3/*.java"]),

--- a/src/java/io/bazel/rulesscala/scalac/definitions.bzl
+++ b/src/java/io/bazel/rulesscala/scalac/definitions.bzl
@@ -1,0 +1,48 @@
+load("@io_bazel_rules_scala_config//:config.bzl", "ENABLE_COMPILER_DEPENDENCY_TRACKING")
+load("@rules_java//java:defs.bzl", "java_binary")
+
+DEFAULT_SCALAC_DEPS = [
+    Label(dep)
+    for dep in [
+        "//scala/private/toolchain_deps:scala_compile_classpath",
+        "//src/java/io/bazel/rulesscala/io_utils",
+        "//src/java/io/bazel/rulesscala/jar",
+        "//src/java/io/bazel/rulesscala/worker",
+        "//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
+        "//src/java/io/bazel/rulesscala/scalac/compileoptions",
+        "//src/java/io/bazel/rulesscala/scalac/reporter",
+        "@bazel_tools//src/main/protobuf:worker_protocol_java_proto",
+    ]
+]
+
+DEFAULT_SRCS = [
+    Label("//src/java/io/bazel/rulesscala/scalac:scalac_files"),
+]
+
+def define_scalac(name = "scalac", srcs = DEFAULT_SRCS, deps = DEFAULT_SCALAC_DEPS):
+    java_binary(
+        name = name,
+        srcs = srcs,
+        javacopts = [
+            "-source 1.8",
+            "-target 1.8",
+        ],
+        main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
+        visibility = ["//visibility:public"],
+        deps = ([
+            Label("//third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler:dep_reporting_compiler"),
+        ] if ENABLE_COMPILER_DEPENDENCY_TRACKING else []) + deps,
+    )
+
+def define_scalac_bootstrap(name = "scalac_bootstrap", srcs = DEFAULT_SRCS, deps = DEFAULT_SCALAC_DEPS):
+    java_binary(
+        name = name,
+        srcs = srcs,
+        javacopts = [
+            "-source 1.8",
+            "-target 1.8",
+        ],
+        main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
+        visibility = ["//visibility:public"],
+        deps = deps,
+    )


### PR DESCRIPTION
I'd like to remove Scala compiler extensions from the Scala toolchain, that I could be potentially building myself (in the same monorepo, build the compiler extension, but also use it).

Till now the only way to add Scala compiler dependencies was a toolchain.
If I left the compiler extension as a toolchain dependency there, I could not build the compiler extension due to a cycle in deps (building the compiler extension would depend on itself through the toolchain).

I'd like to work this around by defining my own scalac java_binary target, where I can define my own dependencies (and then create rule names with macros that override the scalac target).

To do this without duplicating code from rules_scala, refactor SCALAC_DEPS parameter and scalac target definitions to a Starlark file to make them reusable for outside users.

Added:
- `define_scalac()`
- `define_scalac_bootstrap()`

A user could do:
```
EXTENDED_SCALAC_DEPS = DEFAULT_SCALAC_DEPS + [
    "@//my/compiler/dependency:library",
]

define_scalac(
    name = "scalac_with_extensions",
    deps = EXTENDED_SCALAC_DEPS,
)
```

And then build that compiler library in the same monorepo, this way, providing compiler dependencies without  toolchains.

See #1674 for more information.
