### PR TITLE
Toolchainize twitter_scrooge

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -54,6 +54,7 @@ scala_toolchains(
     scala_proto = True,
     scalafmt = True,
     testing = True,
+    twitter_scrooge = True,
 )
 
 register_toolchains(
@@ -61,10 +62,6 @@ register_toolchains(
     "//test/proto:scalapb_toolchain",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load("//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
-
-twitter_scrooge()
 
 # needed for the cross repo proto test
 local_repository(

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -15,6 +15,10 @@ load("//scalatest:scalatest.bzl", "scalatest_artifact_ids")
 load("//specs2:specs2.bzl", "specs2_artifact_ids")
 load("//specs2:specs2_junit.bzl", "specs2_junit_artifact_ids")
 load("//third_party/repositories:repositories.bzl", "repositories")
+load(
+    "//twitter_scrooge/toolchain:toolchain.bzl",
+    "twitter_scrooge_artifact_ids",
+)
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 def scala_toolchains(
@@ -33,7 +37,13 @@ def scala_toolchains(
         scalafmt_default_config_path = ".scalafmt.conf",
         scala_proto = False,
         scala_proto_enable_all_options = False,
-        jmh = False):
+        jmh = False,
+        twitter_scrooge = False,
+        libthrift = None,
+        scrooge_core = None,
+        scrooge_generator = None,
+        util_core = None,
+        util_logging = None):
     """Instantiates @io_bazel_rules_scala_toolchains and all its dependencies.
 
     Provides a unified interface to configuring rules_scala both directly in a
@@ -86,6 +96,13 @@ def scala_toolchains(
             toolchain with all options enabled; `scala_proto` must also be
             `True` for this to take effect
         jmh: whether to instantiate the jmh toolchain
+        twitter_scrooge: whether to instantiate the twitter_scrooge toolchain
+        libthrift: label to a libthrift artifact for twitter_scrooge
+        scrooge_core: label to a scrooge_core artifact for twitter_scrooge
+        scrooge_generator: label to a scrooge_generator artifact for
+            twitter_scrooge
+        util_core: label to a util_core artifact for twitter_scrooge
+        util_logging: label to a util_logging artifact for twitter_scrooge
     """
     scala_repositories(
         maven_servers = maven_servers,
@@ -130,6 +147,17 @@ def scala_toolchains(
             id: False
             for id in jmh_artifact_ids()
         })
+    if twitter_scrooge:
+        artifact_ids_to_fetch_sources.update({
+            id: False
+            for id in twitter_scrooge_artifact_ids(
+                libthrift = libthrift,
+                scrooge_core = scrooge_core,
+                scrooge_generator = scrooge_generator,
+                util_core = util_core,
+                util_logging = util_logging,
+            )
+        })
 
     for scala_version in SCALA_VERSIONS:
         version_specific_artifact_ids = {}
@@ -168,6 +196,7 @@ def scala_toolchains(
         scala_proto = scala_proto,
         scala_proto_enable_all_options = scala_proto_enable_all_options,
         jmh = jmh,
+        twitter_scrooge = twitter_scrooge,
     )
 
 def scala_register_toolchains():

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -35,6 +35,20 @@ def _generate_testing_toolchain_build_file_args(repo_attr):
         "specs2_junit": framework_deps.get("specs2_junit"),
     }
 
+_TWITTER_SCROOGE_ARGS = [
+    "libthrift",
+    "scrooge_core",
+    "scrooge_generator",
+    "util_core",
+    "util_logging",
+]
+
+def _stringify_template_args(args, arg_names):
+    return {
+        arg: ("\"%s\"" % value if type(value) == "string" else value)
+        for arg, value in {name: args.get(name) for name in arg_names}.items()
+    }
+
 def _scala_toolchains_repo_impl(repository_ctx):
     repo_attr = repository_ctx.attr
     format_args = {
@@ -51,6 +65,10 @@ def _scala_toolchains_repo_impl(repository_ctx):
         toolchains["jmh"] = _JMH_TOOLCHAIN_BUILD
     if repo_attr.twitter_scrooge:
         toolchains["twitter_scrooge"] = _TWITTER_SCROOGE_TOOLCHAIN_BUILD
+        format_args.update(_stringify_template_args(
+            repo_attr.twitter_scrooge_deps,
+            _TWITTER_SCROOGE_ARGS,
+        ))
 
     testing_build_args = _generate_testing_toolchain_build_file_args(repo_attr)
     if testing_build_args != None:
@@ -84,6 +102,8 @@ _scala_toolchains_repo = repository_rule(
         "scala_proto_enable_all_options": attr.bool(),
         "jmh": attr.bool(),
         "twitter_scrooge": attr.bool(),
+        # attr.string_keyed_label_dict isn't available in Bazel 6
+        "twitter_scrooge_deps": attr.string_dict(),
     },
 )
 
@@ -220,5 +240,12 @@ load(
     "setup_scrooge_toolchain",
 )
 
-setup_scrooge_toolchain(name = "scrooge_toolchain")
+setup_scrooge_toolchain(
+    name = "scrooge_toolchain",
+    libthrift = {libthrift},
+    scrooge_core = {scrooge_core},
+    scrooge_generator = {scrooge_generator},
+    util_core = {util_core},
+    util_logging = {util_logging},
+)
 """

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -49,6 +49,8 @@ def _scala_toolchains_repo_impl(repository_ctx):
         toolchains["scala_proto"] = _SCALA_PROTO_TOOLCHAIN_BUILD
     if repo_attr.jmh:
         toolchains["jmh"] = _JMH_TOOLCHAIN_BUILD
+    if repo_attr.twitter_scrooge:
+        toolchains["twitter_scrooge"] = _TWITTER_SCROOGE_TOOLCHAIN_BUILD
 
     testing_build_args = _generate_testing_toolchain_build_file_args(repo_attr)
     if testing_build_args != None:
@@ -81,6 +83,7 @@ _scala_toolchains_repo = repository_rule(
         "scala_proto": attr.bool(),
         "scala_proto_enable_all_options": attr.bool(),
         "jmh": attr.bool(),
+        "twitter_scrooge": attr.bool(),
     },
 )
 
@@ -209,4 +212,13 @@ _JMH_TOOLCHAIN_BUILD = """
 load("@@{rules_scala_repo}//jmh/toolchain:toolchain.bzl", "setup_jmh_toolchain")
 
 setup_jmh_toolchain(name = "jmh_toolchain")
+"""
+
+_TWITTER_SCROOGE_TOOLCHAIN_BUILD = """
+load(
+    "@@{rules_scala_repo}//twitter_scrooge/toolchain:toolchain.bzl",
+    "setup_scrooge_toolchain",
+)
+
+setup_scrooge_toolchain(name = "scrooge_toolchain")
 """

--- a/test_version.sh
+++ b/test_version.sh
@@ -46,7 +46,7 @@ run_in_test_repo() {
 
   if [[ -n "$TWITTER_SCROOGE_VERSION" ]]; then
     local version_param="version = \"$TWITTER_SCROOGE_VERSION\""
-    scrooge_ws="scrooge_repositories($version_param)"
+    scrooge_ws="$version_param"
   fi
 
   sed -e "s%\${twitter_scrooge_repositories}%${scrooge_ws}\n%" \

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -54,6 +54,10 @@ scala_config(enable_compiler_dependency_tracking = True)
 
 load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
 
+load(":scrooge_repositories.bzl", "scrooge_repositories")
+
+scrooge_repositories(${twitter_scrooge_repositories})
+
 scala_toolchains(
     fetch_sources = True,
     scala_proto = True,
@@ -63,11 +67,6 @@ scala_toolchains(
 
 register_toolchains(
     "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
-    "@io_bazel_rules_scala//testing:testing_toolchain",
+    "@twitter_scrooge_test_toolchain//...:all",
     "@io_bazel_rules_scala_toolchains//...:all",
 )
-
-load(":scrooge_repositories.bzl", "scrooge_repositories")
-${twitter_scrooge_repositories}
-load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "twitter_scrooge")
-twitter_scrooge()

--- a/test_version/version_specific_tests_dir/scrooge_repositories.bzl
+++ b/test_version/version_specific_tests_dir/scrooge_repositories.bzl
@@ -30,10 +30,10 @@ def _import_external(id, artifact, sha256, deps = [], runtime_deps = []):
     )
 
 def scrooge_repositories(version = None):
-    use_labels = False
+    use_custom_toolchain_deps = False
 
     if version == "18.6.0":
-        use_labels = True
+        use_custom_toolchain_deps = True
         _import_external(
             id = "io_bazel_rules_scala_scrooge_core",
             artifact = "com.twitter:scrooge-core_2.11:18.6.0",
@@ -61,7 +61,7 @@ def scrooge_repositories(version = None):
         )
 
     elif version == "21.2.0":
-        use_labels = True
+        use_custom_toolchain_deps = True
         _import_external(
             id = "io_bazel_rules_scala_scrooge_core",
             artifact = "com.twitter:scrooge-core_2.11:21.2.0",
@@ -88,18 +88,19 @@ def scrooge_repositories(version = None):
             sha256 = "f3b62465963fbf0fe9860036e6255337996bb48a1a3f21a29503a2750d34f319",
         )
 
-    if use_labels:
-        twitter_scrooge(
-            scrooge_core = "@io_bazel_rules_scala_scrooge_core",
-            scrooge_generator = "@io_bazel_rules_scala_scrooge_generator",
-            util_core = "@io_bazel_rules_scala_util_core",
-            util_logging = "@io_bazel_rules_scala_util_logging",
-            register_toolchains = False,
-        )
-    else:
-        twitter_scrooge(register_toolchains = False)
+    toolchain_deps = {} if use_custom_toolchain_deps == False else {
+        dep: "@io_bazel_rules_scala_%s" % dep
+        for dep in [
+            "scrooge_core",
+            "scrooge_generator",
+            "util_core",
+            "util_logging",
+        ]
+    }
 
+    twitter_scrooge(register_toolchains = False, **toolchain_deps)
     scala_toolchains_repo(
         name = "twitter_scrooge_test_toolchain",
         twitter_scrooge = True,
+        twitter_scrooge_deps = toolchain_deps,
     )

--- a/test_version/version_specific_tests_dir/twitter_scrooge/BUILD
+++ b/test_version/version_specific_tests_dir/twitter_scrooge/BUILD
@@ -8,7 +8,7 @@ dependencies_to_test = [
 deps_with_external_binds = [
     (
         dep_name,
-        "//external:io_bazel_rules_scala/dependency/thrift/{}".format(dep_name),
+        "@io_bazel_rules_scala_{}".format(dep_name),
     )
     for dep_name in dependencies_to_test
 ]

--- a/twitter_scrooge/BUILD
+++ b/twitter_scrooge/BUILD
@@ -1,85 +1,14 @@
-load("//twitter_scrooge/toolchain:toolchain.bzl", "export_scrooge_deps", "scrooge_toolchain")
-load("//scala:providers.bzl", "declare_deps_provider")
-
-scrooge_toolchain(
-    name = "scrooge_toolchain_impl",
-    visibility = ["//visibility:public"],
+load(
+    "//twitter_scrooge/toolchain:toolchain.bzl",
+    "DEP_PROVIDERS",
+    "export_scrooge_deps",
 )
 
-toolchain(
-    name = "scrooge_toolchain",
-    toolchain = ":scrooge_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
-    visibility = ["//visibility:public"],
-)
-
-declare_deps_provider(
-    name = "aspect_compile_classpath_provider",
-    deps_id = "aspect_compile_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//external:io_bazel_rules_scala/dependency/thrift/javax_annotation_api",
-        "//external:io_bazel_rules_scala/dependency/thrift/libthrift",
-        "//external:io_bazel_rules_scala/dependency/thrift/scrooge_core",
-        "//external:io_bazel_rules_scala/dependency/thrift/util_core",
-        "//scala/private/toolchain_deps:scala_library_classpath",
-    ],
-)
-
-declare_deps_provider(
-    name = "compile_classpath_provider",
-    deps_id = "compile_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//external:io_bazel_rules_scala/dependency/thrift/libthrift",
-        "//external:io_bazel_rules_scala/dependency/thrift/scrooge_core",
-        "//scala/private/toolchain_deps:scala_library_classpath",
-    ],
-)
-
-declare_deps_provider(
-    name = "scrooge_generator_classpath_provider",
-    deps_id = "scrooge_generator_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//external:io_bazel_rules_scala/dependency/thrift/scrooge_generator",
-    ],
-)
-
-declare_deps_provider(
-    name = "compiler_classpath_provider",
-    deps_id = "compiler_classpath",
-    visibility = ["//visibility:public"],
-    deps = [
-        "//external:io_bazel_rules_scala/dependency/thrift/mustache",
-        "//external:io_bazel_rules_scala/dependency/thrift/scopt",
-        "//external:io_bazel_rules_scala/dependency/thrift/scrooge_generator",
-        "//external:io_bazel_rules_scala/dependency/thrift/util_core",
-        "//external:io_bazel_rules_scala/dependency/thrift/util_logging",
-        "//scala/private/toolchain_deps:parser_combinators",
-    ],
-)
-
-export_scrooge_deps(
-    name = "compile_classpath",
-    deps_id = "compile_classpath",
-    visibility = ["//visibility:public"],
-)
-
-export_scrooge_deps(
-    name = "aspect_compile_classpath",
-    deps_id = "aspect_compile_classpath",
-    visibility = ["//visibility:public"],
-)
-
-export_scrooge_deps(
-    name = "scrooge_generator_classpath",
-    deps_id = "scrooge_generator_classpath",
-    visibility = ["//visibility:public"],
-)
-
-export_scrooge_deps(
-    name = "compiler_classpath",
-    deps_id = "compiler_classpath",
-    visibility = ["//visibility:public"],
-)
+[
+    export_scrooge_deps(
+        name = dep,
+        deps_id = dep,
+        visibility = ["//visibility:public"],
+    )
+    for dep in DEP_PROVIDERS
+]

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -1,8 +1,79 @@
-load("@io_bazel_rules_scala//scala:providers.bzl", "DepsInfo")
 load(
-    "@io_bazel_rules_scala//scala/private/toolchain_deps:toolchain_deps.bzl",
+    "//scala/private/toolchain_deps:toolchain_deps.bzl",
     "expose_toolchain_deps",
 )
+load("//scala:providers.bzl", "DepsInfo", "declare_deps_provider")
+load(
+    "//scala:scala_cross_version.bzl",
+    _default_maven_server_urls = "default_maven_server_urls",
+    _versioned_repositories = "repositories",
+)
+load("//scala_proto/default:repositories.bzl", "GUAVA_ARTIFACT_IDS")
+load("//third_party/repositories:repositories.bzl", "repositories")
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
+
+DEP_PROVIDERS = [
+    "compile_classpath",
+    "aspect_compile_classpath",
+    "scrooge_generator_classpath",
+    "compiler_classpath",
+]
+
+def twitter_scrooge_artifact_ids(
+        libthrift = None,
+        scrooge_core = None,
+        scrooge_generator = None,
+        util_core = None,
+        util_logging = None):
+    artifact_ids = [
+        # Mustache is needed to generate java from thrift.
+        "io_bazel_rules_scala_mustache",
+        "io_bazel_rules_scala_javax_annotation_api",
+        "io_bazel_rules_scala_scopt",
+    ] + GUAVA_ARTIFACT_IDS
+
+    if libthrift == None:
+        artifact_ids.append("libthrift")
+    if scrooge_core == None:
+        artifact_ids.append("io_bazel_rules_scala_scrooge_core")
+    if scrooge_generator == None:
+        artifact_ids.append("io_bazel_rules_scala_scrooge_generator")
+    if util_core == None:
+        artifact_ids.append("io_bazel_rules_scala_util_core")
+    if util_logging == None:
+        artifact_ids.append("io_bazel_rules_scala_util_logging")
+
+    return artifact_ids
+
+def twitter_scrooge(
+        maven_servers = _default_maven_server_urls(),
+        overriden_artifacts = {},
+        # These target labels need maven_servers to compute sensible defaults.
+        # Therefore we leave them None here.
+        libthrift = None,
+        scrooge_core = None,
+        scrooge_generator = None,
+        util_core = None,
+        util_logging = None,
+        register_toolchains = True):
+    repositories(
+        scala_version = SCALA_VERSION,
+        for_artifact_ids = twitter_scrooge_artifact_ids(
+            libthrift,
+            scrooge_core,
+            scrooge_generator,
+            util_core,
+            util_logging,
+        ),
+        maven_servers = maven_servers,
+        fetch_sources = False,
+        overriden_artifacts = overriden_artifacts,
+    )
+
+    if register_toolchains:
+        native.register_toolchains(
+            "@io_bazel_rules_scala_toolchains//twitter_scrooge:all",
+        )
 
 def _scrooge_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
@@ -14,22 +85,15 @@ scrooge_toolchain = rule(
     _scrooge_toolchain_impl,
     attrs = {
         "dep_providers": attr.label_list(
-            default = [
-                "@io_bazel_rules_scala//twitter_scrooge:compile_classpath_provider",
-                "@io_bazel_rules_scala//twitter_scrooge:aspect_compile_classpath_provider",
-                "@io_bazel_rules_scala//twitter_scrooge:compiler_classpath_provider",
-                "@io_bazel_rules_scala//twitter_scrooge:scrooge_generator_classpath_provider",
-            ],
             providers = [DepsInfo],
         ),
     },
 )
 
+_toolchain_type = "//twitter_scrooge/toolchain:scrooge_toolchain_type"
+
 def _export_scrooge_deps_impl(ctx):
-    return expose_toolchain_deps(
-        ctx,
-        "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
-    )
+    return expose_toolchain_deps(ctx, _toolchain_type)
 
 export_scrooge_deps = rule(
     _export_scrooge_deps_impl,
@@ -38,6 +102,70 @@ export_scrooge_deps = rule(
             mandatory = True,
         ),
     },
-    toolchains = ["@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type"],
+    toolchains = [_toolchain_type],
     incompatible_use_toolchain_transition = True,
 )
+
+def setup_scrooge_toolchain(name):
+    scrooge_toolchain(
+        name = "%s_impl" % name,
+        dep_providers = [":%s_provider" % p for p in DEP_PROVIDERS],
+        visibility = ["//visibility:public"],
+    )
+
+    native.toolchain(
+        name = name,
+        toolchain = ":%s_impl" % name,
+        toolchain_type = Label(_toolchain_type),
+        visibility = ["//visibility:public"],
+    )
+
+    declare_deps_provider(
+        name = "aspect_compile_classpath_provider",
+        deps_id = "aspect_compile_classpath",
+        visibility = ["//visibility:public"],
+        deps = _versioned_repositories(SCALA_VERSION, [
+            "@io_bazel_rules_scala_javax_annotation_api",
+            "@libthrift",
+            "@io_bazel_rules_scala_scrooge_core",
+            "@io_bazel_rules_scala_util_core",
+        ]) + [
+            Label("//scala/private/toolchain_deps:scala_library_classpath"),
+        ],
+    )
+
+    declare_deps_provider(
+        name = "compile_classpath_provider",
+        deps_id = "compile_classpath",
+        visibility = ["//visibility:public"],
+        deps = _versioned_repositories(SCALA_VERSION, [
+            "@libthrift",
+            "@io_bazel_rules_scala_scrooge_core",
+        ]) + [
+            Label("//scala/private/toolchain_deps:scala_library_classpath"),
+        ],
+    )
+
+    declare_deps_provider(
+        name = "scrooge_generator_classpath_provider",
+        deps_id = "scrooge_generator_classpath",
+        visibility = ["//visibility:public"],
+        deps = _versioned_repositories(SCALA_VERSION, [
+            "@io_bazel_rules_scala_scrooge_generator",
+        ]),
+    )
+
+    declare_deps_provider(
+        name = "compiler_classpath_provider",
+        deps_id = "compiler_classpath",
+        visibility = ["//visibility:public"],
+        deps = _versioned_repositories(SCALA_VERSION, [
+            "@io_bazel_rules_scala_mustache",
+            "@io_bazel_rules_scala_scopt",
+            "@io_bazel_rules_scala_scrooge_generator",
+            "@io_bazel_rules_scala_util_core",
+            "@io_bazel_rules_scala_util_logging",
+        ]) + [
+            Label("//scala/private/toolchain_deps:parser_combinators"),
+        ],
+    )

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -1,9 +1,5 @@
 load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
-    "//scala:scala_cross_version.bzl",
-    _default_maven_server_urls = "default_maven_server_urls",
-)
-load(
     "//scala/private:common.bzl",
     "write_manifest_file",
 )
@@ -17,124 +13,8 @@ load(
     "compile_java",
     "compile_scala",
 )
-load("@io_bazel_rules_scala//thrift:thrift_info.bzl", "ThriftInfo")
-load(
-    "@io_bazel_rules_scala//thrift:thrift.bzl",
-    "merge_thrift_infos",
-)
-load("//third_party/repositories:repositories.bzl", "repositories")
-
-_jar_extension = ".jar"
-
-def _declare_and_bind(
-        label,
-        artifact_id,
-        external_artifact_id,
-        overriden_artifacts,
-        maven_servers):
-    if not label:
-        repositories(
-            for_artifact_ids = [
-                artifact_id,
-            ],
-            maven_servers = maven_servers,
-            fetch_sources = False,
-            overriden_artifacts = overriden_artifacts,
-        )
-        label = "@" + artifact_id
-
-    native.bind(
-        name = external_artifact_id,
-        actual = label,
-    )
-
-def twitter_scrooge(
-        maven_servers = _default_maven_server_urls(),
-        overriden_artifacts = {},
-        # These target labels need maven_servers to compute sensible defaults.
-        # Therefore we leave them None here.
-        libthrift = None,
-        scrooge_core = None,
-        scrooge_generator = None,
-        util_core = None,
-        util_logging = None):
-    _declare_and_bind(
-        libthrift,
-        "libthrift",
-        "io_bazel_rules_scala/dependency/thrift/libthrift",
-        overriden_artifacts,
-        maven_servers,
-    )
-
-    _declare_and_bind(
-        scrooge_core,
-        "io_bazel_rules_scala_scrooge_core",
-        "io_bazel_rules_scala/dependency/thrift/scrooge_core",
-        overriden_artifacts,
-        maven_servers,
-    )
-
-    _declare_and_bind(
-        scrooge_generator,
-        "io_bazel_rules_scala_scrooge_generator",
-        "io_bazel_rules_scala/dependency/thrift/scrooge_generator",
-        overriden_artifacts,
-        maven_servers,
-    )
-
-    _declare_and_bind(
-        util_core,
-        "io_bazel_rules_scala_util_core",
-        "io_bazel_rules_scala/dependency/thrift/util_core",
-        overriden_artifacts,
-        maven_servers,
-    )
-
-    _declare_and_bind(
-        util_logging,
-        "io_bazel_rules_scala_util_logging",
-        "io_bazel_rules_scala/dependency/thrift/util_logging",
-        overriden_artifacts,
-        maven_servers,
-    )
-
-    repositories(
-        for_artifact_ids = [
-            "io_bazel_rules_scala_mustache",  # Mustache is needed to generate java from thrift, and is passed further down.
-            "io_bazel_rules_scala_guava",
-            "io_bazel_rules_scala_javax_annotation_api",
-            "io_bazel_rules_scala_scopt",
-        ],
-        maven_servers = maven_servers,
-        fetch_sources = False,
-        overriden_artifacts = overriden_artifacts,
-    )
-
-    native.bind(
-        name = "io_bazel_rules_scala/dependency/thrift/mustache",
-        actual = "@io_bazel_rules_scala_mustache",
-    )
-
-    native.bind(
-        name = "io_bazel_rules_scala/dependency/thrift/scopt",
-        actual = "@io_bazel_rules_scala_scopt",
-    )
-
-    # scrooge-generator needs these runtime_deps to generate java from thrift.
-    if not native.existing_rule("io_bazel_rules_scala/dependency/scala/guava"):
-        native.bind(
-            name = "io_bazel_rules_scala/dependency/scala/guava",
-            actual = "@io_bazel_rules_scala_guava",
-        )
-
-    # This is a shim needed to import `@javax.annotation.Generated` when compiled with jdk11.
-    if not native.existing_rule("io_bazel_rules_scala/dependency/thrift/javax_annotation_api"):
-        native.bind(
-            name = "io_bazel_rules_scala/dependency/thrift/javax_annotation_api",
-            actual = "@io_bazel_rules_scala_javax_annotation_api",
-        )
-
-    native.register_toolchains("@io_bazel_rules_scala//twitter_scrooge:scrooge_toolchain")
+load("//thrift:thrift_info.bzl", "ThriftInfo")
+load("//thrift:thrift.bzl", "merge_thrift_infos")
 
 def _colon_paths(data):
     return ":".join([f.path for f in sorted(data)])
@@ -446,8 +326,8 @@ common_aspect_providers = [
 ]
 
 common_toolchains = [
-    "@io_bazel_rules_scala//scala:toolchain_type",
-    "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
+    "//scala:toolchain_type",
+    "//twitter_scrooge/toolchain:scrooge_toolchain_type",
     "@bazel_tools//tools/jdk:toolchain_type",
 ]
 
@@ -562,7 +442,7 @@ scrooge_scala_import = rule(
     },
     provides = [ThriftInfo, JavaInfo, ScroogeImport],
     toolchains = [
-        "@io_bazel_rules_scala//twitter_scrooge/toolchain:scrooge_toolchain_type",
+        "//twitter_scrooge/toolchain:scrooge_toolchain_type",
         "@bazel_tools//tools/jdk:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,


### PR DESCRIPTION
### Description

Adds `twitter_scrooge` to `scala_toolchains()`. Part of #1482 and #1652.

### Motivation

This is the last of the toolchains to receive the "toolchainization" treatment prior to Bzlmodification, and moves `twitter_scrooge()` to `twitter_scrooge/toolchain/toolchain.bzl` for `rules_java` 8 compatibility.