### PR TITLE
Add Java 24 compatibility

### DIFF
--- a/scala/private/phases/phase_coverage.bzl
+++ b/scala/private/phases/phase_coverage.bzl
@@ -8,10 +8,6 @@ load(
     "//scala/private:coverage_replacements_provider.bzl",
     _coverage_replacements_provider = "coverage_replacements_provider",
 )
-load(
-    "//scala/private:rule_impls.bzl",
-    _allow_security_manager = "allow_security_manager",
-)
 
 def phase_coverage_library(ctx, p):
     args = struct(
@@ -64,7 +60,7 @@ def _phase_coverage(ctx, p, srcjars):
             outputs = [output_jar],
             executable = ctx.attr._code_coverage_instrumentation_worker.files_to_run,
             execution_requirements = {"supports-workers": "1"},
-            arguments = ["--jvm_flag=%s" % f for f in _allow_security_manager(ctx)] + [args],
+            arguments = [args],
         )
 
         replacements = {input_jar: output_jar}

--- a/scala/private/phases/phase_scalafmt.bzl
+++ b/scala/private/phases/phase_scalafmt.bzl
@@ -4,10 +4,6 @@
 # Outputs to format the scala files when it is explicitly specified
 #
 load("//scala/private:paths.bzl", _scala_extension = "scala_extension")
-load(
-    "//scala/private:rule_impls.bzl",
-    _allow_security_manager = "allow_security_manager",
-)
 
 def phase_scalafmt(ctx, p):
     if ctx.attr.format:
@@ -26,7 +22,7 @@ def _build_format(ctx):
     files = []
     srcs = []
     manifest_content = []
-    jvm_flags = ["-Dfile.encoding=UTF-8"] + _allow_security_manager(ctx)
+    jvm_flags = ["-Dfile.encoding=UTF-8"]
     for src in ctx.files.srcs:
         # only format scala source files, not generated files
         if src.path.endswith(_scala_extension) and src.is_source:

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -124,7 +124,7 @@ def compile_scala(
     # TODO: scalac worker is run with @bazel_tools//tools/jdk:runtime_toolchain_type
     # which is different from rules_java where compilation runtime is used from
     # @bazel_tools//tools/jdk:toolchain_type
-    final_scalac_jvm_flags = first_non_empty(scalac_jvm_flags, toolchain.scalac_jvm_flags) + allow_security_manager(ctx)
+    final_scalac_jvm_flags = first_non_empty(scalac_jvm_flags, toolchain.scalac_jvm_flags)
 
     ctx.actions.run(
         inputs = ins,
@@ -221,12 +221,3 @@ def java_bin_windows(ctx):
 
 def is_windows(ctx):
     return ctx.configuration.host_path_separator == ";"
-
-# Return a jvm flag allowing security manager for jdk runtime >= 17
-# If no runtime is supplied then runtime is taken from ctx.attr._java_host_runtime
-# This must be a runtime used in generated java_binary script (usually workers using SecurityManager)
-def allow_security_manager(ctx, runtime = None):
-    java_runtime = runtime if runtime else ctx.attr._java_host_runtime[java_common.JavaRuntimeInfo]
-
-    # Bazel 5.x doesn't have java_runtime.version defined
-    return ["-Djava.security.manager=allow"] if hasattr(java_runtime, "version") and java_runtime.version >= 17 else []

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -1,19 +1,18 @@
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load("@rules_proto//proto:defs.bzl", "ProtoInfo")
 load("//scala/private:common.bzl", "write_manifest_file")
 load("//scala/private:dependency.bzl", "legacy_unclear_dependency_info_for_protobuf_scrooge")
+load("//scala/private:phases/api.bzl", "extras_phases", "run_aspect_phases")
 load(
     "//scala/private:rule_impls.bzl",
     "compile_scala",
     "specified_java_compile_toolchain",
-    _allow_security_manager = "allow_security_manager",
 )
 load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load(
     "//scala_proto/private:scala_proto_aspect_provider.bzl",
     "ScalaProtoAspectInfo",
 )
-load("//scala/private:phases/api.bzl", "extras_phases", "run_aspect_phases")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
 
 def _import_paths(proto, ctx):
     # Under Bazel 7.x, direct_sources from generated protos may still contain
@@ -77,7 +76,7 @@ def _generate_sources(ctx, toolchain, proto):
 
     ctx.actions.run(
         executable = toolchain.worker,
-        arguments = ["--jvm_flag=%s" % f for f in _allow_security_manager(ctx)] + [toolchain.worker_flags, args],
+        arguments = [toolchain.worker_flags, args],
         inputs = depset(transitive = [descriptors, toolchain.generators_jars]),
         outputs = outputs.values(),
         tools = [toolchain.protoc],

--- a/src/java/io/bazel/rulesscala/worker/WorkerTest.java
+++ b/src/java/io/bazel/rulesscala/worker/WorkerTest.java
@@ -214,9 +214,6 @@ public class WorkerTest {
 
   @AfterClass
   public static void teardown() {
-    // Persistent workers install a security manager. We need to
-    // reset it here so that our own process can exit!
-    System.setSecurityManager(null);
   }
 
   // Copied/modified from Bazel's MoreAsserts

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -18,6 +18,9 @@ WARNINGS_CONFIG = [
 
 buildifier(
     name = "lint_check",
+    exclude_patterns = [
+        "./.ijwb/*",
+    ],
     lint_mode = "warn",
     lint_warnings = WARNINGS_CONFIG,
     mode = "check",
@@ -25,6 +28,9 @@ buildifier(
 
 buildifier(
     name = "lint_fix",
+    exclude_patterns = [
+        "./.ijwb/*",
+    ],
     lint_mode = "fix",
     lint_warnings = WARNINGS_CONFIG,
     mode = "fix",

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -1,3 +1,4 @@
+load("@bazel_skylib//lib:dicts.bzl", "dicts")
 load(
     "//scala/private:common.bzl",
     "write_manifest_file",
@@ -8,13 +9,11 @@ load(
 )
 load(
     "//scala/private:rule_impls.bzl",
-    "allow_security_manager",
     "compile_java",
     "compile_scala",
 )
-load("//thrift:thrift_info.bzl", "ThriftInfo")
 load("//thrift:thrift.bzl", "merge_thrift_infos")
-load("@bazel_skylib//lib:dicts.bzl", "dicts")
+load("//thrift:thrift_info.bzl", "ThriftInfo")
 
 def _colon_paths(data):
     return ":".join([f.path for f in sorted(data)])
@@ -86,7 +85,7 @@ def _generate_jvm_code(ctx, label, compile_thrifts, include_thrifts, jar_output,
         # be correctly handled since the executable is a jvm app that will
         # consume the flags on startup.
         #arguments = ["--jvm_flag=%s" % flag for flag in ctx.attr.jvm_flags] +
-        arguments = ["--jvm_flag=%s" % f for f in allow_security_manager(ctx)] + ["@" + argfile.path],
+        arguments = ["@" + argfile.path],
     )
 
 def _compiled_jar_file(actions, scrooge_jar):


### PR DESCRIPTION
The SecurityManager is a hollow shell that just throws exceptions in Java 24. We should avoid calling it. This will make tests that call System.exit crash the worker.

Bazel is doing the same thing for now, see
https://github.com/bazelbuild/bazel/issues/24354

It is often possible to edit code to avoid calling System.exit, and guarding against it requires more effort in Java 24+, likely involving attaching an agent. Until someone actually has that need, it doesn't seem worth doing.