### PR TITLE
Fix scala_proto_library default outputs

### DIFF
--- a/scala_proto/private/scala_proto.bzl
+++ b/scala_proto/private/scala_proto.bzl
@@ -22,14 +22,11 @@ def phase_merge_aspect_java_info(ctx, p):
 
 def phase_default_info(ctx, p):
     java_info = p.merge_aspects.java_info
+    output_jars = [jar.class_jar for jar in java_info.outputs.jars]
+    source_jars = [jar.source_jar for jar in java_info.outputs.jars if jar.source_jar]
     return struct(
         external_providers = {
-            "DefaultInfo": DefaultInfo(
-                files = depset(
-                    java_info.source_jars,
-                    transitive = [java_info.full_compile_jars],
-                ),
-            ),
+            "DefaultInfo": DefaultInfo(files = depset(output_jars + source_jars)),
         },
     )
 

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -12,6 +12,7 @@ load(
     "//scala_proto:scala_proto_toolchain.bzl",
     "scala_proto_toolchain",
 )
+load(":default_outputs_test.bzl", "default_outputs_test")
 
 scala_proto_toolchain(
     name = "test_scala_proto_toolchain_configuration",
@@ -225,4 +226,18 @@ scala_test(
     srcs = ["PackProtosTest.scala"],
     unused_dependency_checker_mode = "off",
     deps = [":pack_protos_lib"],
+)
+
+scala_proto_library(
+    name = "standalone_scala_proto",
+    deps = [":standalone_proto"],
+)
+
+default_outputs_test(
+    name = "standalone_scala_proto_outs_test",
+    expected_outs = [
+        "standalone_proto_scalapb-src.jar",
+        "standalone_proto_scalapb.jar",
+    ],
+    target_under_test = ":standalone_scala_proto",
 )

--- a/test/proto/BUILD
+++ b/test/proto/BUILD
@@ -241,3 +241,22 @@ default_outputs_test(
     ],
     target_under_test = ":standalone_scala_proto",
 )
+
+scala_proto_library(
+    name = "multiple_deps_scala_proto",
+    deps = [
+        ":test2",
+        ":test3",
+    ],
+)
+
+default_outputs_test(
+    name = "multiple_deps_scala_proto_outs_test",
+    expected_outs = [
+        "test2_scalapb-src.jar",
+        "test2_scalapb.jar",
+        "test3_scalapb-src.jar",
+        "test3_scalapb.jar",
+    ],
+    target_under_test = ":multiple_deps_scala_proto",
+)

--- a/test/proto/default_outputs_test.bzl
+++ b/test/proto/default_outputs_test.bzl
@@ -1,0 +1,18 @@
+load("@bazel_skylib//lib:unittest.bzl", "analysistest", "asserts")
+
+def _default_outputs_test(ctx):
+    env = analysistest.begin(ctx)
+
+    target_under_test = analysistest.target_under_test(env)
+    actual_outs = [f.basename for f in target_under_test[DefaultInfo].files.to_list()]
+
+    asserts.equals(env, sorted(ctx.attr.expected_outs), sorted(actual_outs))
+
+    return analysistest.end(env)
+
+default_outputs_test = analysistest.make(
+    _default_outputs_test,
+    attrs = {
+        "expected_outs": attr.string_list(),
+    },
+)


### PR DESCRIPTION
### Description
scala_proto_library returns too many outputs via DefaultInfo files

It returns all transitive jars used for compilation while it should return
pair of srcjar and compile jar for each direct proto_library dependency

Test `standalone_scala_proto_outs_test` failure before change:
```
In test _default_outputs_test from //test/proto:default_outputs_test.bzl: 
Expected "["standalone_proto_scalapb-src.jar", "standalone_proto_scalapb.jar"]", but got 
"["disruptor-3.4.2.jar", "fastparse_2.12-2.1.3.jar", "grpc-api-1.70.0.jar", "grpc-context-1.70.0.jar", "grpc-core-1.70.0.jar", "grpc-netty-1.70.0.jar", "grpc-protobuf-1.70.0.jar", "grpc-stub-1.70.0.jar", "guava-33.4.0-jre.jar", "instrumentation-api-0.3.0.jar", "lenses_2.12-0.11.17.jar", "libcore.jar", "liblite_runtime_only.jar", "netty-buffer-4.1.110.Final.jar", "netty-codec-4.1.110.Final.jar", "netty-codec-http-4.1.110.Final.jar", "netty-codec-http2-4.1.110.Final.jar", "netty-codec-socks-4.1.110.Final.jar", "netty-common-4.1.110.Final.jar", "netty-handler-4.1.110.Final.jar", "netty-handler-proxy-4.1.110.Final.jar", "netty-resolver-4.1.110.Final.jar", "netty-transport-4.1.110.Final.jar", "opencensus-api-0.22.1.jar", "opencensus-contrib-grpc-metrics-0.22.1.jar", "opencensus-impl-0.22.1.jar", "opencensus-impl-core-0.22.1.jar", "perfmark-api-0.27.0.jar", "scala-library-2.12.20.jar", "scala-reflect-2.12.20.jar", "scalapb-runtime-grpc_2.12-0.11.17.jar", "scalapb-runtime_2.12-0.11.17.jar", "standalone_proto_scalapb-src.jar", "standalone_proto_scalapb.jar"]"
```

### Motivation
When downloading target outputs via result-store we get unrelated jars.
