### PR TITLE
Bump Scalafmt from 3.8.6 to 3.9.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.8.6"
+version = "3.9.1"
 runner.dialect = scala213
 align.openParenCallSite = false
 align.openParenDefnSite = false

--- a/scala/scalafmt/scalafmt/ScalafmtAdapter.scala
+++ b/scala/scalafmt/scalafmt/ScalafmtAdapter.scala
@@ -2,11 +2,11 @@ package io.bazel.rules_scala.scalafmt
 
 import java.io.File
 import org.scalafmt.config.ScalafmtConfig
-import org.scalafmt.sysops.FileOps
+import org.scalafmt.sysops.PlatformFileOps
 
 object ScalafmtAdapter {
     def readFile(file: File)(implicit codec: scala.io.Codec): String =
-        FileOps.readFile(file.toPath())(codec)
+        PlatformFileOps.readFile(file.toPath())(codec)
 
     def parseConfigFile(configFile: File): ScalafmtConfig =
         ScalafmtConfig.fromHoconFile(configFile.toPath()).get

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -54,6 +54,7 @@ _SCALAFMT_DEPS_2_11 = [
 ]
 
 _SCALAFMT_DEPS_2_12 = [
+    "org_scalameta_io",
     "org_scalameta_mdoc_parser",
     "org_scalameta_metaconfig_core",
     "org_scalameta_metaconfig_pprint",

--- a/scripts/create_repository.py
+++ b/scripts/create_repository.py
@@ -29,7 +29,7 @@ PARSER_COMBINATORS_VERSION = '1.1.2'
 SBT_COMPILER_INTERFACE_VERSION = '1.10.7'
 SBT_UTIL_INTERFACE_VERSION = '1.10.7'
 SCALATEST_VERSION = "3.2.19"
-SCALAFMT_VERSION = "3.8.6"
+SCALAFMT_VERSION = "3.9.1"
 KIND_PROJECTOR_VERSION = "0.13.3"
 PROTOBUF_JAVA_VERSION = "4.29.3"
 JLINE_VERSION = '3.29.0'
@@ -253,10 +253,7 @@ class MavenCoordinates:
                 f'Expected {self.group}:{self.artifact}, ' +
                 f'got {other.group}:{other.artifact}'
             )
-        return (
-            self.__compare_versions(other.scala_version, self.scala_version) or
-            self.__compare_versions(other.version, self.version)
-        )
+        return self.__compare_versions(other.version, self.version)
 
     def __compare_versions(self, lhs, rhs):
         lhs_parts = lhs.split('.')

--- a/test/scalafmt/.scalafmt.conf
+++ b/test/scalafmt/.scalafmt.conf
@@ -1,4 +1,4 @@
-version = "3.8.6"
+version = "3.9.1"
 runner.dialect = scala213
 maxColumn = 40
 lineEndings = preserve

--- a/test_cross_build/scalafmt/.scalafmt2.conf
+++ b/test_cross_build/scalafmt/.scalafmt2.conf
@@ -1,4 +1,4 @@
-version = "3.8.6"
+version = "3.9.1"
 runner.dialect = scala213
 maxColumn = 40
 lineEndings = preserve

--- a/test_cross_build/scalafmt/.scalafmt3.conf
+++ b/test_cross_build/scalafmt/.scalafmt3.conf
@@ -1,4 +1,4 @@
-version = "3.8.6"
+version = "3.9.1"
 runner.dialect = scala3
 maxColumn = 40
 lineEndings = preserve

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -408,8 +408,8 @@ artifacts = {
         "sha256": "c720e6e5bcbe6b2f48ded75a47bccdb763eede79d14330102e0d352e3d89ed92",
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_2.12:2.12.0",
-        "sha256": "1619c5e4399e1e4793667970aae232652db0549e795c90abf91e44c55ec37cb3",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.12:2.13.0",
+        "sha256": "a0eb3523bf46797afd3ede3e402122fcaf56f661f4721f9058360f4036f17610",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -422,8 +422,8 @@ artifacts = {
         ],
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.12:4.12.7",
-        "sha256": "d216462d8c0bae82c0a885703367ea8d988d0856b38a6a0bcf8887dfebf79225",
+        "artifact": "org.scalameta:common_2.12:4.13.2",
+        "sha256": "2f71e2591d430fc647e18963ea1af10873ba52f1db9871d016d888377f25e1e4",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -445,16 +445,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.12:4.13.2",
+        "sha256": "7fd6cc4ec9e4638c650cc75f5f6d8a424204191f2d291f43701255c1f0ee0464",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.12:2.6.2",
-        "sha256": "9de918cbb8f340b1011c7a9dd9218ff33360382f725274b9683f35c2c67ca34e",
+        "artifact": "org.scalameta:mdoc-parser_2.12:2.6.4",
+        "sha256": "11c47b5e44e537adece65377b1cdfe1dde3f70c6d0708f07a4ac173dd79441df",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.12:0.14.0",
-        "sha256": "9b497e0e2f47713ed2a12d3876716a1708e5a251fca364abc707869469d09065",
+        "artifact": "org.scalameta:metaconfig-core_2.12:0.15.0",
+        "sha256": "9eb67935b7418939274ab9982c20dd5b0f3e660a86ef737cc2621c0a175a8bde",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -464,8 +471,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.12:0.14.0",
-        "sha256": "2377a7dba35569c35334bc3a788136addcf50a23c0d032385298ca56b42193c9",
+        "artifact": "org.scalameta:metaconfig-pprint_2.12:0.15.0",
+        "sha256": "6f01efb734218a427c6da72a1b3456e464751025820c8c802eacd3baf7f9a205",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler",
@@ -474,8 +481,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.12:0.14.0",
-        "sha256": "2988dbae5e39438b538d0cb2dfc897915a15b88e6e80866dc32ba2e9c2d44222",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.12:0.15.0",
+        "sha256": "aa53ec43d986af541016590ea3057f5e821a27330708eac00d3a464849564bc7",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library",
@@ -483,16 +490,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.12:4.12.7",
-        "sha256": "a30d1481339d8e3516b8a741c235169c8ba324925e343270140c2ae7d454296d",
+        "artifact": "org.scalameta:parsers_2.12:4.13.2",
+        "sha256": "1e5a497f961ee1bbcde1e8d7b8c5c99d45deff5bab143c67ed077bc2a3ef7fe9",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.12:3.8.6",
-        "sha256": "166d8485c4efa4631ca3661022c59004b842001b17d1852f97fb3914ad0eacd5",
+        "artifact": "org.scalameta:scalafmt-config_2.12:3.9.1",
+        "sha256": "4864b0544a9a35d79cba98df8b354713678b333bd7031790e7224cb9153efc34",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_metaconfig_core",
@@ -500,8 +507,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.12:3.8.6",
-        "sha256": "61e367c431ef6e783e3d8827630ff2aa78334e2a2a5cc6bd8b6dc3500bd0a84f",
+        "artifact": "org.scalameta:scalafmt-core_2.12:3.9.1",
+        "sha256": "1721418c28f4b1e71ec65d2fb8da6aef35142922cd397a4a14422a6015c3f9a1",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_mdoc_parser",
@@ -511,8 +518,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.12:3.8.6",
-        "sha256": "8e2d8ef4f5a45a5969f76cdcf80910f5ef90ffb50dbf0a18672d18797d025e37",
+        "artifact": "org.scalameta:scalafmt-macros_2.12:3.9.1",
+        "sha256": "0fc1e93bd59844b8f5bba287bf96d47b07df52f2252e61352ab777575290221b",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -520,16 +527,16 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.12:3.8.6",
-        "sha256": "4e1edbf6e06810c3c5d65fd8a6a2e92674a3994acf4fd0f4a643c0a577eb5f4b",
+        "artifact": "org.scalameta:scalafmt-sysops_2.12:3.9.1",
+        "sha256": "5ce1699ecf9fdd76301dfcac7997d0b2ab479f5b4db21e53d697764b41bc25f9",
         "deps": [
             "@com_github_bigwheel_util_backports",
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.12:4.12.7",
-        "sha256": "b81fb9bf9f9746f9556b168c9ae8bb3a082c05691dc7fe32c650417f276c6f6c",
+        "artifact": "org.scalameta:scalameta_2.12:4.13.2",
+        "sha256": "3ef4c36ad55d405ddc38a61a09d8460e7565439d4f3d8653bf56f953b3d09ef8",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_parsers",
@@ -543,11 +550,12 @@ artifacts = {
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.12:4.12.7",
-        "sha256": "c9160f5829c23658b7d98f8d28b8298b9d2d12520f23be6eaeb1a25a04c90a34",
+        "artifact": "org.scalameta:trees_2.12:4.13.2",
+        "sha256": "a690ea3df29be35e28e59be53ffde381a63eb814abd856761bd49ad863a5f921",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -198,8 +198,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -432,8 +432,8 @@ artifacts = {
         "sha256": "99c22a966838ba4291e69a5dd5689afd049500eb9362b23baace731f9c9c97dd",
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.12.0",
-        "sha256": "befff482233cd7f9a7ca1e1f5a36ede421c018e6ce82358978c475d45532755f",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -446,8 +446,8 @@ artifacts = {
         ],
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -469,16 +469,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -488,8 +495,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler",
@@ -498,8 +505,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library",
@@ -507,16 +514,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_metaconfig_core",
@@ -524,8 +531,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_mdoc_parser",
@@ -535,8 +542,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -544,16 +551,16 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_parsers",
@@ -567,11 +574,12 @@ artifacts = {
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -217,8 +217,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -474,8 +474,8 @@ artifacts = {
         ],
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.12.0",
-        "sha256": "befff482233cd7f9a7ca1e1f5a36ede421c018e6ce82358978c475d45532755f",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -499,8 +499,8 @@ artifacts = {
         "sha256": "1d6b91efa42b70fc064caed6d62962374e13b27737f885a87c84c667b30be625",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -522,16 +522,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -541,8 +548,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -551,8 +558,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -560,16 +567,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -577,8 +584,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -588,8 +595,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -597,27 +604,28 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -217,8 +217,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -474,8 +474,8 @@ artifacts = {
         ],
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.12.0",
-        "sha256": "befff482233cd7f9a7ca1e1f5a36ede421c018e6ce82358978c475d45532755f",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -499,8 +499,8 @@ artifacts = {
         "sha256": "1d6b91efa42b70fc064caed6d62962374e13b27737f885a87c84c667b30be625",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -522,16 +522,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -541,8 +548,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -551,8 +558,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -560,16 +567,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -577,8 +584,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -588,8 +595,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -597,27 +604,28 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -230,8 +230,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -490,10 +490,10 @@ artifacts = {
         ],
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_3:2.12.0",
-        "sha256": "af81a8bc7d85d2e02ad4448a83ed5f9fe08f64e3d47ca9c050a8c33e19aa4018",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
-            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scala_lang_scalap": {
@@ -515,8 +515,8 @@ artifacts = {
         "sha256": "1d6b91efa42b70fc064caed6d62962374e13b27737f885a87c84c667b30be625",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -538,16 +538,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -557,8 +564,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -567,8 +574,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -576,16 +583,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -593,8 +600,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -604,8 +611,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -613,27 +620,28 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_3_4.bzl
+++ b/third_party/repositories/scala_3_4.bzl
@@ -224,8 +224,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -481,10 +481,10 @@ artifacts = {
         ],
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_3:2.12.0",
-        "sha256": "af81a8bc7d85d2e02ad4448a83ed5f9fe08f64e3d47ca9c050a8c33e19aa4018",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
-            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scala_lang_scalap": {
@@ -506,8 +506,8 @@ artifacts = {
         "sha256": "1d6b91efa42b70fc064caed6d62962374e13b27737f885a87c84c667b30be625",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -529,16 +529,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -548,8 +555,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -558,8 +565,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -567,16 +574,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -584,8 +591,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -595,8 +602,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -604,27 +611,28 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_3_5.bzl
+++ b/third_party/repositories/scala_3_5.bzl
@@ -224,8 +224,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -481,10 +481,10 @@ artifacts = {
         ],
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_3:2.12.0",
-        "sha256": "af81a8bc7d85d2e02ad4448a83ed5f9fe08f64e3d47ca9c050a8c33e19aa4018",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
-            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scala_lang_scalap": {
@@ -506,8 +506,8 @@ artifacts = {
         "sha256": "1d6b91efa42b70fc064caed6d62962374e13b27737f885a87c84c667b30be625",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -529,16 +529,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -548,8 +555,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -558,8 +565,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -567,16 +574,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -584,8 +591,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -595,8 +602,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -604,27 +611,28 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {

--- a/third_party/repositories/scala_3_6.bzl
+++ b/third_party/repositories/scala_3_6.bzl
@@ -230,8 +230,8 @@ artifacts = {
         "sha256": "1ebb2b6f9e4eb4022497c19b1e1e825019c08514f962aaac197145f88ed730f1",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
-        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.1.0",
-        "sha256": "717eee20ce47367a7ad6481ad29084ce6868e42a78babe965d2ec965334749b1",
+        "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
+        "sha256": "4eae6e68cf44e9f709970355590ae981883edf6484608d747376a56cbb285432",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -490,10 +490,10 @@ artifacts = {
         ],
     },
     "org_scala_lang_modules_scala_collection_compat": {
-        "artifact": "org.scala-lang.modules:scala-collection-compat_3:2.12.0",
-        "sha256": "af81a8bc7d85d2e02ad4448a83ed5f9fe08f64e3d47ca9c050a8c33e19aa4018",
+        "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.13.0",
+        "sha256": "40f141575b57796bf0c1e4b5f0974d91e3a6dee6ecea47ceed62c0efa1298234",
         "deps": [
-            "@io_bazel_rules_scala_scala_library",
+            "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scala_lang_scalap": {
@@ -515,8 +515,8 @@ artifacts = {
         "sha256": "1d6b91efa42b70fc064caed6d62962374e13b27737f885a87c84c667b30be625",
     },
     "org_scalameta_common": {
-        "artifact": "org.scalameta:common_2.13:4.12.7",
-        "sha256": "f16c5689d91f6086f03f6e78d368153521c5ff3b4941bda85c69b4e5409e1482",
+        "artifact": "org.scalameta:common_2.13:4.13.2",
+        "sha256": "58989114218e701f0799ecf6546d35ebd3a97635a15d4f357b6152bb0770529e",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -538,16 +538,23 @@ artifacts = {
             "@io_bazel_rules_scala_scala_library",
         ],
     },
+    "org_scalameta_io": {
+        "artifact": "org.scalameta:io_2.13:4.13.2",
+        "sha256": "766e806a3ef41b44f6b9041f3813fe6c2384fa9be5f4406dd093cbbb354568e9",
+        "deps": [
+            "@io_bazel_rules_scala_scala_library_2",
+        ],
+    },
     "org_scalameta_mdoc_parser": {
-        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.2",
-        "sha256": "f12618065d4eedba3819b4593e5d0b5c43f69a9662959daee76a8dcf33560836",
+        "artifact": "org.scalameta:mdoc-parser_2.13:2.6.4",
+        "sha256": "d1462cf777c227a9a751ae9aae3cb7ab7c3fc1f70689f35eafe58746e33566cc",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
     },
     "org_scalameta_metaconfig_core": {
-        "artifact": "org.scalameta:metaconfig-core_2.13:0.14.0",
-        "sha256": "bb93a43e780ecc30fa97ee07b8969391d2bf7da7882df2f9abf9f328cba8616a",
+        "artifact": "org.scalameta:metaconfig-core_2.13:0.15.0",
+        "sha256": "c0b789c2d4468238fc325ef0a17f1a029b3635ff12b510bde03dd577a1281278",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -557,8 +564,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_pprint": {
-        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.14.0",
-        "sha256": "f23dea7d0fd98d585fef21130f9b424a9f75b6c386c88a665dc09ab8b2e09e61",
+        "artifact": "org.scalameta:metaconfig-pprint_2.13:0.15.0",
+        "sha256": "357e65682c00db62978f0dd21fea01f13a5f0fb31b45308ad74b136b1ec4f021",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -567,8 +574,8 @@ artifacts = {
         ],
     },
     "org_scalameta_metaconfig_typesafe_config": {
-        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.14.0",
-        "sha256": "f33109d2ec39a762ea8d66b502dc9ef8959d41935c8d8cb4dba1fa4614993383",
+        "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.15.0",
+        "sha256": "2ae5a8ecba43fb809696e419f1f98739e419534cc25918e2d8949a2d2727327e",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -576,16 +583,16 @@ artifacts = {
         ],
     },
     "org_scalameta_parsers": {
-        "artifact": "org.scalameta:parsers_2.13:4.12.7",
-        "sha256": "e88ce87f7383a5799bb6a0d13a90c3d633f4d0d74f055e56f81ab6b5e3fc24a7",
+        "artifact": "org.scalameta:parsers_2.13:4.13.2",
+        "sha256": "6d3ba3dbcf63b0f1d5068fea822412c5f5152310102099b1f61c94d800b2dec3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
         ],
     },
     "org_scalameta_scalafmt_config": {
-        "artifact": "org.scalameta:scalafmt-config_2.13:3.8.6",
-        "sha256": "a6b93de140cf501aac45ccbd04e8a2074616d68b938062618fbaf21b7d339c0f",
+        "artifact": "org.scalameta:scalafmt-config_2.13:3.9.1",
+        "sha256": "f543f1076717e6e8b96cc0149a08b3fc09e7e746c651f0dfadf64d33f3ba334a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -593,8 +600,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_core": {
-        "artifact": "org.scalameta:scalafmt-core_2.13:3.8.6",
-        "sha256": "26a5797dcb20d16a0b7d524757913a8e51234db8a3a04e7858de51c80919aee1",
+        "artifact": "org.scalameta:scalafmt-core_2.13:3.9.1",
+        "sha256": "99612ddaf548a46c0beba1881b30c36340d0580252c966a95cccf0cfc464d6d9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -604,8 +611,8 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_macros": {
-        "artifact": "org.scalameta:scalafmt-macros_2.13:3.8.6",
-        "sha256": "b04ab3452868f23a09abae7935b5d52e10c747dcc7e9b972cab358d2031e23e7",
+        "artifact": "org.scalameta:scalafmt-macros_2.13:3.9.1",
+        "sha256": "1bd711d82ca30e4861c0f2849e32135967c63af2aa19cefd117df131119fc506",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -613,27 +620,28 @@ artifacts = {
         ],
     },
     "org_scalameta_scalafmt_sysops": {
-        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.8.6",
-        "sha256": "e82444ad3a5a1798016640de02035b3e9a6eb413beec1333a381924c58057f88",
+        "artifact": "org.scalameta:scalafmt-sysops_2.13:3.9.1",
+        "sha256": "86725f4905f2e090ebbadb16b4897e098d3d2dec9f003d9acbfc791b078e48d0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_parallel_collections",
         ],
     },
     "org_scalameta_scalameta": {
-        "artifact": "org.scalameta:scalameta_2.13:4.12.7",
-        "sha256": "e39cfbc8c39ffec5a5a4ada4561088f265b14c3f7bd6f220b93776d06ab21a0d",
+        "artifact": "org.scalameta:scalameta_2.13:4.13.2",
+        "sha256": "b56df246d06c2a044de0e3d1bcd53ee883331ca116bb4654fdad50d062ec6646",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
         ],
     },
     "org_scalameta_trees": {
-        "artifact": "org.scalameta:trees_2.13:4.12.7",
-        "sha256": "2e8100be7aa7e6a16538444b00e8c95247eb2b743035a7363cfa675b7142edaa",
+        "artifact": "org.scalameta:trees_2.13:4.13.2",
+        "sha256": "c9fde64b53db432789b55ea424653349f735c6d7640724d5547ddbd407d49bb0",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
+            "@org_scalameta_io",
         ],
     },
     "org_springframework_spring_core": {


### PR DESCRIPTION
### Description

Also updates `scripts/create_repository.py` to prevent `scala-collection-compat` versions from flipping on subsequent runs by no longer comparing Scala versions. Part of #1482.

Both Scalafmt and ScalaPB depend on
`org_scala_lang_modules_scala_collection_compat`. Before removing the Scala version comparison, subsequent `create_repository.py` runs would flip between these two artifacts for Scala 3.3 through 3.6:

- `org.scala-lang.modules:scala-collection-compat_2.13:2.13.0`
- `org.scala-lang.modules:scala-collection-compat_3:2.12.0`

The artifact with the higher release version number is preferable to the artifact with the higher Scala version.

The change from `FileOps` to `PlatformFileOps` in `ScalafmtAdapter` is a consequence of an update first included in Scalafmt 3.9.0:

- https://github.com/scalameta/scalafmt/pull/4800
- https://github.com/scalameta/scalafmt/commit/0bdbf039d4b89ab8d1fb0275d49e1e3ff23457c4

### Motivation

As with #1692, this is to ensure Scalafmt is as current as can be before landing Bzlmod and Bazel 8 compatibility changes.
