### PR TITLE
Do not include default javacopts

### DIFF
--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -157,9 +157,7 @@ def compile_java(ctx, source_jars, source_files, output, extra_javac_opts, provi
         output = output,
         javac_opts = expand_location(
             ctx,
-            java_common.default_javac_opts(
-                java_toolchain = java_toolchain,
-            ) + extra_javac_opts,
+            extra_javac_opts
         ),
         deps = providers_of_dependencies,
         #exports can be empty since the manually created provider exposes exports


### PR DESCRIPTION
[rules_java](https://github.com/bazelbuild/rules_java) already includes the toolchain's default javacopts when compiling java_library.

Please see: https://github.com/bazelbuild/rules_java/blob/f26a240c3392f0ae45a2ce3244c93713d7539611/java/common/rules/java_toolchain.bzl#L167

fixes #1685