### PR TITLE
Toolchainize //scala_proto:{,deps_}toolchain_type

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -50,6 +50,7 @@ load("//scala:toolchains.bzl", "scala_toolchains")
 
 scala_toolchains(
     fetch_sources = True,
+    scala_proto = True,
     scalafmt = True,
     testing = True,
 )
@@ -67,10 +68,6 @@ twitter_scrooge()
 load("//jmh:jmh.bzl", "jmh_repositories")
 
 jmh_repositories()
-
-load("//scala_proto:scala_proto.bzl", "scala_proto_repositories")
-
-scala_proto_repositories()
 
 # needed for the cross repo proto test
 local_repository(

--- a/scala/private/toolchain_deps/toolchain_dep_rules.bzl
+++ b/scala/private/toolchain_deps/toolchain_dep_rules.bzl
@@ -3,16 +3,16 @@ load(
     "expose_toolchain_deps",
 )
 
-_toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type"
+_TOOLCHAIN_TYPE = Label("//scala:toolchain_type")
 
 def _common_toolchain_deps(ctx):
-    return expose_toolchain_deps(ctx, _toolchain_type)
+    return expose_toolchain_deps(ctx, _TOOLCHAIN_TYPE)
 
 common_toolchain_deps = rule(
     implementation = _common_toolchain_deps,
     attrs = {
         "deps_id": attr.string(mandatory = True),
     },
-    toolchains = [_toolchain_type],
+    toolchains = [_TOOLCHAIN_TYPE],
     incompatible_use_toolchain_transition = True,
 )

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -9,6 +9,7 @@ load(
 )
 load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//scala:toolchains_repo.bzl", "scala_toolchains_repo")
+load("//scala_proto/default:repositories.bzl", "scala_proto_artifact_ids")
 load("//scalatest:scalatest.bzl", "scalatest_artifact_ids")
 load("//specs2:specs2.bzl", "specs2_artifact_ids")
 load("//specs2:specs2_junit.bzl", "specs2_junit_artifact_ids")
@@ -28,7 +29,9 @@ def scala_toolchains(
         specs2 = False,
         testing = False,
         scalafmt = False,
-        scalafmt_default_config_path = ".scalafmt.conf"):
+        scalafmt_default_config_path = ".scalafmt.conf",
+        scala_proto = False,
+        scala_proto_enable_all_options = False):
     """Instantiates @io_bazel_rules_scala_toolchains and all its dependencies.
 
     Provides a unified interface to configuring rules_scala both directly in a
@@ -76,6 +79,10 @@ def scala_toolchains(
         scalafmt: whether to instantiate the Scalafmt toolchain
         scalafmt_default_config_path: the relative path to the default Scalafmt
             config file within the repository
+        scala_proto: whether to instantiate the scala_proto toolchain
+        scala_proto_enable_all_options: whether to instantiate the scala_proto
+            toolchain with all options enabled; `scala_proto` must also be
+            `True` for this to take effect
     """
     scala_repositories(
         maven_servers = maven_servers,
@@ -119,6 +126,11 @@ def scala_toolchains(
     for scala_version in SCALA_VERSIONS:
         version_specific_artifact_ids = {}
 
+        if scala_proto:
+            version_specific_artifact_ids.update({
+                id: True
+                for id in scala_proto_artifact_ids(scala_version)
+            })
         if scalafmt:
             version_specific_artifact_ids.update({
                 id: fetch_sources
@@ -145,6 +157,8 @@ def scala_toolchains(
         specs2 = specs2,
         testing = testing,
         scalafmt = scalafmt,
+        scala_proto = scala_proto,
+        scala_proto_enable_all_options = scala_proto_enable_all_options,
     )
 
 def scala_register_toolchains():

--- a/scala_proto/BUILD
+++ b/scala_proto/BUILD
@@ -1,16 +1,4 @@
-load("//scala:providers.bzl", "declare_deps_provider")
-load(
-    "//scala_proto/default:default_deps.bzl",
-    "DEFAULT_SCALAPB_COMPILE_DEPS",
-    "DEFAULT_SCALAPB_GRPC_DEPS",
-    "DEFAULT_SCALAPB_WORKER_DEPS",
-)
 load("//scala_proto/private:toolchain_deps.bzl", "export_scalapb_toolchain_deps")
-load(
-    "//scala_proto:scala_proto_toolchain.bzl",
-    "scala_proto_deps_toolchain",
-    "scala_proto_toolchain",
-)
 
 toolchain_type(
     name = "toolchain_type",
@@ -20,68 +8,6 @@ toolchain_type(
 toolchain_type(
     name = "deps_toolchain_type",
     visibility = ["//visibility:public"],
-)
-
-scala_proto_deps_toolchain(
-    name = "default_deps_toolchain_impl",
-    visibility = ["//visibility:public"],
-)
-
-scala_proto_toolchain(
-    name = "default_toolchain_impl",
-    visibility = ["//visibility:public"],
-    with_flat_package = False,
-    with_grpc = True,
-    with_single_line_to_string = False,
-)
-
-toolchain(
-    name = "default_toolchain",
-    toolchain = ":default_toolchain_impl",
-    toolchain_type = "//scala_proto:toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
-toolchain(
-    name = "default_deps_toolchain",
-    toolchain = ":default_deps_toolchain_impl",
-    toolchain_type = ":deps_toolchain_type",
-)
-
-scala_proto_toolchain(
-    name = "enable_all_options_toolchain_impl",
-    visibility = ["//visibility:public"],
-    with_flat_package = True,
-    with_grpc = True,
-    with_single_line_to_string = True,
-)
-
-toolchain(
-    name = "enable_all_options_toolchain",
-    toolchain = ":enable_all_options_toolchain_impl",
-    toolchain_type = "//scala_proto:toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
-declare_deps_provider(
-    name = "scalapb_compile_deps_provider",
-    deps_id = "scalapb_compile_deps",
-    visibility = ["//visibility:public"],
-    deps = DEFAULT_SCALAPB_COMPILE_DEPS,
-)
-
-declare_deps_provider(
-    name = "scalapb_grpc_deps_provider",
-    deps_id = "scalapb_grpc_deps",
-    visibility = ["//visibility:public"],
-    deps = DEFAULT_SCALAPB_GRPC_DEPS,
-)
-
-declare_deps_provider(
-    name = "scalapb_worker_deps_provider",
-    deps_id = "scalapb_worker_deps",
-    visibility = ["//visibility:public"],
-    deps = DEFAULT_SCALAPB_WORKER_DEPS,
 )
 
 export_scalapb_toolchain_deps(

--- a/scala_proto/default/default_deps.bzl
+++ b/scala_proto/default/default_deps.bzl
@@ -7,10 +7,22 @@
 # dependency lists. This needs to be the unrolled transitive path to be used
 # without such a facility.
 
+load("//scala:scala_cross_version.bzl", "repositories")
 load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+
+_DEFAULT_DEP_PROVIDER_FORMAT = (
+    "@io_bazel_rules_scala_toolchains//scala_proto:scalapb_%s_deps_provider"
+)
+
+def scala_proto_deps_providers(
+        compile = _DEFAULT_DEP_PROVIDER_FORMAT % "compile",
+        grpc = _DEFAULT_DEP_PROVIDER_FORMAT % "grpc",
+        worker = _DEFAULT_DEP_PROVIDER_FORMAT % "worker"):
+    return [compile, grpc, worker]
 
 DEFAULT_SCALAPB_COMPILE_DEPS = [
-    "//scala/private/toolchain_deps:scala_library_classpath",
+    Label("//scala/private/toolchain_deps:scala_library_classpath"),
     "@com_google_protobuf//:protobuf_java",
     "@com_lihaoyi_fastparse",
     "@scala_proto_rules_scalapb_lenses",
@@ -51,5 +63,7 @@ DEFAULT_SCALAPB_WORKER_DEPS = [
     "@scala_proto_rules_scalapb_protoc_bridge",
 ] + select_for_scala_version(
     any_2_11 = [],
-    since_2_12 = ["@scala_proto_rules_scalapb_protoc_gen"],
+    since_2_12 = repositories(SCALA_VERSION, [
+        "@scala_proto_rules_scalapb_protoc_gen",
+    ]),
 )

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -9,14 +9,10 @@ load(
 )
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(
-    "@io_bazel_rules_scala//scala_proto/private:scala_proto_aspect_provider.bzl",
+    "//scala_proto/private:scala_proto_aspect_provider.bzl",
     "ScalaProtoAspectInfo",
 )
-load(
-    "@io_bazel_rules_scala//scala/private:phases/api.bzl",
-    "extras_phases",
-    "run_aspect_phases",
-)
+load("//scala/private:phases/api.bzl", "extras_phases", "run_aspect_phases")
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 def _import_paths(proto, ctx):
@@ -47,7 +43,7 @@ def _code_should_be_generated(ctx, toolchain):
     return toolchain.blacklisted_protos.get(target_absolute_label) == None
 
 def _compile_deps(ctx, toolchain):
-    deps_toolchain_type_label = "@io_bazel_rules_scala//scala_proto:deps_toolchain_type"
+    deps_toolchain_type_label = Label("//scala_proto:deps_toolchain_type")
     return [
         dep[JavaInfo]
         for id in toolchain.compile_dep_ids
@@ -149,14 +145,14 @@ def _phase_deps(ctx, p):
     return [d[ScalaProtoAspectInfo].java_info for d in ctx.rule.attr.deps]
 
 def _phase_scalacopts(ctx, p):
-    return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalacopts
+    return ctx.toolchains[Label("//scala:toolchain_type")].scalacopts
 
 def _phase_generate_and_compile(ctx, p):
     proto = p.proto_info
     deps = p.deps
     scalacopts = p.scalacopts
     stamp_label = p.stamp_label
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
+    toolchain = ctx.toolchains[Label("//scala_proto:toolchain_type")]
 
     if proto.direct_sources and _code_should_be_generated(ctx, toolchain):
         src_jars = _generate_sources(ctx, toolchain, proto)
@@ -181,7 +177,7 @@ def _strip_suffix(str, suffix):
 
 def _phase_stamp_label(ctx, p):
     rule_label = str(p.target.label)
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
+    toolchain = ctx.toolchains[Label("//scala_proto:toolchain_type")]
 
     if toolchain.stamp_by_convention and rule_label.endswith("_proto"):
         return _strip_suffix(rule_label, "_proto") + "_scala_proto"
@@ -228,9 +224,9 @@ def make_scala_proto_aspect(*extras):
             *[extra["attrs"] for extra in extras if "attrs" in extra]
         ),
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
-            "@io_bazel_rules_scala//scala_proto:toolchain_type",
-            "@io_bazel_rules_scala//scala_proto:deps_toolchain_type",
+            Label("//scala:toolchain_type"),
+            Label("//scala_proto:toolchain_type"),
+            Label("//scala_proto:deps_toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
     )

--- a/scala_proto/private/toolchain_deps.bzl
+++ b/scala_proto/private/toolchain_deps.bzl
@@ -1,10 +1,12 @@
 load(
-    "@io_bazel_rules_scala//scala/private/toolchain_deps:toolchain_deps.bzl",
+    "//scala/private/toolchain_deps:toolchain_deps.bzl",
     "expose_toolchain_deps",
 )
 
+_DEPS_TOOLCHAIN_TYPE = Label("//scala_proto:deps_toolchain_type")
+
 def _export_scalapb_toolchain_deps(ctx):
-    return expose_toolchain_deps(ctx, "@io_bazel_rules_scala//scala_proto:deps_toolchain_type")
+    return expose_toolchain_deps(ctx, _DEPS_TOOLCHAIN_TYPE)
 
 export_scalapb_toolchain_deps = rule(
     _export_scalapb_toolchain_deps,
@@ -14,5 +16,5 @@ export_scalapb_toolchain_deps = rule(
         ),
     },
     incompatible_use_toolchain_transition = True,
-    toolchains = ["@io_bazel_rules_scala//scala_proto:deps_toolchain_type"],
+    toolchains = [_DEPS_TOOLCHAIN_TYPE],
 )

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -1,4 +1,8 @@
 load("//scala:providers.bzl", "DepsInfo")
+load(
+    "//scala_proto/default:default_deps.bzl",
+    _scala_proto_deps_providers = "scala_proto_deps_providers",
+)
 
 def _generators(ctx):
     return dict(
@@ -138,13 +142,11 @@ scala_proto_deps_toolchain = rule(
     implementation = _scala_proto_deps_toolchain,
     attrs = {
         "dep_providers": attr.label_list(
-            default = [
-                Label("//scala_proto:scalapb_compile_deps_provider"),
-                Label("//scala_proto:scalapb_grpc_deps_provider"),
-                Label("//scala_proto:scalapb_worker_deps_provider"),
-            ],
+            default = _scala_proto_deps_providers(),
             cfg = "target",
             providers = [DepsInfo],
         ),
     },
 )
+
+scala_proto_deps_providers = _scala_proto_deps_providers

--- a/scala_proto/toolchains.bzl
+++ b/scala_proto/toolchains.bzl
@@ -1,5 +1,66 @@
+load(
+    "//scala_proto:scala_proto_toolchain.bzl",
+    "scala_proto_deps_toolchain",
+    "scala_proto_toolchain",
+)
+
 def scala_proto_register_toolchains():
-    native.register_toolchains("@io_bazel_rules_scala//scala_proto:default_toolchain")
+    native.register_toolchains(str(Label("//scala_proto:default_toolchain")))
 
 def scala_proto_register_enable_all_options_toolchain():
-    native.register_toolchains("@io_bazel_rules_scala//scala_proto:enable_all_options_toolchain")
+    native.register_toolchains(
+        str(Label("//scala_proto:enable_all_options_toolchain")),
+    )
+
+def setup_scala_proto_toolchains(name, enable_all_options = False):
+    """Used by @io_bazel_rules_scala_toolchains//scala_proto/BUILD.
+
+    See //scala/private:macros/toolchains_repo.bzl for details, especially the
+    _SCALA_PROTO_TOOLCHAIN_BUILD string template.
+
+    Args:
+      name: prefix for all generate toolchains
+      enable_all_options: set to True to enable the `with_flat_package` and
+        `with_single_line_to_string` attributes of `scala_proto_toolchain`
+    """
+    scala_proto_deps_toolchain(
+        name = "%s_default_deps_toolchain_impl" % name,
+        dep_providers = [
+            ":scalapb_%s_deps_provider" % p
+            for p in ["compile", "grpc", "worker"]
+        ],
+        visibility = ["//visibility:public"],
+    )
+
+    native.toolchain(
+        name = "%s_default_deps_toolchain" % name,
+        toolchain = ":%s_default_deps_toolchain_impl" % name,
+        toolchain_type = Label("//scala_proto:deps_toolchain_type"),
+    )
+
+    toolchain_name = "%s_default_toolchain" % name
+    toolchain_impl_name = "%s_default_toolchain_impl" % name
+    toolchain_options = {
+        "with_flat_package": False,
+        "with_grpc": True,
+        "with_single_line_to_string": False,
+    }
+
+    if enable_all_options:
+        toolchain_name = "%s_enable_all_options_toolchain" % name
+        toolchain_impl_name = "%s_enable_all_options_toolchain_impl" % name
+        toolchain_options["with_flat_package"] = True
+        toolchain_options["with_single_line_to_string"] = True
+
+    scala_proto_toolchain(
+        name = toolchain_impl_name,
+        visibility = ["//visibility:public"],
+        **toolchain_options
+    )
+
+    native.toolchain(
+        name = toolchain_name,
+        toolchain = ":" + toolchain_impl_name,
+        toolchain_type = Label("//scala_proto:toolchain_type"),
+        visibility = ["//visibility:public"],
+    )

--- a/test/proto/custom_generator/BUILD.bazel
+++ b/test/proto/custom_generator/BUILD.bazel
@@ -4,6 +4,7 @@ load("//scala_proto/default:default_deps.bzl", "DEFAULT_SCALAPB_WORKER_DEPS")
 load("//scala_proto:scala_proto.bzl", "scala_proto_library")
 load(
     "//scala_proto:scala_proto_toolchain.bzl",
+    "scala_proto_deps_providers",
     "scala_proto_deps_toolchain",
     "scala_proto_toolchain",
 )
@@ -48,17 +49,15 @@ declare_deps_provider(
 
 scala_proto_deps_toolchain(
     name = "scala_proto_deps_toolchain_def",
-    dep_providers = [
-        ":scalapb_worker_deps_provider",
-        "@io_bazel_rules_scala//scala_proto:scalapb_compile_deps_provider",
-        "@io_bazel_rules_scala//scala_proto:scalapb_grpc_deps_provider",
-    ],
+    dep_providers = scala_proto_deps_providers(
+        worker = ":scalapb_worker_deps_provider",
+    ),
 )
 
 toolchain(
     name = "scala_proto_deps_toolchain",
     toolchain = ":scala_proto_deps_toolchain_def",
-    toolchain_type = "@io_bazel_rules_scala//scala_proto:deps_toolchain_type",
+    toolchain_type = "//scala_proto:deps_toolchain_type",
 )
 
 scala_proto_toolchain(
@@ -69,7 +68,7 @@ scala_proto_toolchain(
 toolchain(
     name = "scala_proto_toolchain",
     toolchain = ":scala_proto_toolchain_def",
-    toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    toolchain_type = "//scala_proto:toolchain_type",
 )
 
 scala_library(
@@ -88,17 +87,15 @@ declare_deps_provider(
 
 scala_proto_deps_toolchain(
     name = "failing_scala_proto_deps_toolchain_def",
-    dep_providers = [
-        ":failing_scalapb_worker_deps_provider",
-        "@io_bazel_rules_scala//scala_proto:scalapb_compile_deps_provider",
-        "@io_bazel_rules_scala//scala_proto:scalapb_grpc_deps_provider",
-    ],
+    dep_providers = scala_proto_deps_providers(
+        worker = ":failing_scalapb_worker_deps_provider",
+    ),
 )
 
 toolchain(
     name = "failing_scala_proto_deps_toolchain",
     toolchain = ":failing_scala_proto_deps_toolchain_def",
-    toolchain_type = "@io_bazel_rules_scala//scala_proto:deps_toolchain_type",
+    toolchain_type = "//scala_proto:deps_toolchain_type",
 )
 
 scala_proto_toolchain(
@@ -109,5 +106,5 @@ scala_proto_toolchain(
 toolchain(
     name = "failing_scala_proto_toolchain",
     toolchain = ":failing_scala_proto_toolchain_def",
-    toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    toolchain_type = "//scala_proto:toolchain_type",
 )

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -56,6 +56,7 @@ load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
 
 scala_toolchains(
     fetch_sources = True,
+    scala_proto = True,
     scalatest = True,
     specs2 = True,
 )
@@ -70,11 +71,3 @@ load(":scrooge_repositories.bzl", "scrooge_repositories")
 ${twitter_scrooge_repositories}
 load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
 twitter_scrooge()
-
-load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
-
-scala_proto_repositories()
-
-load("@io_bazel_rules_scala//scala_proto:toolchains.bzl", "scala_proto_register_toolchains")
-
-scala_proto_register_toolchains()

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -54,17 +54,9 @@ scala_config()
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
 
-scala_toolchains()
+scala_toolchains(scala_proto = True)
 
 register_toolchains(
     "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_repositories")
-
-scala_proto_repositories()
-
-load("@io_bazel_rules_scala//scala_proto:toolchains.bzl", "scala_proto_register_toolchains")
-
-scala_proto_register_toolchains()


### PR DESCRIPTION
### Description

Adds scala_proto toolchains to `scala_toolchains()`. Part of #1482.

The most significant part of the change is moving all the toolchain rules from `scala_proto/BUILD` to `setup_scala_toolchains()` in `scala_proto/toolchains.bzl`.

Adds the `scala_proto_deps_providers()` macro to replace `//scala_proto:scalapb_{compile,grpc,worker}_deps_provider` targets in the `dep_providers` parameter of `scala_proto_deps_toolchain()`. Examples of this are in `test/proto/custom_generator/BUILD`.

Excludes `@scala_proto_rules_scalapb_protoc_gen` from `DEFAULT_SCALAPB_WORKER_DEPS` in `scala_proto/default/default_deps.bzl` for Scala 2.11. For other Scala versions, this repo name will have the Scala version appended. 

A lot of the other changes are more opportunistic removals of `@io_bazel_rules_scala` label prefixes and application of `Label()` where appropriate.

### Motivation

This is the next step in the toolchainization of the frameworks used to implement various rules, as required to implement Bzlmod support.

Excluding `@scala_proto_rules_scalapb_protoc_gen` from `DEFAULT_SCALAPB_WORKER_DEPS` avoids build failures under Bzlmod, since:

- This repo is required by ScalaPB 0.11.17, but Scala 2.11 is capped at ScalaPB 0.9.8.

- Importing the nonexistent `scala_proto_rules_scalapb_protoc_gen` under Scala 2.11 results in an error under Bzlmod, as does importing it multiple times when configuring multiple Scala versions.

- `MODULE.bazel` can iterate over a list of Scala versions, filtering out Scala 2.11, and call `use_repo()` on each version specific repo.

As in other pull requests, removing `@io_bazel_rules_scala`  label prefixes will allow Bzlmod users to use `rules_scala` without setting `repo_name = "@io_bazel_rules_scala"` in `bazel_dep()`.