### PR TITLE
Use `rctx.name` if `rctx.original_name` is empty

### DIFF
--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -69,8 +69,12 @@ def _jvm_import_external_impl(repository_ctx):
         not repository_ctx.attr.neverlink):
         fail("Only use generated_linkable_rule_name if neverlink is set")
 
-    # Replace with rctx.original_name once all supported Bazels have it
-    repo_name = getattr(repository_ctx, "original_name", repository_ctx.name)
+    # Replace with rctx.original_name once all supported Bazels have it.
+    # Remove `or rctx.name` after Bazel fixes bazelbuild/bazel#25286.
+    repo_name = (
+        getattr(repository_ctx, "original_name", repository_ctx.name) or
+        repository_ctx.name
+    )
     name = repository_ctx.attr.generated_rule_name or repo_name
     urls = repository_ctx.attr.jar_urls
     if repository_ctx.attr.jar_sha256:

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -141,8 +141,12 @@ def repositories(
 def _alias_repository_impl(rctx):
     """ Builds a repository containing just two aliases to the Scala Maven artifacts in the `target` repository. """
     format_kwargs = {
-        # Replace with rctx.original_name once all supported Bazels have it
-        "name": getattr(rctx, "original_name", rctx.attr.default_target_name),
+        # Replace with rctx.original_name once all supported Bazels have it.
+        # Remove `or rctx.name` after Bazel fixes bazelbuild/bazel#25286.
+        "name": (
+            getattr(rctx, "original_name", rctx.attr.default_target_name) or
+            rctx.name
+        ),
         "target": rctx.attr.target,
     }
     rctx.file("BUILD", """alias(


### PR DESCRIPTION
### Description

Works around breakages when building under `WORKSPACE` with Bazel 8.1.0, as described in bazelbuild/bazel#25286. Part of #1652.

### Motivation

PR #1694 added support for `rctx.original_name` after the implementation of bazelbuild/bazel#24467 landed in 8.1.0rc2. However, I hadn't tested `WORKSPACE` builds with 8.1.0rc2 before 8.1.0 came out.

This resolves the breakage until a Bazel 8 release containing a fix for bazelbuild/bazel#25286 becomes available (possibly Bazel 8.2.0).