### PR TITLE
Throw a more informative error when scala_macro_library isn't used

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -237,7 +237,7 @@ class ScalacWorker implements Worker.Interface {
       }
       if (ops.directTargets.length > 0) {
         pluginParams.add(
-          "-P:dependency-analyzer:direct-targets:" + encodeStringSeqPluginParam(ops.directTargets));
+          "-P:dependency-analyzer:direct-targets:" + encodeStringSeqPluginParam(ops.directTargets));   
       }
       if (ops.indirectJars.length > 0) {
         pluginParams.add(
@@ -269,20 +269,7 @@ class ScalacWorker implements Worker.Interface {
     String[] compilerArgs =
         merge(ops.scalaOpts, pluginArgs, constParams, pluginParams, scalaSources);
 
-    ScalacInvokerResults compilerResults;
-
-    try {
-      compilerResults = ScalacInvoker.invokeCompiler(ops, compilerArgs);
-    } catch (CompilationFailed exception) {
-      if (exception.getCause() instanceof ClassFormatError) {
-        throw new Exception(
-          "You may have declared a target containing a macro as a `scala_library` target instead of a `scala_macro_library` target.",
-          exception
-        );
-      }
-
-      throw exception;
-    }
+    ScalacInvokerResults compilerResults = ScalacInvoker.invokeCompiler(ops, compilerArgs);
 
     if (ops.printCompileTime) {
       System.err.println("Compiler runtime: " + (compilerResults.stopTime - compilerResults.startTime) + "ms.");

--- a/test/macros/BUILD
+++ b/test/macros/BUILD
@@ -1,0 +1,23 @@
+load("//scala:scala.bzl", "scala_library", "scala_macro_library")
+
+scala_library(
+    name = "incorrect-macro",
+    srcs = ["IdentityMacro.scala"],
+)
+
+scala_macro_library(
+    name = "correct-macro",
+    srcs = ["IdentityMacro.scala"],
+)
+
+scala_library(
+    name = "incorrect-macro-user",
+    srcs = ["MacroUser.scala"],
+    deps = [":incorrect-macro"],
+)
+
+scala_library(
+    name = "correct-macro-user",
+    srcs = ["MacroUser.scala"],
+    deps = [":correct-macro"],
+)

--- a/test/macros/BUILD
+++ b/test/macros/BUILD
@@ -13,6 +13,7 @@ scala_macro_library(
 scala_library(
     name = "incorrect-macro-user",
     srcs = ["MacroUser.scala"],
+    tags = ["manual"],
     deps = [":incorrect-macro"],
 )
 

--- a/test/macros/IdentityMacro.scala
+++ b/test/macros/IdentityMacro.scala
@@ -1,0 +1,9 @@
+package macros
+
+import scala.language.experimental.macros
+import scala.reflect.macros.blackbox
+
+object IdentityMacro {
+  def identityMacro[A](value: A): A = macro identityMacroImpl[A]
+  def identityMacroImpl[A](context: blackbox.Context)(value: context.Expr[A]): context.Expr[A] = value
+}

--- a/test/macros/MacroUser.scala
+++ b/test/macros/MacroUser.scala
@@ -1,0 +1,5 @@
+package macros
+
+object Main {
+  def main(arguments: Array[String]): Unit = println(IdentityMacro.identityMacro("Hello, world!"))
+}

--- a/test/shell/test_macros.sh
+++ b/test/shell/test_macros.sh
@@ -1,0 +1,17 @@
+# shellcheck source=./test_runner.sh
+dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+. "${dir}"/test_runner.sh
+. "${dir}"/test_helper.sh
+runner=$(get_test_runner "${1:-local}")
+
+incorrect_macro_user_does_not_build() {
+  (! bazel build //test/macros:incorrect-macro-user) |&
+    grep --fixed-strings 'java.lang.Exception: You may have declared a target containing a macro as a `scala_library` target instead of a `scala_macro_library` target.'
+}
+
+correct_macro_user_builds() {
+  bazel build //test/macros:correct-macro-user
+}
+
+$runner incorrect_macro_user_does_not_build
+$runner correct_macro_user_builds

--- a/test/shell/test_macros.sh
+++ b/test/shell/test_macros.sh
@@ -6,7 +6,7 @@ runner=$(get_test_runner "${1:-local}")
 
 incorrect_macro_user_does_not_build() {
   (! bazel build //test/macros:incorrect-macro-user) |&
-    grep --fixed-strings 'java.lang.Exception: You may have declared a target containing a macro as a `scala_library` target instead of a `scala_macro_library` target.'
+    grep --fixed-strings 'Build failure during macro expansion. You may have declared a target containing a macro as a `scala_library` target instead of a `scala_macro_library` target'
 }
 
 correct_macro_user_builds() {


### PR DESCRIPTION
### Description

This PR should fix https://github.com/bazelbuild/rules_scala/issues/366. Now, when `scala_library` is mistakenly used in place of `scala_macro_library`, the following exception is thrown:
```
error: java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file macros/IdentityMacro$
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1022)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:555)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at scala.reflect.macros.runtime.JavaReflectionRuntimes$JavaReflectionResolvers.resolveJavaReflectionRuntime(JavaReflectionRuntimes.scala:28)
	at scala.reflect.macros.runtime.JavaReflectionRuntimes$JavaReflectionResolvers.resolveJavaReflectionRuntime$(JavaReflectionRuntimes.scala:27)
	at scala.reflect.macros.runtime.MacroRuntimes$MacroRuntimeResolver.resolveJavaReflectionRuntime(MacroRuntimes.scala:62)
	at scala.reflect.macros.runtime.MacroRuntimes$MacroRuntimeResolver.resolveRuntime(MacroRuntimes.scala:75)
	at scala.reflect.macros.runtime.MacroRuntimes.$anonfun$standardMacroRuntime$3(MacroRuntimes.scala:48)
	at scala.collection.mutable.MapLike.getOrElseUpdate(MapLike.scala:209)
	at scala.collection.mutable.MapLike.getOrElseUpdate$(MapLike.scala:206)
	at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:85)
	at scala.reflect.macros.runtime.MacroRuntimes.standardMacroRuntime(MacroRuntimes.scala:48)
	at scala.reflect.macros.runtime.MacroRuntimes.standardMacroRuntime$(MacroRuntimes.scala:41)
	at scala.tools.nsc.Global$$anon$5.standardMacroRuntime(Global.scala:494)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$12.default(AnalyzerPlugins.scala:473)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$12.default(AnalyzerPlugins.scala:470)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.invoke(AnalyzerPlugins.scala:411)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroRuntime(AnalyzerPlugins.scala:470)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroRuntime$(AnalyzerPlugins.scala:470)
	at scala.tools.nsc.Global$$anon$5.pluginsMacroRuntime(Global.scala:494)
	at scala.reflect.macros.runtime.MacroRuntimes.macroRuntime(MacroRuntimes.scala:35)
	at scala.reflect.macros.runtime.MacroRuntimes.macroRuntime$(MacroRuntimes.scala:35)
	at scala.tools.nsc.Global$$anon$5.macroRuntime(Global.scala:494)
	at scala.tools.nsc.typechecker.Macros$MacroExpander.$anonfun$expand$2(Macros.scala:653)
	at scala.tools.nsc.Global.withInfoLevel(Global.scala:239)
	at scala.tools.nsc.typechecker.Macros$MacroExpander.expand(Macros.scala:647)
	at scala.tools.nsc.typechecker.Macros$MacroExpander.apply(Macros.scala:609)
	at scala.tools.nsc.typechecker.Macros.standardMacroExpand(Macros.scala:810)
	at scala.tools.nsc.typechecker.Macros.standardMacroExpand$(Macros.scala:808)
	at scala.tools.nsc.Global$$anon$5.standardMacroExpand(Global.scala:494)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$10.default(AnalyzerPlugins.scala:457)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$10.default(AnalyzerPlugins.scala:454)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.invoke(AnalyzerPlugins.scala:411)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroExpand(AnalyzerPlugins.scala:454)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroExpand$(AnalyzerPlugins.scala:454)
	at scala.tools.nsc.Global$$anon$5.pluginsMacroExpand(Global.scala:494)
	at scala.tools.nsc.typechecker.Macros.macroExpand(Macros.scala:799)
	at scala.tools.nsc.typechecker.Macros.macroExpand$(Macros.scala:792)
	at scala.tools.nsc.Global$$anon$5.macroExpand(Global.scala:494)
	at scala.tools.nsc.typechecker.Typers$Typer.vanillaAdapt$1(Typers.scala:1183)
	at scala.tools.nsc.typechecker.Typers$Typer.adapt(Typers.scala:1246)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5831)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedArg$1(Typers.scala:3374)
	at scala.tools.nsc.typechecker.Typers$Typer.typedArg(Typers.scala:491)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.typedArgWithFormal$1(PatternTypers.scala:121)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.$anonfun$typedArgsForFormals$4(PatternTypers.scala:135)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.typedArgsForFormals(PatternTypers.scala:135)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.typedArgsForFormals$(PatternTypers.scala:116)
	at scala.tools.nsc.typechecker.Typers$Typer.typedArgsForFormals(Typers.scala:202)
	at scala.tools.nsc.typechecker.Typers$Typer.handleMonomorphicCall$1(Typers.scala:3716)
	at scala.tools.nsc.typechecker.Typers$Typer.doTypedApply(Typers.scala:3749)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typed1$26(Typers.scala:4853)
	at scala.tools.nsc.typechecker.Typers$Typer.silent(Typers.scala:713)
	at scala.tools.nsc.typechecker.Typers$Typer.tryTypedApply$1(Typers.scala:4853)
	at scala.tools.nsc.typechecker.Typers$Typer.normalTypedApply$1(Typers.scala:4937)
	at scala.tools.nsc.typechecker.Typers$Typer.typedApply$1(Typers.scala:4950)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5772)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Typers$Typer.typedDefDef(Typers.scala:6033)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5737)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:5881)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedTemplate(Typers.scala:2038)
	at scala.tools.nsc.typechecker.Typers$Typer.typedModuleDef(Typers.scala:1904)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5739)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:5881)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedPackageDef$1(Typers.scala:5449)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5741)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$TyperPhase.apply(Analyzer.scala:114)
	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:465)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$TyperPhase.run(Analyzer.scala:102)
	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1521)
	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1505)
	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1498)
	at scala.tools.nsc.Global$Run.compile(Global.scala:1627)
	at scala.tools.nsc.Driver.doCompile(Driver.scala:47)
	at scala.tools.nsc.MainClass.doCompile(Main.scala:32)
	at scala.tools.nsc.Driver.process(Driver.scala:67)
	at io.bazel.rulesscala.scalac.ScalacInvoker.invokeCompiler(ScalacInvoker.java:24)
	at io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:275)
	at io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:88)
	at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:96)
	at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:49)
	at io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:48)
java.lang.Exception: You may have declared a target containing a macro as a `scala_library` target instead of a `scala_macro_library` target.
	at io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:278)
	at io.bazel.rulesscala.scalac.ScalacWorker.work(ScalacWorker.java:88)
	at io.bazel.rulesscala.worker.Worker.persistentWorkerMain(Worker.java:96)
	at io.bazel.rulesscala.worker.Worker.workerMain(Worker.java:49)
	at io.bazel.rulesscala.scalac.ScalacWorker.main(ScalacWorker.java:48)
Caused by: io.bazel.rulesscala.scalac.ScalacWorker$CompilationFailed: Build failure during macro expansion
	at io.bazel.rulesscala.scalac.ScalacInvoker.invokeCompiler(ScalacInvoker.java:31)
	at io.bazel.rulesscala.scalac.ScalacWorker.compileScalaSources(ScalacWorker.java:275)
	... 4 more
Caused by: java.lang.ClassFormatError: Absent Code attribute in method that is not native or abstract in class file macros/IdentityMacro$
	at java.base/java.lang.ClassLoader.defineClass1(Native Method)
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1022)
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174)
	at java.base/java.net.URLClassLoader.defineClass(URLClassLoader.java:555)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:458)
	at java.base/java.net.URLClassLoader$1.run(URLClassLoader.java:452)
	at java.base/java.security.AccessController.doPrivileged(Native Method)
	at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:451)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
	at java.base/java.lang.Class.forName0(Native Method)
	at java.base/java.lang.Class.forName(Class.java:398)
	at scala.reflect.macros.runtime.JavaReflectionRuntimes$JavaReflectionResolvers.resolveJavaReflectionRuntime(JavaReflectionRuntimes.scala:28)
	at scala.reflect.macros.runtime.JavaReflectionRuntimes$JavaReflectionResolvers.resolveJavaReflectionRuntime$(JavaReflectionRuntimes.scala:27)
	at scala.reflect.macros.runtime.MacroRuntimes$MacroRuntimeResolver.resolveJavaReflectionRuntime(MacroRuntimes.scala:62)
	at scala.reflect.macros.runtime.MacroRuntimes$MacroRuntimeResolver.resolveRuntime(MacroRuntimes.scala:75)
	at scala.reflect.macros.runtime.MacroRuntimes.$anonfun$standardMacroRuntime$3(MacroRuntimes.scala:48)
	at scala.collection.mutable.MapLike.getOrElseUpdate(MapLike.scala:209)
	at scala.collection.mutable.MapLike.getOrElseUpdate$(MapLike.scala:206)
	at scala.collection.mutable.AbstractMap.getOrElseUpdate(Map.scala:85)
	at scala.reflect.macros.runtime.MacroRuntimes.standardMacroRuntime(MacroRuntimes.scala:48)
	at scala.reflect.macros.runtime.MacroRuntimes.standardMacroRuntime$(MacroRuntimes.scala:41)
	at scala.tools.nsc.Global$$anon$5.standardMacroRuntime(Global.scala:494)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$12.default(AnalyzerPlugins.scala:473)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$12.default(AnalyzerPlugins.scala:470)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.invoke(AnalyzerPlugins.scala:411)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroRuntime(AnalyzerPlugins.scala:470)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroRuntime$(AnalyzerPlugins.scala:470)
	at scala.tools.nsc.Global$$anon$5.pluginsMacroRuntime(Global.scala:494)
	at scala.reflect.macros.runtime.MacroRuntimes.macroRuntime(MacroRuntimes.scala:35)
	at scala.reflect.macros.runtime.MacroRuntimes.macroRuntime$(MacroRuntimes.scala:35)
	at scala.tools.nsc.Global$$anon$5.macroRuntime(Global.scala:494)
	at scala.tools.nsc.typechecker.Macros$MacroExpander.$anonfun$expand$2(Macros.scala:653)
	at scala.tools.nsc.Global.withInfoLevel(Global.scala:239)
	at scala.tools.nsc.typechecker.Macros$MacroExpander.expand(Macros.scala:647)
	at scala.tools.nsc.typechecker.Macros$MacroExpander.apply(Macros.scala:609)
	at scala.tools.nsc.typechecker.Macros.standardMacroExpand(Macros.scala:810)
	at scala.tools.nsc.typechecker.Macros.standardMacroExpand$(Macros.scala:808)
	at scala.tools.nsc.Global$$anon$5.standardMacroExpand(Global.scala:494)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$10.default(AnalyzerPlugins.scala:457)
	at scala.tools.nsc.typechecker.AnalyzerPlugins$$anon$10.default(AnalyzerPlugins.scala:454)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.invoke(AnalyzerPlugins.scala:411)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroExpand(AnalyzerPlugins.scala:454)
	at scala.tools.nsc.typechecker.AnalyzerPlugins.pluginsMacroExpand$(AnalyzerPlugins.scala:454)
	at scala.tools.nsc.Global$$anon$5.pluginsMacroExpand(Global.scala:494)
	at scala.tools.nsc.typechecker.Macros.macroExpand(Macros.scala:799)
	at scala.tools.nsc.typechecker.Macros.macroExpand$(Macros.scala:792)
	at scala.tools.nsc.Global$$anon$5.macroExpand(Global.scala:494)
	at scala.tools.nsc.typechecker.Typers$Typer.vanillaAdapt$1(Typers.scala:1183)
	at scala.tools.nsc.typechecker.Typers$Typer.adapt(Typers.scala:1246)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5831)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedArg$1(Typers.scala:3374)
	at scala.tools.nsc.typechecker.Typers$Typer.typedArg(Typers.scala:491)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.typedArgWithFormal$1(PatternTypers.scala:121)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.$anonfun$typedArgsForFormals$4(PatternTypers.scala:135)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.typedArgsForFormals(PatternTypers.scala:135)
	at scala.tools.nsc.typechecker.PatternTypers$PatternTyper.typedArgsForFormals$(PatternTypers.scala:116)
	at scala.tools.nsc.typechecker.Typers$Typer.typedArgsForFormals(Typers.scala:202)
	at scala.tools.nsc.typechecker.Typers$Typer.handleMonomorphicCall$1(Typers.scala:3716)
	at scala.tools.nsc.typechecker.Typers$Typer.doTypedApply(Typers.scala:3749)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typed1$26(Typers.scala:4853)
	at scala.tools.nsc.typechecker.Typers$Typer.silent(Typers.scala:713)
	at scala.tools.nsc.typechecker.Typers$Typer.tryTypedApply$1(Typers.scala:4853)
	at scala.tools.nsc.typechecker.Typers$Typer.normalTypedApply$1(Typers.scala:4937)
	at scala.tools.nsc.typechecker.Typers$Typer.typedApply$1(Typers.scala:4950)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5772)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Typers$Typer.typedDefDef(Typers.scala:6033)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5737)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:5881)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedTemplate(Typers.scala:2038)
	at scala.tools.nsc.typechecker.Typers$Typer.typedModuleDef(Typers.scala:1904)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5739)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStat$1(Typers.scala:5881)
	at scala.tools.nsc.typechecker.Typers$Typer.$anonfun$typedStats$10(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedStats(Typers.scala:3356)
	at scala.tools.nsc.typechecker.Typers$Typer.typedPackageDef$1(Typers.scala:5449)
	at scala.tools.nsc.typechecker.Typers$Typer.typed1(Typers.scala:5741)
	at scala.tools.nsc.typechecker.Typers$Typer.typed(Typers.scala:5817)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$TyperPhase.apply(Analyzer.scala:114)
	at scala.tools.nsc.Global$GlobalPhase.applyPhase(Global.scala:465)
	at scala.tools.nsc.typechecker.Analyzer$typerFactory$TyperPhase.run(Analyzer.scala:102)
	at scala.tools.nsc.Global$Run.compileUnitsInternal(Global.scala:1521)
	at scala.tools.nsc.Global$Run.compileUnits(Global.scala:1505)
	at scala.tools.nsc.Global$Run.compileSources(Global.scala:1498)
	at scala.tools.nsc.Global$Run.compile(Global.scala:1627)
	at scala.tools.nsc.Driver.doCompile(Driver.scala:47)
	at scala.tools.nsc.MainClass.doCompile(Main.scala:32)
	at scala.tools.nsc.Driver.process(Driver.scala:67)
	at io.bazel.rulesscala.scalac.ScalacInvoker.invokeCompiler(ScalacInvoker.java:24)
	... 5 more
```

### Motivation

Closing https://github.com/bazelbuild/rules_scala/issues/366.
