### PR TITLE
Remove @io_bazel_rules_scala or replace with Label

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -1,4 +1,4 @@
-workspace(name = "io_bazel_rules_scala")
+workspace(name = "rules_scala")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("//scala:deps.bzl", "rules_scala_dependencies")
@@ -42,11 +42,11 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
-load("//scala:toolchains.bzl", "scala_toolchains")
+load("//scala:toolchains.bzl", "scala_register_toolchains", "scala_toolchains")
 
 scala_toolchains(
     fetch_sources = True,
@@ -60,8 +60,9 @@ scala_toolchains(
 register_toolchains(
     "//scala:unused_dependency_checker_error_toolchain",
     "//test/proto:scalapb_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
 )
+
+scala_register_toolchains()
 
 # needed for the cross repo proto test
 local_repository(

--- a/dt_patches/compiler_sources/extensions.bzl
+++ b/dt_patches/compiler_sources/extensions.bzl
@@ -1,20 +1,20 @@
+load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 load(
-    "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
+    "@rules_scala//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
 )
 load(
-    "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
+    "@rules_scala//scala:scala_maven_import_external.bzl",
     "scala_maven_import_external",
 )
 load(
-    "@io_bazel_rules_scala//third_party/repositories:scala_2_13.bzl",
+    "@rules_scala//third_party/repositories:scala_2_13.bzl",
     _scala_2_version = "scala_version",
 )
 load(
-    "@io_bazel_rules_scala//third_party/repositories:scala_3_5.bzl",
+    "@rules_scala//third_party/repositories:scala_3_5.bzl",
     _scala_3_version = "scala_version",
 )
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 _IS_SCALA_2 = SCALA_VERSION.startswith("2.")
 _IS_SCALA_3 = SCALA_VERSION.startswith("3.")

--- a/dt_patches/test_dt_patches/BUILD
+++ b/dt_patches/test_dt_patches/BUILD
@@ -1,8 +1,8 @@
+load("@rules_scala//scala:scala.bzl", "setup_scala_toolchain")
 load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
-    "setup_scala_toolchain",
+    "@rules_scala//scala:scala_cross_version_select.bzl",
+    "select_for_scala_version",
 )
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 SCALA_LIBS = ["@scala_library"] + select_for_scala_version(
     any_2 = ["@scala_reflect"],

--- a/dt_patches/test_dt_patches/WORKSPACE
+++ b/dt_patches/test_dt_patches/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "test_dt_patches")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,7 +48,7 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
@@ -61,14 +61,17 @@ load("@compiler_sources//:extensions.bzl", "import_compiler_source_repos")
 
 import_compiler_source_repos()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
     validate_scala_version = False,
 )
 
-register_toolchains(
-    ":dt_scala_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
-)
+register_toolchains(":dt_scala_toolchain")
+
+scala_register_toolchains()

--- a/dt_patches/test_dt_patches/dummy/BUILD
+++ b/dt_patches/test_dt_patches/dummy/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "dummy",

--- a/dt_patches/test_dt_patches_user_srcjar/BUILD
+++ b/dt_patches/test_dt_patches_user_srcjar/BUILD
@@ -1,8 +1,11 @@
 load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
+    "@rules_scala//scala:scala.bzl",
     "setup_scala_toolchain",
 )
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load(
+    "@rules_scala//scala:scala_cross_version_select.bzl",
+    "select_for_scala_version",
+)
 
 SCALA_LIBS = ["@scala_library"] + select_for_scala_version(
     any_2 = ["@scala_reflect"],

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "test_dt_patches")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,7 +48,7 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
 
@@ -137,7 +137,11 @@ srcjars_by_version = {
     },
 }
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
@@ -145,7 +149,6 @@ scala_toolchains(
     validate_scala_version = False,
 )
 
-register_toolchains(
-    ":dt_scala_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
-)
+register_toolchains(":dt_scala_toolchain")
+
+scala_register_toolchains()

--- a/dt_patches/test_dt_patches_user_srcjar/dummy/BUILD
+++ b/dt_patches/test_dt_patches_user_srcjar/dummy/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "dummy",

--- a/examples/crossbuild/1_single/BUILD
+++ b/examples/crossbuild/1_single/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_test")
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library", "scala_test")
 
 # Here we demonstrate the simplest case,
 # single binary, test or library for which we set a specific version or use the default one:

--- a/examples/crossbuild/2_deps/BUILD
+++ b/examples/crossbuild/2_deps/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 
 # Here we demonstrate how scala_version is propagated through deps.
 

--- a/examples/crossbuild/3_select/BUILD
+++ b/examples/crossbuild/3_select/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 # Here we demonstrate how to provide distinct source files depending on the version requested
 

--- a/examples/crossbuild/WORKSPACE
+++ b/examples/crossbuild/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "cross_build")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,7 +48,7 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(
     scala_version = "3.3.5",
@@ -59,8 +59,12 @@ scala_config(
     ],
 )
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(scalatest = True)
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+scala_register_toolchains()

--- a/examples/scala3/BUILD
+++ b/examples/scala3/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 
 scala_library(
     name = "lib",

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "specs2_junit_repositories")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,12 +48,16 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(scala_version = "3.6.3")
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(fetch_sources = True)
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+scala_register_toolchains()

--- a/examples/semanticdb/BUILD
+++ b/examples/semanticdb/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
 
 scala_toolchain(
     name = "semanticdb_toolchain_impl",
@@ -11,7 +11,7 @@ scala_toolchain(
 toolchain(
     name = "semanticdb_toolchain",
     toolchain = "semanticdb_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "@rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/examples/semanticdb/WORKSPACE
+++ b/examples/semanticdb/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "specs2_junit_repositories")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,16 +48,21 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(scala_version = "2.13.15")
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(fetch_sources = True)
 
 register_toolchains(
     #Register and use the custom toolchain that has semanticdb enabled
     "//:semanticdb_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
 )
+
+scala_register_toolchains()

--- a/examples/semanticdb/aspect.bzl
+++ b/examples/semanticdb/aspect.bzl
@@ -1,7 +1,7 @@
 #This aspect is an example of exposing semanticdb information for each target into a json file.
 # An IDE could use a json file like this to consume the semanticdb data for each target.
 
-load("@io_bazel_rules_scala//scala:semanticdb_provider.bzl", "SemanticdbInfo")
+load("@rules_scala//scala:semanticdb_provider.bzl", "SemanticdbInfo")
 
 def semanticdb_info_aspect_impl(target, ctx):
     if SemanticdbInfo in target:
@@ -20,5 +20,5 @@ def semanticdb_info_aspect_impl(target, ctx):
 semanticdb_info_aspect = aspect(
     implementation = semanticdb_info_aspect_impl,
     attr_aspects = ["deps"],
-    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+    toolchains = ["@rules_scala//scala:toolchain_type"],
 )

--- a/examples/testing/multi_frameworks_toolchain/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@io_bazel_rules_scala//testing:testing.bzl",
+    "@rules_scala//testing:testing.bzl",
     "setup_scala_testing_toolchain",
 )
 

--- a/examples/testing/multi_frameworks_toolchain/WORKSPACE
+++ b/examples/testing/multi_frameworks_toolchain/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "multi_frameworks_toolchain")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,18 +48,21 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
     testing = True,
 )
 
-register_toolchains(
-    ":testing_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
-)
+register_toolchains(":testing_toolchain")
+
+scala_register_toolchains()

--- a/examples/testing/multi_frameworks_toolchain/example/BUILD
+++ b/examples/testing/multi_frameworks_toolchain/example/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_specs2_junit_test", "scala_test")
+load("@rules_scala//scala:scala.bzl", "scala_specs2_junit_test", "scala_test")
 
 scala_test(
     name = "scalatest_example",

--- a/examples/testing/scalatest_repositories/WORKSPACE
+++ b/examples/testing/scalatest_repositories/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "scalatest_repositories")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,15 +48,19 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
     scalatest = True,
 )
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+scala_register_toolchains()

--- a/examples/testing/scalatest_repositories/example/BUILD
+++ b/examples/testing/scalatest_repositories/example/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load("@rules_scala//scala:scala.bzl", "scala_test")
 
 scala_test(
     name = "example",

--- a/examples/testing/specs2_junit_repositories/WORKSPACE
+++ b/examples/testing/specs2_junit_repositories/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "specs2_junit_repositories")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,15 +48,19 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
     specs2 = True,
 )
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+scala_register_toolchains()

