### PR TITLE
Use rctx.original_name if available, Go 1.23.6

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -99,7 +99,7 @@ load(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.23.5")
+go_register_toolchains(version = "1.23.6")
 
 http_archive(
     name = "bazelci_rules",

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -68,7 +68,9 @@ def _jvm_import_external_impl(repository_ctx):
     if (repository_ctx.attr.generated_linkable_rule_name and
         not repository_ctx.attr.neverlink):
         fail("Only use generated_linkable_rule_name if neverlink is set")
-    repo_name = repository_ctx.name
+
+    # Replace with rctx.original_name once all supported Bazels have it
+    repo_name = getattr(repository_ctx, "original_name", repository_ctx.name)
     name = repository_ctx.attr.generated_rule_name or repo_name
     urls = repository_ctx.attr.jar_urls
     if repository_ctx.attr.jar_sha256:
@@ -257,6 +259,8 @@ _jvm_import_external = repository_rule(
     environ = [_FETCH_SOURCES_ENV_VAR_NAME],
 )
 
+# Remove this macro and restore `_jvm_import_external` to `jvm_import_external`
+# once all supported Bazel versions support `repository_ctx.original_name`.
 def jvm_import_external(**kwargs):
     """Wraps `_jvm_import_external` to pass `name` as `generated_target_name`.
 

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -140,9 +140,9 @@ def repositories(
 
 def _alias_repository_impl(rctx):
     """ Builds a repository containing just two aliases to the Scala Maven artifacts in the `target` repository. """
-
     format_kwargs = {
-        "name": rctx.attr.default_target_name,
+        # Replace with rctx.original_name once all supported Bazels have it
+        "name": getattr(rctx, "original_name", rctx.attr.default_target_name),
         "target": rctx.attr.target,
     }
     rctx.file("BUILD", """alias(
@@ -161,11 +161,14 @@ def _alias_repository_impl(rctx):
 _alias_repository = repository_rule(
     implementation = _alias_repository_impl,
     attrs = {
+        # Remove once all supported Bazels have repository_ctx.original_name
         "default_target_name": attr.string(mandatory = True),
         "target": attr.string(mandatory = True),
     },
 )
 
+# Remove this macro and use `_alias_repository` directly once all supported
+# Bazel versions support `repository_ctx.original_name`.
 def _alias_repository_wrapper(**kwargs):
     """Wraps `_alias_repository` to pass `name` as `default_target_name`."""
     default_target_name = kwargs.pop("default_target_name", kwargs.get("name"))


### PR DESCRIPTION
### Description

Prepares for `repository_ctx.original_name` support in Bazel 8.1.0 per bazelbuild/bazel#24467 and bumps Go to 1.23.6. Part of #1482 and #1652.

The underlying repo rules will now use `repository_ctx.original_name` if it's available.

I've confirmed that these changes use `repository_ctx.original_name` under Bazel 8.1.0rc2 after commenting out the wrappers and restoring the original repo rule symbols.

### Motivation

This change ensures compatibility with future Bazel releases. New comments indicate where to simplify code after dropping support for Bazel versions that don't have `repository_ctx.original_name`.

The Go 1.23.6 bump is a convenience update that isn't essential to the rest of the change.

Under Bzlmod, `repository_ctx.name` contains the canonical repository name. This broke the `_alias_repository` and `jvm_import_external` repository rules, which used `repository_ctx.name` to generate default top level target names for their repos. #1650 added wrapper macros passing the original name as an extra attribute to the underlying repo rules as a portable workaround.

The Bazel maintainers eventually recognized this as a common use case and added `repository_ctx.original_name` to eliminate the need for such wrappers (eventually).

- https://bazel.build/rules/lib/builtins/repository_ctx#name
- https://bazel.build/rules/lib/builtins/repository_ctx#original_name