--- a/examples/testing/specs2_junit_repositories/example/BUILD
+++ b/examples/testing/specs2_junit_repositories/example/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_specs2_junit_test")
+load("@rules_scala//scala:scala.bzl", "scala_specs2_junit_test")
 
 scala_specs2_junit_test(
     name = "example",

--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -73,9 +73,7 @@ def scala_benchmark_jmh(**kw):
     scala_library(
         name = lib,
         srcs = srcs,
-        deps = deps + [
-            "@io_bazel_rules_scala//jmh:jmh_core",
-        ],
+        deps = deps + [Label("//jmh:jmh_core")],
         runtime_deps = runtime_deps,
         scalacopts = scalacopts,
         resources = kw.get("resources", []),
@@ -98,7 +96,7 @@ def scala_benchmark_jmh(**kw):
         name = compiled_lib,
         srcs = ["%s.srcjar" % codegen],
         deps = deps + [
-            "@io_bazel_rules_scala//jmh:jmh_core",
+            Label("//jmh:jmh_core"),
             lib,
         ],
         resource_jars = ["%s_resources.jar" % codegen],
@@ -108,7 +106,7 @@ def scala_benchmark_jmh(**kw):
     scala_binary(
         name = name,
         deps = [
-            "@io_bazel_rules_scala//jmh:jmh_classpath",
+            Label("//jmh:jmh_classpath"),
             compiled_lib,
         ],
         data = data,

--- a/jmh/toolchain/toolchain.bzl
+++ b/jmh/toolchain/toolchain.bzl
@@ -35,7 +35,7 @@ def jmh_repositories(
         maven_servers = maven_servers,
         overriden_artifacts = overriden_artifacts,
     )
-    native.register_toolchains("@io_bazel_rules_scala_toolchains//jmh:all")
+    native.register_toolchains("@rules_scala_toolchains//jmh:all")
 
 def _jmh_toolchain_impl(ctx):
     toolchain = platform_common.ToolchainInfo(
@@ -53,7 +53,7 @@ jmh_toolchain = rule(
     },
 )
 
-_toolchain_type = "//jmh/toolchain:jmh_toolchain_type"
+_toolchain_type = Label("//jmh/toolchain:jmh_toolchain_type")
 
 def _export_toolchain_deps_impl(ctx):
     return expose_toolchain_deps(ctx, _toolchain_type)
@@ -79,7 +79,7 @@ def setup_jmh_toolchain(name):
     native.toolchain(
         name = name,
         toolchain = ":%s_impl" % name,
-        toolchain_type = Label(_toolchain_type),
+        toolchain_type = _toolchain_type,
         visibility = ["//visibility:public"],
     )
 
@@ -107,7 +107,7 @@ def setup_jmh_toolchain(name):
         deps_id = "benchmark_generator",
         visibility = ["//visibility:public"],
         deps = [
-            "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/jar",
+            Label("//src/java/io/bazel/rulesscala/jar"),
         ] + _versioned_repositories(SCALA_VERSION, [
             "@io_bazel_rules_scala_org_openjdk_jmh_jmh_core",
             "@io_bazel_rules_scala_org_openjdk_jmh_jmh_generator_asm",

--- a/manual_test/coverage_local_jacocorunner/BUILD
+++ b/manual_test/coverage_local_jacocorunner/BUILD
@@ -9,7 +9,7 @@ scala_toolchain(
 toolchain(
     name = "local_jacocorunner_scala_toolchain",
     toolchain = "local_jacocorunner_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/manual_test/scala_test_jacocorunner/BUILD
+++ b/manual_test/scala_test_jacocorunner/BUILD
@@ -10,7 +10,7 @@ scala_toolchain(
 toolchain(
     name = "passing_scala_toolchain",
     toolchain = "passing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/manual_test/scala_test_jvm_flags/BUILD
+++ b/manual_test/scala_test_jvm_flags/BUILD
@@ -11,7 +11,7 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -25,7 +25,7 @@ scala_toolchain(
 toolchain(
     name = "passing_scala_toolchain",
     toolchain = "passing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/manual_test/scalac_jvm_opts/BUILD
+++ b/manual_test/scalac_jvm_opts/BUILD
@@ -13,7 +13,7 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -27,7 +27,7 @@ scala_toolchain(
 toolchain(
     name = "passing_scala_toolchain",
     toolchain = "passing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/scala/BUILD
+++ b/scala/BUILD
@@ -12,7 +12,7 @@ toolchain_type(
 alias(
     name = "default_toolchain",
     actual = (
-        "@io_bazel_rules_scala_toolchains//scala:toolchain" +
+        "@rules_scala_toolchains//scala:toolchain" +
         version_suffix(SCALA_VERSION)
     ),
 )

--- a/scala/advanced_usage/scala.bzl
+++ b/scala/advanced_usage/scala.bzl
@@ -4,25 +4,25 @@ It is used only when you intend to add functionalities to existing default rules
 """
 
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_binary.bzl",
+    "//scala/private:rules/scala_binary.bzl",
     _make_scala_binary = "make_scala_binary",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_junit_test.bzl",
+    "//scala/private:rules/scala_junit_test.bzl",
     _make_scala_junit_test = "make_scala_junit_test",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_library.bzl",
+    "//scala/private:rules/scala_library.bzl",
     _make_scala_library = "make_scala_library",
     _make_scala_library_for_plugin_bootstrapping = "make_scala_library_for_plugin_bootstrapping",
     _make_scala_macro_library = "make_scala_macro_library",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_repl.bzl",
+    "//scala/private:rules/scala_repl.bzl",
     _make_scala_repl = "make_scala_repl",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_test.bzl",
+    "//scala/private:rules/scala_test.bzl",
     _make_scala_test = "make_scala_test",
 )
 

--- a/scala/plusone.bzl
+++ b/scala/plusone.bzl
@@ -10,19 +10,22 @@ PlusOneDeps = provider(
 )
 
 def _collect_plus_one_deps_aspect_impl(target, ctx):
-    if (ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].dependency_mode != "plus-one"):
+    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    if toolchain.dependency_mode != "plus-one":
         return []
+
     export_plus_one_deps = []
     for exported_dep in getattr(ctx.rule.attr, "exports", []):
         if PlusOneDeps in exported_dep:
             export_plus_one_deps.extend(exported_dep[PlusOneDeps].direct_deps)
-    return [PlusOneDeps(direct_deps = export_plus_one_deps + getattr(ctx.rule.attr, "deps", []))]
+
+    return [PlusOneDeps(
+        direct_deps = export_plus_one_deps + getattr(ctx.rule.attr, "deps", []),
+    )]
 
 collect_plus_one_deps_aspect = aspect(
     implementation = _collect_plus_one_deps_aspect_impl,
     attr_aspects = ["deps", "exports"],
-    toolchains = [
-        "@io_bazel_rules_scala//scala:toolchain_type",
-    ],
+    toolchains = [Label("//scala:toolchain_type")],
     incompatible_use_toolchain_transition = True,
 )

--- a/scala/private/common.bzl
+++ b/scala/private/common.bzl
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_scala//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
-load("@io_bazel_rules_scala//scala:plusone.bzl", "PlusOneDeps")
-load("@io_bazel_rules_scala//scala:providers.bzl", "ScalaInfo")
+load("//scala:jars_to_labels.bzl", "JarsToLabelsInfo")
+load("//scala:plusone.bzl", "PlusOneDeps")
+load("//scala:providers.bzl", "ScalaInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def write_manifest_file(actions, output_file, main_class):

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -1,11 +1,11 @@
 """Shared attributes for rules"""
 
 load(
-    "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
+    "//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
 load(
-    "@io_bazel_rules_scala//scala:plusone.bzl",
+    "//scala:plusone.bzl",
     _collect_plus_one_deps_aspect = "collect_plus_one_deps_aspect",
 )
 
@@ -57,7 +57,7 @@ common_attrs.update(common_attrs_for_plugin_bootstrapping)
 common_attrs.update({
     "_dependency_analyzer_plugin": attr.label(
         default = Label(
-            "@io_bazel_rules_scala//third_party/dependency_analyzer/src/main:dependency_analyzer",
+            "//third_party/dependency_analyzer/src/main:dependency_analyzer",
         ),
         allow_files = [".jar"],
         mandatory = False,
@@ -73,7 +73,9 @@ common_attrs.update({
     ),
     "unused_dependency_checker_ignored_targets": attr.label_list(default = []),
     "_code_coverage_instrumentation_worker": attr.label(
-        default = "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/coverage/instrumenter",
+        default = Label(
+            "//src/java/io/bazel/rulesscala/coverage/instrumenter",
+        ),
         allow_files = True,
         executable = True,
         cfg = "exec",
@@ -90,19 +92,19 @@ implicit_deps = {
     "_scalac": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac"),
+        default = Label("//src/java/io/bazel/rulesscala/scalac"),
         allow_files = True,
     ),
     "_exe": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/exe:exe"),
+        default = Label("//src/java/io/bazel/rulesscala/exe:exe"),
     ),
 }
 
 launcher_template = {
     "_java_stub_template": attr.label(
-        default = Label("@io_bazel_rules_scala//java_stub_template/file"),
+        default = Label("//java_stub_template/file"),
     ),
 }
 
@@ -110,9 +112,7 @@ launcher_template = {
 resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [
-            Label(
-                "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
-            ),
+            Label("//scala/private/toolchain_deps:scala_library_classpath"),
         ],
         allow_files = False,
     ),

--- a/scala/private/coverage_replacements_provider.bzl
+++ b/scala/private/coverage_replacements_provider.bzl
@@ -67,7 +67,7 @@ def _aspect_impl(target, ctx):
 _aspect = aspect(
     attr_aspects = _dependency_attributes,
     implementation = _aspect_impl,
-    toolchains = ["@io_bazel_rules_scala//scala:toolchain_type"],
+    toolchains = [Label("//scala:toolchain_type")],
     incompatible_use_toolchain_transition = True,
 )
 

--- a/scala/private/dependency.bzl
+++ b/scala/private/dependency.bzl
@@ -43,13 +43,13 @@ def get_strict_deps_mode(ctx):
     if not hasattr(ctx.attr, "_dependency_analyzer_plugin"):
         return "off"
 
-    return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].strict_deps_mode
+    return ctx.toolchains[Label("//scala:toolchain_type")].strict_deps_mode
 
 def get_compiler_deps_mode(ctx):
     if not hasattr(ctx.attr, "_dependency_analyzer_plugin"):
         return "off"
 
-    return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].compiler_deps_mode
+    return ctx.toolchains[Label("//scala:toolchain_type")].compiler_deps_mode
 
 def _is_strict_deps_on(ctx):
     return get_strict_deps_mode(ctx) != "off"

--- a/scala/private/phases/api.bzl
+++ b/scala/private/phases/api.bzl
@@ -3,7 +3,7 @@ The phase API for rules implementation
 """
 
 load(
-    "@io_bazel_rules_scala//scala:advanced_usage/providers.bzl",
+    "//scala:advanced_usage/providers.bzl",
     _ScalaRulePhase = "ScalaRulePhase",
 )
 load("@bazel_skylib//lib:dicts.bzl", "dicts")

--- a/scala/private/phases/phase_collect_exports_jars.bzl
+++ b/scala/private/phases/phase_collect_exports_jars.bzl
@@ -3,10 +3,7 @@
 #
 # DOCUMENT THIS
 #
-load(
-    "@io_bazel_rules_scala//scala/private:common.bzl",
-    "collect_jars",
-)
+load("//scala/private:common.bzl", "collect_jars")
 
 def phase_collect_exports_jars(ctx, p):
     # Add information from exports (is key that AFTER all build actions/runfiles analysis)

--- a/scala/private/phases/phase_collect_jars.bzl
+++ b/scala/private/phases/phase_collect_jars.bzl
@@ -3,10 +3,7 @@
 #
 # DOCUMENT THIS
 #
-load(
-    "@io_bazel_rules_scala//scala/private:common.bzl",
-    "collect_jars",
-)
+load("//scala/private:common.bzl", "collect_jars")
 
 def phase_collect_jars_scalatest(ctx, p):
     args = struct(

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -4,14 +4,14 @@
 # DOCUMENT THIS
 #
 load(
-    "@io_bazel_rules_scala//scala/private:paths.bzl",
+    "//scala/private:paths.bzl",
     _get_files_with_extension = "get_files_with_extension",
     _java_extension = "java_extension",
     _scala_extension = "scala_extension",
     _srcjar_extension = "srcjar_extension",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "//scala/private:rule_impls.bzl",
     "specified_java_compile_toolchain",
     _compile_java = "compile_java",
     _compile_scala = "compile_scala",
@@ -91,7 +91,8 @@ def phase_compile_common(ctx, p):
     return _phase_compile_default(ctx, p)
 
 def _phase_compile_default(ctx, p, _args = struct()):
-    buildijar_default_value = True if ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scala_version.startswith("2.") else False
+    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    buildijar_default_value = toolchain.scala_version.startswith("2.")
 
     return _phase_compile(
         ctx,

--- a/scala/private/phases/phase_coverage.bzl
+++ b/scala/private/phases/phase_coverage.bzl
@@ -5,11 +5,11 @@
 #
 
 load(
-    "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
+    "//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "//scala/private:rule_impls.bzl",
     _allow_security_manager = "allow_security_manager",
 )
 

--- a/scala/private/phases/phase_coverage_runfiles.bzl
+++ b/scala/private/phases/phase_coverage_runfiles.bzl
@@ -4,7 +4,7 @@
 # DOCUMENT THIS
 #
 load(
-    "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
+    "//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
 
@@ -21,7 +21,7 @@ def phase_coverage_runfiles(ctx, p):
             coverage_replacements[jar] if jar in coverage_replacements else jar
             for jar in rjars.to_list()
         ])
-        jacocorunner = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].jacocorunner
+        jacocorunner = ctx.toolchains[Label("//scala:toolchain_type")].jacocorunner
         coverage_runfiles = jacocorunner.files.to_list() + ctx.files._lcov_merger + coverage_replacements.values()
     return struct(
         coverage_runfiles = coverage_runfiles,

--- a/scala/private/phases/phase_declare_executable.bzl
+++ b/scala/private/phases/phase_declare_executable.bzl
@@ -3,10 +3,7 @@
 #
 # DOCUMENT THIS
 #
-load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    "is_windows",
-)
+load("//scala/private:rule_impls.bzl", "is_windows")
 
 def phase_declare_executable(ctx, p):
     if (is_windows(ctx)):

--- a/scala/private/phases/phase_default_info.bzl
+++ b/scala/private/phases/phase_default_info.bzl
@@ -4,7 +4,7 @@
 # DOCUMENT THIS
 #
 
-load("@io_bazel_rules_scala//scala/private:rule_impls.bzl", "specified_java_runtime")
+load("//scala/private:rule_impls.bzl", "specified_java_runtime")
 
 def phase_default_info(ctx, p):
     executable = None

--- a/scala/private/phases/phase_dependency.bzl
+++ b/scala/private/phases/phase_dependency.bzl
@@ -81,7 +81,7 @@ def _get_unused_deps_mode(ctx):
     if ctx.attr.unused_dependency_checker_mode:
         return ctx.attr.unused_dependency_checker_mode
     else:
-        return ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].unused_dependency_checker_mode
+        return ctx.toolchains[Label("//scala:toolchain_type")].unused_dependency_checker_mode
 
 def _is_target_included(target, includes, excludes):
     for exclude in excludes:

--- a/scala/private/phases/phase_java_wrapper.bzl
+++ b/scala/private/phases/phase_java_wrapper.bzl
@@ -3,10 +3,7 @@
 #
 # DOCUMENT THIS
 #
-load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    _java_bin = "java_bin",
-)
+load("//scala/private:rule_impls.bzl", _java_bin = "java_bin")
 
 def phase_java_wrapper_repl(ctx, p):
     args = struct(

--- a/scala/private/phases/phase_merge_jars.bzl
+++ b/scala/private/phases/phase_merge_jars.bzl
@@ -3,10 +3,7 @@
 #
 # DOCUMENT THIS
 #
-load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
-    "specified_java_compile_toolchain",
-)
+load("//scala/private:rule_impls.bzl", "specified_java_compile_toolchain")
 
 def merge_jars_to_output(ctx, output, jars):
     """Calls Bazel's singlejar utility.

--- a/scala/private/phases/phase_runfiles.bzl
+++ b/scala/private/phases/phase_runfiles.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala/private:common.bzl", "rlocationpath_from_file")
+load("//scala/private:common.bzl", "rlocationpath_from_file")
 
 #
 # PHASE: runfiles

--- a/scala/private/phases/phase_scalac_provider.bzl
+++ b/scala/private/phases/phase_scalac_provider.bzl
@@ -3,17 +3,11 @@
 #
 # DOCUMENT THIS
 #
-load(
-    "@io_bazel_rules_scala//scala:providers.bzl",
-    _ScalacProvider = "ScalacProvider",
-)
-load(
-    "@io_bazel_rules_scala//scala/private/toolchain_deps:toolchain_deps.bzl",
-    "find_deps_info_on",
-)
+load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
+load("//scala:providers.bzl", _ScalacProvider = "ScalacProvider")
 
 def phase_scalac_provider(ctx, p):
-    toolchain_type_label = "@io_bazel_rules_scala//scala:toolchain_type"
+    toolchain_type_label = Label("//scala:toolchain_type")
 
     library_classpath = find_deps_info_on(ctx, toolchain_type_label, "scala_library_classpath").deps
     compile_classpath = find_deps_info_on(ctx, toolchain_type_label, "scala_compile_classpath").deps

--- a/scala/private/phases/phase_scalacopts.bzl
+++ b/scala/private/phases/phase_scalacopts.bzl
@@ -1,3 +1,3 @@
 def phase_scalacopts(ctx, p):
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
+    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
     return toolchain.scalacopts + ctx.attr.scalacopts

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -3,10 +3,7 @@
 #
 # Outputs to format the scala files when it is explicitly specified
 #
-load(
-    "@io_bazel_rules_scala//scala/private:paths.bzl",
-    _scala_extension = "scala_extension",
-)
+load("//scala/private:paths.bzl", _scala_extension = "scala_extension")
 load(
     "//scala/private:rule_impls.bzl",
     _allow_security_manager = "allow_security_manager",

--- a/scala/private/phases/phase_semanticdb.bzl
+++ b/scala/private/phases/phase_semanticdb.bzl
@@ -1,8 +1,5 @@
-load(
-    "@io_bazel_rules_scala//scala/private/toolchain_deps:toolchain_deps.bzl",
-    "find_deps_info_on",
-)
-load("@io_bazel_rules_scala//scala:semanticdb_provider.bzl", "SemanticdbInfo")
+load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
+load("//scala:semanticdb_provider.bzl", "SemanticdbInfo")
 load("@bazel_skylib//lib:paths.bzl", "paths")
 
 def phase_semanticdb(ctx, p):
@@ -12,8 +9,8 @@ def phase_semanticdb(ctx, p):
 
     #Scala3: Semanticdb is built into scalac. Currently, if semanticdb-target is used, the semanticdb files are written and not bundled, otherwise, the semanticdb files are not written as files and only available inside the jar.
 
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
-    toolchain_type_label = "@io_bazel_rules_scala//scala:toolchain_type"
+    toolchain_type_label = Label("//scala:toolchain_type")
+    toolchain = ctx.toolchains[toolchain_type_label]
 
     if toolchain.enable_semanticdb == True:
         scalacopts = []

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -4,7 +4,7 @@
 # DOCUMENT THIS
 #
 load(
-    "@io_bazel_rules_scala//scala/private:rule_impls.bzl",
+    "//scala/private:rule_impls.bzl",
     "allow_security_manager",
     "expand_location",
     "first_non_empty",
@@ -14,14 +14,14 @@ load(
     "runfiles_root",
     "specified_java_runtime",
 )
-load("@io_bazel_rules_scala//scala/private:common.bzl", "rlocationpath_from_file")
+load("//scala/private:common.bzl", "rlocationpath_from_file")
 
 def phase_write_executable_scalatest(ctx, p):
     # jvm_flags passed in on the target override scala_test_jvm_flags passed in on the
     # toolchain
     final_jvm_flags = first_non_empty(
         ctx.attr.jvm_flags,
-        ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scala_test_jvm_flags,
+        ctx.toolchains[Label("//scala:toolchain_type")].scala_test_jvm_flags,
     )
 
     args = struct(
@@ -116,7 +116,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
         wrapper.short_path,
     )
 
-    scala_toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
+    scala_toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
 
     test_runner_classpath_mode = "argsfile" if scala_toolchain.use_argument_file_in_runner else "manifest"
 

--- a/scala/private/phases/phase_write_manifest.bzl
+++ b/scala/private/phases/phase_write_manifest.bzl
@@ -4,7 +4,7 @@
 # DOCUMENT THIS
 #
 load(
-    "@io_bazel_rules_scala//scala/private:common.bzl",
+    "//scala/private:common.bzl",
     _write_manifest_file = "write_manifest_file",
 )
 

--- a/scala/private/phases/phases.bzl
+++ b/scala/private/phases/phases.bzl
@@ -3,22 +3,22 @@ Re-expose all the phase APIs and built-in phases
 """
 
 load(
-    "@io_bazel_rules_scala//scala/private:phases/api.bzl",
+    "//scala/private:phases/api.bzl",
     _extras_phases = "extras_phases",
     _run_phases = "run_phases",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_collect_jars.bzl",
+    "//scala/private:phases/phase_collect_jars.bzl",
     _phase_collect_jars_common = "phase_collect_jars_common",
     _phase_collect_jars_junit_test = "phase_collect_jars_junit_test",
     _phase_collect_jars_macro_library = "phase_collect_jars_macro_library",
     _phase_collect_jars_repl = "phase_collect_jars_repl",
     _phase_collect_jars_scalatest = "phase_collect_jars_scalatest",
 )
-load("@io_bazel_rules_scala//scala/private:phases/phase_collect_exports_jars.bzl", _phase_collect_exports_jars = "phase_collect_exports_jars")
-load("@io_bazel_rules_scala//scala/private:phases/phase_collect_srcjars.bzl", _phase_collect_srcjars = "phase_collect_srcjars")
+load("//scala/private:phases/phase_collect_exports_jars.bzl", _phase_collect_exports_jars = "phase_collect_exports_jars")
+load("//scala/private:phases/phase_collect_srcjars.bzl", _phase_collect_srcjars = "phase_collect_srcjars")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_compile.bzl",
+    "//scala/private:phases/phase_compile.bzl",
     _phase_compile_binary = "phase_compile_binary",
     _phase_compile_common = "phase_compile_common",
     _phase_compile_junit_test = "phase_compile_junit_test",
@@ -28,49 +28,49 @@ load(
     _phase_compile_scalatest = "phase_compile_scalatest",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_coverage.bzl",
+    "//scala/private:phases/phase_coverage.bzl",
     _phase_coverage_common = "phase_coverage_common",
     _phase_coverage_library = "phase_coverage_library",
 )
-load("@io_bazel_rules_scala//scala/private:phases/phase_coverage_runfiles.bzl", _phase_coverage_runfiles = "phase_coverage_runfiles")
-load("@io_bazel_rules_scala//scala/private:phases/phase_declare_executable.bzl", _phase_declare_executable = "phase_declare_executable")
-load("@io_bazel_rules_scala//scala/private:phases/phase_default_info.bzl", _phase_default_info = "phase_default_info")
+load("//scala/private:phases/phase_coverage_runfiles.bzl", _phase_coverage_runfiles = "phase_coverage_runfiles")
+load("//scala/private:phases/phase_declare_executable.bzl", _phase_declare_executable = "phase_declare_executable")
+load("//scala/private:phases/phase_default_info.bzl", _phase_default_info = "phase_default_info")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_dependency.bzl",
+    "//scala/private:phases/phase_dependency.bzl",
     _phase_dependency_common = "phase_dependency_common",
     _phase_dependency_library_for_plugin_bootstrapping = "phase_dependency_library_for_plugin_bootstrapping",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_java_wrapper.bzl",
+    "//scala/private:phases/phase_java_wrapper.bzl",
     _phase_java_wrapper_common = "phase_java_wrapper_common",
     _phase_java_wrapper_repl = "phase_java_wrapper_repl",
 )
-load("@io_bazel_rules_scala//scala/private:phases/phase_jvm_flags.bzl", _phase_jvm_flags = "phase_jvm_flags")
-load("@io_bazel_rules_scala//scala/private:phases/phase_merge_jars.bzl", _phase_merge_jars = "phase_merge_jars")
+load("//scala/private:phases/phase_jvm_flags.bzl", _phase_jvm_flags = "phase_jvm_flags")
+load("//scala/private:phases/phase_merge_jars.bzl", _phase_merge_jars = "phase_merge_jars")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_runfiles.bzl",
+    "//scala/private:phases/phase_runfiles.bzl",
     _phase_runfiles_common = "phase_runfiles_common",
     _phase_runfiles_library = "phase_runfiles_library",
     _phase_runfiles_scalatest = "phase_runfiles_scalatest",
 )
-load("@io_bazel_rules_scala//scala/private:phases/phase_scalac_provider.bzl", _phase_scalac_provider = "phase_scalac_provider")
-load("@io_bazel_rules_scala//scala/private:phases/phase_scalacopts.bzl", _phase_scalacopts = "phase_scalacopts")
-load("@io_bazel_rules_scala//scala/private:phases/phase_scalafmt.bzl", _phase_scalafmt = "phase_scalafmt")
+load("//scala/private:phases/phase_scalac_provider.bzl", _phase_scalac_provider = "phase_scalac_provider")
+load("//scala/private:phases/phase_scalacopts.bzl", _phase_scalacopts = "phase_scalacopts")
+load("//scala/private:phases/phase_scalafmt.bzl", _phase_scalafmt = "phase_scalafmt")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_scalainfo_provider.bzl",
+    "//scala/private:phases/phase_scalainfo_provider.bzl",
     _phase_scalainfo_provider_macro = "phase_scalainfo_provider_macro",
     _phase_scalainfo_provider_non_macro = "phase_scalainfo_provider_non_macro",
 )
-load("@io_bazel_rules_scala//scala/private:phases/phase_semanticdb.bzl", _phase_semanticdb = "phase_semanticdb")
-load("@io_bazel_rules_scala//scala/private:phases/phase_test_environment.bzl", _phase_test_environment = "phase_test_environment")
+load("//scala/private:phases/phase_semanticdb.bzl", _phase_semanticdb = "phase_semanticdb")
+load("//scala/private:phases/phase_test_environment.bzl", _phase_test_environment = "phase_test_environment")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phase_write_executable.bzl",
+    "//scala/private:phases/phase_write_executable.bzl",
     _phase_write_executable_common = "phase_write_executable_common",
     _phase_write_executable_junit_test = "phase_write_executable_junit_test",
     _phase_write_executable_repl = "phase_write_executable_repl",
     _phase_write_executable_scalatest = "phase_write_executable_scalatest",
 )
-load("@io_bazel_rules_scala//scala/private:phases/phase_write_manifest.bzl", _phase_write_manifest = "phase_write_manifest")
+load("//scala/private:phases/phase_write_manifest.bzl", _phase_write_manifest = "phase_write_manifest")
 
 # API
 run_phases = _run_phases

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -64,7 +64,7 @@ def compile_scala(
     if dependency_info.use_analyzer:
         plugins = depset(transitive = [plugins, ctx.attr._dependency_analyzer_plugin.files])
 
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"]
+    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
     compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars
     classpath_resources = getattr(ctx.files, "classpath_resources", [])
     scalacopts_expanded = [ctx.expand_location(v, input_plugins) for v in scalacopts]

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -2,16 +2,16 @@
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
 load(
-    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "//scala/private:common_attributes.bzl",
     "common_attrs",
     "implicit_deps",
     "launcher_template",
     "resolve_deps",
 )
-load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+load("//scala/private:common_outputs.bzl", "common_outputs")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
+    "//scala/private:phases/phases.bzl",
     "extras_phases",
     "phase_collect_jars_common",
     "phase_compile_binary",
@@ -89,7 +89,7 @@ def make_scala_binary(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -1,7 +1,7 @@
 """Scaladoc support"""
 
-load("@io_bazel_rules_scala//scala:providers.bzl", "ScalaInfo")
-load("@io_bazel_rules_scala//scala/private:common.bzl", "collect_plugin_paths")
+load("//scala/private:common.bzl", "collect_plugin_paths")
+load("//scala:providers.bzl", "ScalaInfo")
 
 ScaladocAspectInfo = provider(fields = [
     "src_files",  #depset[File]

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -1,23 +1,23 @@
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
 load(
-    "@io_bazel_rules_scala//scala/private:common.bzl",
+    "//scala/private:common.bzl",
     "sanitize_string_for_usage",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "//scala/private:common_attributes.bzl",
     "common_attrs",
     "common_attrs_for_plugin_bootstrapping",
     "implicit_deps",
     "resolve_deps",
 )
-load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
+load("//scala/private:common_outputs.bzl", "common_outputs")
 load(
-    "@io_bazel_rules_scala//scala/private:coverage_replacements_provider.bzl",
+    "//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
+    "//scala/private:phases/phases.bzl",
     "extras_phases",
     "phase_collect_exports_jars",
     "phase_collect_jars_common",
@@ -105,7 +105,7 @@ def make_scala_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,
@@ -180,7 +180,9 @@ _scala_library_for_plugin_bootstrapping_attrs.update({
     "_scalac": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac:scalac_bootstrap"),
+        default = Label(
+            "//src/java/io/bazel/rulesscala/scalac:scalac_bootstrap",
+        ),
         allow_files = True,
     ),
 })
@@ -208,7 +210,7 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,
@@ -285,7 +287,7 @@ def make_scala_macro_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -2,16 +2,16 @@
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
 load(
-    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "//scala/private:common_attributes.bzl",
     "common_attrs",
     "implicit_deps",
     "launcher_template",
     "resolve_deps",
 )
-load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+load("//scala/private:common_outputs.bzl", "common_outputs")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
+    "//scala/private:phases/phases.bzl",
     "extras_phases",
     "phase_collect_jars_repl",
     "phase_compile_repl",
@@ -84,7 +84,7 @@ def make_scala_repl(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            "@io_bazel_rules_scala//scala:toolchain_type",
+            Label("//scala:toolchain_type"),
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -2,16 +2,16 @@
 
 load("@bazel_skylib//lib:dicts.bzl", _dicts = "dicts")
 load(
-    "@io_bazel_rules_scala//scala/private:common_attributes.bzl",
+    "//scala/private:common_attributes.bzl",
     "common_attrs",
     "implicit_deps",
     "launcher_template",
 )
-load("@io_bazel_rules_scala//scala/private:common.bzl", "sanitize_string_for_usage")
-load("@io_bazel_rules_scala//scala/private:common_outputs.bzl", "common_outputs")
-load("@io_bazel_rules_scala//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
+load("//scala/private:common.bzl", "sanitize_string_for_usage")
+load("//scala/private:common_outputs.bzl", "common_outputs")
+load("//scala:scala_cross_version.bzl", "scala_version_transition", "toolchain_transition_attr")
 load(
-    "@io_bazel_rules_scala//scala/private:phases/phases.bzl",
+    "//scala/private:phases/phases.bzl",
     "extras_phases",
     "phase_collect_jars_scalatest",
     "phase_compile_scalatest",
@@ -71,7 +71,7 @@ _scala_test_attrs = {
     ),
     "_scalatest": attr.label(
         default = Label(
-            "@io_bazel_rules_scala//testing/toolchain:scalatest_classpath",
+            "//testing/toolchain:scalatest_classpath",
         ),
     ),
     "_scalatest_runner": attr.label(
@@ -93,10 +93,10 @@ _test_resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [
             Label(
-                "@io_bazel_rules_scala//scala/private/toolchain_deps:scala_library_classpath",
+                "//scala/private/toolchain_deps:scala_library_classpath",
             ),
             Label(
-                "@io_bazel_rules_scala//testing/toolchain:scalatest_classpath",
+                "//testing/toolchain:scalatest_classpath",
             ),
         ],
         allow_files = False,

--- a/scala/private/toolchain_deps/toolchain_deps.bzl
+++ b/scala/private/toolchain_deps/toolchain_deps.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:providers.bzl", "DepsInfo")
+load("//scala:providers.bzl", "DepsInfo")
 
 def _required_deps_id_message(target, toolchain_type_label, deps_id):
     return target + " requires mapping of " + deps_id + " provider id on the toolchain " + toolchain_type_label

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -114,7 +114,7 @@ def _default_dep_providers():
     if SCALA_MAJOR_VERSION.startswith("2."):
         dep_providers.append("semanticdb")
     return [
-        "@io_bazel_rules_scala_toolchains//scala:%s_provider" % p
+        "@rules_scala_toolchains//scala:%s_provider" % p
         for p in dep_providers
     ]
 

--- a/scala/scalafmt/BUILD
+++ b/scala/scalafmt/BUILD
@@ -40,7 +40,7 @@ scalafmt_singleton(
 alias(
     name = "scalafmt_toolchain",
     actual = (
-        "@io_bazel_rules_scala_toolchains//scalafmt:scalafmt_toolchain" +
+        "@rules_scala_toolchains//scalafmt:scalafmt_toolchain" +
         version_suffix(SCALA_VERSION)
     ),
 )

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -90,6 +90,6 @@ def scalafmt_repositories(
         )
 
         native.register_toolchains(str(Label(
-            "//scala/scalafmt:scalafmt_toolchain" +
+            "@rules_scala_toolchains//scalafmt:scalafmt_toolchain" +
             version_suffix(scala_version),
         )))

--- a/scala/scalafmt/toolchain/toolchain.bzl
+++ b/scala/scalafmt/toolchain/toolchain.bzl
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:providers.bzl", _DepsInfo = "DepsInfo")
+load("//scala:providers.bzl", _DepsInfo = "DepsInfo")
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "expose_toolchain_deps")
 
 SCALAFMT_TOOLCHAIN_TYPE = Label(

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -1,4 +1,4 @@
-"""Macros to instantiate and register @io_bazel_rules_scala_toolchains"""
+"""Macros to instantiate and register @rules_scala_toolchains"""
 
 load("//jmh/toolchain:toolchain.bzl", "jmh_artifact_ids")
 load("//junit:junit.bzl", "junit_artifact_ids")
@@ -49,12 +49,12 @@ def scala_toolchains(
     Provides a unified interface to configuring rules_scala both directly in a
     `WORKSPACE` file and in a Bazel module extension.
 
-    Instantiates the `@io_bazel_rules_scala_toolchains` repository. Under
+    Instantiates the `@rules_scala_toolchains` repository. Under
     `WORKSPACE`, you will need to call `register_toolchains` at some point.
     Under Bzlmod, rules_scala does this automatically.
 
     ```starlark
-    register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+    register_toolchains("@rules_scala_toolchains//...:all")
     ```
 
     All arguments are optional.
@@ -204,7 +204,7 @@ def scala_toolchains(
     )
 
 def scala_register_toolchains():
-    native.register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+    native.register_toolchains("@rules_scala_toolchains//...:all")
 
 def scala_register_unused_deps_toolchains():
     native.register_toolchains(

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -1,4 +1,4 @@
-"""Repository rule to instantiate @io_bazel_rules_scala_toolchains"""
+"""Repository rule to instantiate @rules_scala_toolchains"""
 
 def _generate_testing_toolchain_build_file_args(repo_attr):
     framework_deps = {}
@@ -107,7 +107,7 @@ _scala_toolchains_repo = repository_rule(
     },
 )
 
-def scala_toolchains_repo(name = "io_bazel_rules_scala_toolchains", **kwargs):
+def scala_toolchains_repo(name = "rules_scala_toolchains", **kwargs):
     _scala_toolchains_repo(
         name = name,
         **kwargs

--- a/scala/unstable/defs.bzl
+++ b/scala/unstable/defs.bzl
@@ -9,7 +9,7 @@ use the stable rules exported by scala.bzl:
 
 ```
 load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
+    "//scala:scala.bzl",
     "scala_library",
     "scala_binary",
     "scala_test"
@@ -19,15 +19,15 @@ load(
 """
 
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_binary.bzl",
+    "//scala/private:rules/scala_binary.bzl",
     _make_scala_binary = "make_scala_binary",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_library.bzl",
+    "//scala/private:rules/scala_library.bzl",
     _make_scala_library = "make_scala_library",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:rules/scala_test.bzl",
+    "//scala/private:rules/scala_test.bzl",
     _make_scala_test = "make_scala_test",
 )
 

--- a/scala_proto/default/default_deps.bzl
+++ b/scala_proto/default/default_deps.bzl
@@ -12,7 +12,7 @@ load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 
 _DEFAULT_DEP_PROVIDER_FORMAT = (
-    "@io_bazel_rules_scala_toolchains//scala_proto:scalapb_%s_deps_provider"
+    "@rules_scala_toolchains//scala_proto:scalapb_%s_deps_provider"
 )
 
 def scala_proto_deps_providers(

--- a/scala_proto/private/scala_proto.bzl
+++ b/scala_proto/private/scala_proto.bzl
@@ -1,10 +1,10 @@
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load(
-    "@io_bazel_rules_scala//scala_proto/private:scala_proto_aspect_provider.bzl",
+    "//scala_proto/private:scala_proto_aspect_provider.bzl",
     "ScalaProtoAspectInfo",
 )
 load(
-    "@io_bazel_rules_scala//scala/private:phases/api.bzl",
+    "//scala/private:phases/api.bzl",
     "extras_phases",
     "run_phases",
 )

--- a/scala_proto/toolchains.bzl
+++ b/scala_proto/toolchains.bzl
@@ -13,7 +13,7 @@ def scala_proto_register_enable_all_options_toolchain():
     )
 
 def setup_scala_proto_toolchains(name, enable_all_options = False):
-    """Used by @io_bazel_rules_scala_toolchains//scala_proto/BUILD.
+    """Used by @rules_scala_toolchains//scala_proto/BUILD.
 
     See //scala/private:macros/toolchains_repo.bzl for details, especially the
     _SCALA_PROTO_TOOLCHAIN_BUILD string template.

--- a/src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD
+++ b/src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD
@@ -3,7 +3,7 @@ load("@rules_java//java:defs.bzl", "java_binary")
 java_binary(
     name = "instrumenter",
     srcs = [
-        "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/coverage/instrumenter:instrumenter_files",
+        "//src/java/io/bazel/rulesscala/coverage/instrumenter:instrumenter_files",
     ],
     javacopts = [
         "-source 1.8",

--- a/src/java/io/bazel/rulesscala/scalac/reporter/BUILD
+++ b/src/java/io/bazel/rulesscala/scalac/reporter/BUILD
@@ -32,7 +32,7 @@ java_library(
         ":scala_deps_java_proto",
         "//scala/private/toolchain_deps:scala_compile_classpath",
         "//src/java/io/bazel/rulesscala/scalac/compileoptions",
-        "@io_bazel_rules_scala//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
+        "//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
     ],
 )
 

--- a/src/java/io/bazel/rulesscala/test_discovery/BUILD
+++ b/src/java/io/bazel/rulesscala/test_discovery/BUILD
@@ -8,5 +8,5 @@ scala_library(
         "FilteredRunnerBuilder.scala",
     ],
     visibility = ["//visibility:public"],
-    deps = ["@io_bazel_rules_scala//testing/toolchain:junit_classpath"],
+    deps = ["//testing/toolchain:junit_classpath"],
 )

--- a/test/diagnostics_reporter/BUILD
+++ b/test/diagnostics_reporter/BUILD
@@ -1,5 +1,5 @@
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 load("@rules_java//java:defs.bzl", "java_binary")
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 java_binary(
     name = "diagnostics_reporter_test",

--- a/test/phase/providers/phase_providers_expose.bzl
+++ b/test/phase/providers/phase_providers_expose.bzl
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
-load("@io_bazel_rules_scala//scala:advanced_usage/scala.bzl", "make_scala_library")
+load("//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("//scala:advanced_usage/scala.bzl", "make_scala_library")
 
 ext_phase_expose_provider = {
     "phase_providers": [

--- a/test/phase/providers/phase_providers_override.bzl
+++ b/test/phase/providers/phase_providers_override.bzl
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
-load("@io_bazel_rules_scala//scala:advanced_usage/scala.bzl", "make_scala_library")
+load("//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("//scala:advanced_usage/scala.bzl", "make_scala_library")
 
 ext_phase_override_provider = {
     "phase_providers": [

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -35,7 +35,7 @@ scala_proto_toolchain(
 toolchain(
     name = "scalapb_toolchain",
     toolchain = ":test_scala_proto_toolchain_configuration",
-    toolchain_type = "@io_bazel_rules_scala//scala_proto:toolchain_type",
+    toolchain_type = "//scala_proto:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -127,7 +127,7 @@ scala_proto_library(
     deps = [
         ":blacklisted_proto",
         ":test_service",
-        "@io_bazel_rules_scala//test/proto:other_blacklisted_proto",
+        "//test/proto:other_blacklisted_proto",
     ],
 )
 

--- a/test/proto_cross_repo_boundary/BUILD
+++ b/test/proto_cross_repo_boundary/BUILD
@@ -1,6 +1,6 @@
-load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scalapb_proto_library")
+load("//scala_proto:scala_proto.bzl", "scala_proto_library")
 
-scalapb_proto_library(
+scala_proto_library(
     name = "sample_scala_proto",
     visibility = ["//visibility:public"],
     deps = ["@proto_cross_repo_boundary//:sample_proto"],

--- a/test/scala_test/BUILD
+++ b/test/scala_test/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load("//scala:scala.bzl", "scala_test")
 
 scala_test(
     name = "a",

--- a/test/semanticdb/BUILD
+++ b/test/semanticdb/BUILD
@@ -12,7 +12,7 @@ scala_toolchain(
 toolchain(
     name = "semanticdb_bundle_toolchain",
     toolchain = "semanticdb_bundle_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -26,7 +26,7 @@ scala_toolchain(
 toolchain(
     name = "semanticdb_nobundle_toolchain",
     toolchain = "semanticdb_nobundle_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test/src/main/scala/scalarules/test/io_utils/BUILD
+++ b/test/src/main/scala/scalarules/test/io_utils/BUILD
@@ -6,6 +6,6 @@ scala_test(
         "DeleteDirectoryTest.scala",
     ],
     deps = [
-        "@io_bazel_rules_scala//src/java/io/bazel/rulesscala/io_utils",
+        "//src/java/io/bazel/rulesscala/io_utils",
     ],
 )

--- a/test/src/main/scala/scalarules/test/stamping/BUILD
+++ b/test/src/main/scala/scalarules/test/stamping/BUILD
@@ -1,5 +1,5 @@
 load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
+    "//scala:scala.bzl",
     "scala_library",
     "scala_macro_library",
     "scala_test",

--- a/test_all.sh
+++ b/test_all.sh
@@ -3,8 +3,13 @@
 set -euo pipefail
 
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+"${dir}"/test_lint.sh
 "${dir}"/test_rules_scala.sh
 "${dir}"/test_version.sh
 "${dir}"/test_cross_build.sh
 "${dir}"/test_reproducibility.sh
 #"${dir}"/test_intellij_aspect.sh
+"${dir}"/test_examples.sh
+"${dir}"/test_coverage.sh
+"${dir}"/test_thirdparty_version.sh
+"${dir}"/dt_patches/dt_patch_test.sh

--- a/test_cross_build/WORKSPACE
+++ b/test_cross_build/WORKSPACE
@@ -3,11 +3,11 @@
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,7 +48,7 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(
     scala_version = "3.1.3",
@@ -63,11 +63,15 @@ scala_config(
 )
 
 # loads other rules Rules Scala depends on
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     scalafmt = True,
     scalatest = True,
 )
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+scala_register_toolchains()

--- a/test_cross_build/scalafmt/scalafmt_rules.bzl
+++ b/test_cross_build/scalafmt/scalafmt_rules.bzl
@@ -1,11 +1,11 @@
 load(
-    "@io_bazel_rules_scala//scala:advanced_usage/scala.bzl",
+    "@rules_scala//scala:advanced_usage/scala.bzl",
     "make_scala_binary",
     "make_scala_library",
     "make_scala_test",
 )
 load(
-    "@io_bazel_rules_scala//scala/scalafmt:phase_scalafmt_ext.bzl",
+    "@rules_scala//scala/scalafmt:phase_scalafmt_ext.bzl",
     "ext_scalafmt",
 )
 

--- a/test_cross_build/version_specific/BUILD
+++ b/test_cross_build/version_specific/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_library")
 
 # A collection of arbitrarily chosen backward- and forward-incompatible code.
 # This simply tests if the proper compiler is assigned, according to Scala version setting.

--- a/test_expect_failure/compiler_dependency_tracker/BUILD
+++ b/test_expect_failure/compiler_dependency_tracker/BUILD
@@ -1,5 +1,5 @@
+load("//scala:scala.bzl", "scala_library")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
 
 scala_toolchain(
     name = "ast_plus_error_impl",
@@ -14,7 +14,7 @@ scala_toolchain(
 toolchain(
     name = "ast_plus_error",
     toolchain = ":ast_plus_error_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -31,7 +31,7 @@ scala_toolchain(
 toolchain(
     name = "ast_plus_warn",
     toolchain = ":ast_plus_warn_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/diagnostics_reporter/BUILD
+++ b/test_expect_failure/diagnostics_reporter/BUILD
@@ -1,6 +1,6 @@
 load("//scala:scala.bzl", "scala_library")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 scala_toolchain(
     name = "diagnostics_reporter_toolchain_impl",
@@ -11,7 +11,7 @@ scala_toolchain(
 toolchain(
     name = "diagnostics_reporter_toolchain",
     toolchain = "diagnostics_reporter_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -25,7 +25,7 @@ scala_toolchain(
 toolchain(
     name = "diagnostics_reporter_and_semanticdb_toolchain",
     toolchain = "diagnostics_reporter_and_semanticdb_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/missing_direct_deps/filtering/BUILD
+++ b/test_expect_failure/missing_direct_deps/filtering/BUILD
@@ -4,7 +4,7 @@ load("//scala:scala_toolchain.bzl", "scala_toolchain")
 toolchain(
     name = "plus_one_strict_deps_filter",
     toolchain = ":plus_one_strict_deps_filter_a_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
+++ b/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
@@ -15,7 +15,9 @@ custom_jvm = rule(
         "deps": attr.label_list(),
         "jar": attr.label(
             allow_single_file = True,
-            default = Label("@io_bazel_rules_scala//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar"),
+            default = Label(
+                "//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar",
+            ),
         ),
     },
 )

--- a/test_expect_failure/missing_direct_deps/scala_proto_deps/customized_scala_proto.bzl
+++ b/test_expect_failure/missing_direct_deps/scala_proto_deps/customized_scala_proto.bzl
@@ -1,9 +1,9 @@
 load("//scala_proto:scala_proto.bzl", "make_scala_proto_aspect", "make_scala_proto_library")
-load("@io_bazel_rules_scala//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
+load("//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
 
 def _phase_custom_stamping_convention(ctx, p):
     rule_label = str(p.target.label)
-    toolchain = ctx.toolchains["@io_bazel_rules_scala//scala_proto:toolchain_type"]
+    toolchain = ctx.toolchains[Label("//scala_proto:toolchain_type")]
 
     if toolchain.stamp_by_convention:
         return rule_label + "_custom_suffix"

--- a/test_expect_failure/scala_test_env_inherit/BUILD
+++ b/test_expect_failure/scala_test_env_inherit/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load("//scala:scala.bzl", "scala_test")
 
 scala_test(
     name = "inherit_a",

--- a/test_expect_failure/scala_test_jacocorunner/BUILD
+++ b/test_expect_failure/scala_test_jacocorunner/BUILD
@@ -11,7 +11,7 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/scala_test_jvm_flags/BUILD
+++ b/test_expect_failure/scala_test_jvm_flags/BUILD
@@ -18,14 +18,14 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
 toolchain(
     name = "passing_scala_toolchain",
     toolchain = "passing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/scala_test_testfilter/BUILD
+++ b/test_expect_failure/scala_test_testfilter/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load("//scala:scala.bzl", "scala_test")
 
 scala_test(
     name = "tests",

--- a/test_expect_failure/scalac_jvm_opts/BUILD
+++ b/test_expect_failure/scalac_jvm_opts/BUILD
@@ -11,7 +11,7 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/scalacopts_from_toolchain/BUILD
+++ b/test_expect_failure/scalacopts_from_toolchain/BUILD
@@ -10,7 +10,7 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/unused_dependency_checker/BUILD
+++ b/test_expect_failure/unused_dependency_checker/BUILD
@@ -10,7 +10,7 @@ scala_toolchain(
 toolchain(
     name = "failing_scala_toolchain",
     toolchain = "failing_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_expect_failure/unused_dependency_checker/filtering/BUILD
+++ b/test_expect_failure/unused_dependency_checker/filtering/BUILD
@@ -4,7 +4,7 @@ load("//scala:scala_toolchain.bzl", "scala_toolchain")
 toolchain(
     name = "plus_one_unused_deps_filter",
     toolchain = ":plus_one_unused_deps_filter_a_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_version/WORKSPACE.template
+++ b/test_version/WORKSPACE.template
@@ -1,13 +1,13 @@
-workspace(name = "io_bazel_rules_scala_test")
+workspace(name = "rules_scala_test")
 
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../../"
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,15 +48,19 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config(enable_compiler_dependency_tracking = True)
-
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
 
 load(":scrooge_repositories.bzl", "scrooge_repositories")
 
 scrooge_repositories(${twitter_scrooge_repositories})
+
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
@@ -66,7 +70,8 @@ scala_toolchains(
 )
 
 register_toolchains(
-    "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
+    "@rules_scala//scala:unused_dependency_checker_error_toolchain",
     "@twitter_scrooge_test_toolchain//...:all",
-    "@io_bazel_rules_scala_toolchains//...:all",
 )
+
+scala_register_toolchains()

--- a/test_version/test_reporter/BUILD
+++ b/test_version/test_reporter/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//scala:scala_toolchain.bzl", "scala_toolchain")
+load("@rules_scala//scala:scala.bzl", "scala_library")
 
 scala_toolchain(
     name = "diagnostics_reporter_toolchain_impl",
@@ -10,7 +10,7 @@ scala_toolchain(
 toolchain(
     name = "diagnostics_reporter_toolchain",
     toolchain = "diagnostics_reporter_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "@rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -24,7 +24,7 @@ scala_toolchain(
 toolchain(
     name = "diagnostics_reporter_and_semanticdb_toolchain",
     toolchain = "diagnostics_reporter_and_semanticdb_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "@rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 
@@ -36,7 +36,7 @@ scala_toolchain(
 toolchain(
     name = "no_diagnostics_reporter_toolchain",
     toolchain = "no_diagnostics_reporter_toolchain_impl",
-    toolchain_type = "@io_bazel_rules_scala//scala:toolchain_type",
+    toolchain_type = "@rules_scala//scala:toolchain_type",
     visibility = ["//visibility:public"],
 )
 

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -1,6 +1,6 @@
 load("@rules_java//java:defs.bzl", "java_binary", "java_library")
 load(
-    "@io_bazel_rules_scala//scala:scala.bzl",
+    "@rules_scala//scala:scala.bzl",
     "scala_binary",
     "scala_junit_test",
     "scala_library",

--- a/test_version/version_specific_tests_dir/proto/BUILD
+++ b/test_version/version_specific_tests_dir/proto/BUILD
@@ -1,8 +1,5 @@
-load(
-    "@io_bazel_rules_scala//scala_proto:scala_proto.bzl",
-    "scala_proto_library",
-)
 load("@rules_proto//proto:defs.bzl", "proto_library")
+load("@rules_scala//scala_proto:scala_proto.bzl", "scala_proto_library")
 
 proto_library(
     name = "test2",

--- a/test_version/version_specific_tests_dir/scrooge_repositories.bzl
+++ b/test_version/version_specific_tests_dir/scrooge_repositories.bzl
@@ -1,17 +1,17 @@
 load(
-    "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
+    "@rules_scala//scala:scala_cross_version.bzl",
     "default_maven_server_urls",
 )
 load(
-    "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
+    "@rules_scala//scala:scala_maven_import_external.bzl",
     _scala_maven_import_external = "scala_maven_import_external",
 )
 load(
-    "@io_bazel_rules_scala//scala:toolchains_repo.bzl",
+    "@rules_scala//scala:toolchains_repo.bzl",
     "scala_toolchains_repo",
 )
 load(
-    "@io_bazel_rules_scala//twitter_scrooge/toolchain:toolchain.bzl",
+    "@rules_scala//twitter_scrooge/toolchain:toolchain.bzl",
     "twitter_scrooge",
 )
 

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
-load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_binary", "scala_library")
+load("@rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
 
 scrooge_scala_library(
     name = "scrooge1",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/prefix_test/a/b/c/d/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/prefix_test/a/b/c/d/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
-load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
 
 thrift_library(
     name = "a_thrift",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/prefix_test/e/f/b/c/d/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/prefix_test/e/f/b/c/d/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
-load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_library")
 
 thrift_library(
     name = "b_thrift",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
 
 thrift_library(
     name = "thrift",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
 
 thrift_library(
     name = "foo",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/bare_jar_1/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/bare_jar_1/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
 
 thrift_library(
     name = "bar",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/bare_jar_2/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/bare_jar_thrifts/bare_jar_2/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
 
 thrift_library(
     name = "baz",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
 
 thrift_library(
     name = "thrift2_a",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/thrift3/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/thrift3/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
-load("@io_bazel_rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_import")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//twitter_scrooge:twitter_scrooge.bzl", "scrooge_scala_import")
 
 thrift_library(
     name = "thrift3",

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/thrift4/BUILD
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/twitter_scrooge/thrift/thrift2/thrift4/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//thrift:thrift.bzl", "thrift_library")
+load("@rules_scala//thrift:thrift.bzl", "thrift_library")
 
 thrift_library(
     name = "thrift4",

--- a/testing/BUILD
+++ b/testing/BUILD
@@ -6,7 +6,7 @@ load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
     alias(
         name = framework + "_toolchain",
         actual = (
-            "@io_bazel_rules_scala_toolchains//testing:testing_toolchain" +
+            "@rules_scala_toolchains//testing:testing_toolchain" +
             version_suffix(SCALA_VERSION)
         ),
     )

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
@@ -1,5 +1,5 @@
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 load("//scala:scala.bzl", "scala_library_for_plugin_bootstrapping")
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 scala_library_for_plugin_bootstrapping(
     name = "dep_reporting_compiler",

--- a/third_party/dependency_analyzer/src/test/analyzer_test.bzl
+++ b/third_party/dependency_analyzer/src/test/analyzer_test.bzl
@@ -1,7 +1,11 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
-load("@io_bazel_rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
-load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_MAJOR_VERSION", "SCALA_VERSION")
+load("//scala:scala.bzl", "scala_test")
 load("//scala:scala_cross_version.bzl", "version_suffix")
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+load(
+    "@io_bazel_rules_scala_config//:config.bzl",
+    "SCALA_MAJOR_VERSION",
+    "SCALA_VERSION",
+)
 
 def tests():
     suffix = version_suffix(SCALA_VERSION)

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -1,4 +1,14 @@
 load(
+    "//scala:scala_cross_version.bzl",
+    "default_maven_server_urls",
+    "extract_major_version",
+    "version_suffix",
+)
+load(
+    "//scala:scala_maven_import_external.bzl",
+    _scala_maven_import_external = "scala_maven_import_external",
+)
+load(
     "//third_party/repositories:scala_2_11.bzl",
     _artifacts_2_11 = "artifacts",
     _scala_version_2_11 = "scala_version",
@@ -42,16 +52,6 @@ load(
     "//third_party/repositories:scala_3_6.bzl",
     _artifacts_3_6 = "artifacts",
     _scala_version_3_6 = "scala_version",
-)
-load(
-    "@io_bazel_rules_scala//scala:scala_cross_version.bzl",
-    "default_maven_server_urls",
-    "extract_major_version",
-    "version_suffix",
-)
-load(
-    "@io_bazel_rules_scala//scala:scala_maven_import_external.bzl",
-    _scala_maven_import_external = "scala_maven_import_external",
 )
 load("@io_bazel_rules_scala_config//:config.bzl", "SCALA_VERSION")
 

--- a/third_party/test/example_external_workspace/WORKSPACE
+++ b/third_party/test/example_external_workspace/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "example_external_workspace")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,15 +48,19 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(
     fetch_sources = True,
     scalatest = True,
 )
 
-register_toolchains("@io_bazel_rules_scala_toolchains//...:all")
+scala_register_toolchains()

--- a/third_party/test/example_external_workspace/strip/BUILD.bazel
+++ b/third_party/test/example_external_workspace/strip/BUILD.bazel
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_library")
+load("@rules_scala//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "noSrcsWithResources",

--- a/third_party/test/example_external_workspace/test/BUILD
+++ b/third_party/test/example_external_workspace/test/BUILD
@@ -1,4 +1,4 @@
-load("@io_bazel_rules_scala//scala:scala.bzl", "scala_test")
+load("@rules_scala//scala:scala.bzl", "scala_test")
 
 scala_test(
     name = "empty_test",

--- a/third_party/test/proto/BUILD.bazel
+++ b/third_party/test/proto/BUILD.bazel
@@ -1,5 +1,5 @@
 load("@rules_proto//proto:defs.bzl", "proto_library")
-load("@io_bazel_rules_scala//scala_proto:scala_proto.bzl", "scala_proto_library")
+load("@rules_scala//scala_proto:scala_proto.bzl", "scala_proto_library")
 
 proto_library(
     name = "proto",

--- a/third_party/test/proto/WORKSPACE
+++ b/third_party/test/proto/WORKSPACE
@@ -3,11 +3,11 @@ workspace(name = "proto")
 load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 
 local_repository(
-    name = "io_bazel_rules_scala",
+    name = "rules_scala",
     path = "../../..",
 )
 
-load("@io_bazel_rules_scala//scala:deps.bzl", "rules_scala_dependencies")
+load("@rules_scala//scala:deps.bzl", "rules_scala_dependencies")
 
 rules_scala_dependencies()
 
@@ -48,15 +48,20 @@ load("@rules_proto//proto:toolchains.bzl", "rules_proto_toolchains")
 
 rules_proto_toolchains()
 
-load("@io_bazel_rules_scala//:scala_config.bzl", "scala_config")
+load("@rules_scala//:scala_config.bzl", "scala_config")
 
 scala_config()
 
-load("@io_bazel_rules_scala//scala:toolchains.bzl", "scala_toolchains")
+load(
+    "@rules_scala//scala:toolchains.bzl",
+    "scala_register_toolchains",
+    "scala_toolchains",
+)
 
 scala_toolchains(scala_proto = True)
 
 register_toolchains(
-    "@io_bazel_rules_scala//scala:unused_dependency_checker_error_toolchain",
-    "@io_bazel_rules_scala_toolchains//...:all",
+    "@rules_scala//scala:unused_dependency_checker_error_toolchain",
 )
+
+scala_register_toolchains()

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -1,6 +1,6 @@
 """Rules for organizing thrift files."""
 
-load("@io_bazel_rules_scala//thrift:thrift_info.bzl", "ThriftInfo")
+load("//thrift:thrift_info.bzl", "ThriftInfo")
 
 def empty_thrift_info():
     return ThriftInfo(srcs = depset(), transitive_srcs = depset())

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -80,7 +80,7 @@ def twitter_scrooge(
 
     if register_toolchains:
         native.register_toolchains(
-            "@io_bazel_rules_scala_toolchains//twitter_scrooge:all",
+            "@rules_scala_toolchains//twitter_scrooge:all",
         )
 
 def _scrooge_toolchain_impl(ctx):
@@ -98,7 +98,7 @@ scrooge_toolchain = rule(
     },
 )
 
-_toolchain_type = "//twitter_scrooge/toolchain:scrooge_toolchain_type"
+_toolchain_type = Label("//twitter_scrooge/toolchain:scrooge_toolchain_type")
 
 def _export_scrooge_deps_impl(ctx):
     return expose_toolchain_deps(ctx, _toolchain_type)

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -1,4 +1,3 @@
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "//scala/private:common.bzl",
     "write_manifest_file",
@@ -15,6 +14,7 @@ load(
 )
 load("//thrift:thrift_info.bzl", "ThriftInfo")
 load("//thrift:thrift.bzl", "merge_thrift_infos")
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 def _colon_paths(data):
     return ":".join([f.path for f in sorted(data)])
@@ -162,7 +162,7 @@ def _compile_generated_scala(
         print_compile_time = False,
         expect_java_output = False,
         scalac_jvm_flags = [],
-        scalacopts = ctx.toolchains["@io_bazel_rules_scala//scala:toolchain_type"].scalacopts,
+        scalacopts = ctx.toolchains[Label("//scala:toolchain_type")].scalacopts,
         scalac = ctx.executable._scalac,
         dependency_info = legacy_unclear_dependency_info_for_protobuf_scrooge(ctx),
         unused_dependency_checker_ignored_targets = [],
@@ -309,11 +309,7 @@ common_attrs = {
     ),
     "_implicit_compile_deps": attr.label_list(
         providers = [JavaInfo],
-        default = [
-            Label(
-                "@io_bazel_rules_scala//twitter_scrooge:aspect_compile_classpath",
-            ),
-        ],
+        default = [Label("//twitter_scrooge:aspect_compile_classpath")],
     ),
     "_java_host_runtime": attr.label(
         default = Label("@rules_java//toolchains:current_host_java_runtime"),
@@ -326,8 +322,8 @@ common_aspect_providers = [
 ]
 
 common_toolchains = [
-    "//scala:toolchain_type",
-    "//twitter_scrooge/toolchain:scrooge_toolchain_type",
+    Label("//scala:toolchain_type"),
+    Label("//twitter_scrooge/toolchain:scrooge_toolchain_type"),
     "@bazel_tools//tools/jdk:toolchain_type",
 ]
 
@@ -340,7 +336,7 @@ scrooge_scala_aspect = aspect(
             "_scalac": attr.label(
                 executable = True,
                 cfg = "exec",
-                default = Label("@io_bazel_rules_scala//src/java/io/bazel/rulesscala/scalac"),
+                default = Label("//src/java/io/bazel/rulesscala/scalac"),
                 allow_files = True,
             ),
         },
@@ -433,16 +429,12 @@ scrooge_scala_import = rule(
         "scala_jars": attr.label_list(allow_files = [".jar"]),
         "_implicit_compile_deps": attr.label_list(
             providers = [JavaInfo],
-            default = [
-                Label(
-                    "@io_bazel_rules_scala//twitter_scrooge:compile_classpath",
-                ),
-            ],
+            default = [Label("//twitter_scrooge:compile_classpath")],
         ),
     },
     provides = [ThriftInfo, JavaInfo, ScroogeImport],
     toolchains = [
-        "//twitter_scrooge/toolchain:scrooge_toolchain_type",
+        Label("//twitter_scrooge/toolchain:scrooge_toolchain_type"),
         "@bazel_tools//tools/jdk:toolchain_type",
     ],
     incompatible_use_toolchain_transition = True,


### PR DESCRIPTION
### Description

Removes all remaining internal usages of `@io_bazel_rules_scala` without changing any actual logic. Part of #1482 and #1652, this is the last change required before adding Bzlmod compatibility.

Updates `WORKSPACE` files to use `@rules_scala` and `scala_register_toolchains()` instead of `@io_bazel_rules_scala` and `register_toolchains("@io_bazel_rules_scala_toolchains//...:all")`.

Also adds all the scripts run in CI to `test_all.sh`, plus `dt_patches/dt_patch_test.sh`.

Leaves `@io_bazel_rules_scala_config` as is for now, because it's a documented public interface. It can be easily changed and documented in a future commit if desired.

Also doesn't change the `io_bazel_rules_scala_` prefix for Maven artifact repos. This could also be done and documented in a future commit if desired.

### Motivation

This change enables `WORKSPACE` and Bzlmod users to import `rules_scala` as `rules_scala`, instead of requiring `io_bazel_rules_scala` due to internal dependencies.

i.e., `WORKSPACE` users can still use `http_archive` to import `rules_scala` as `io_bazel_rules_scala`. Bzlmod users will be able to call `bazel_dep(name = "rules_scala", repo_name = "io_bazel_rules_scala")`. However, `io_bazel_rules_scala` is no longer required by `rules_scala` itself.