### PR TITLE
Cleanup WorkerTest after SecurityManager was removed

### DIFF
--- a/src/java/io/bazel/rulesscala/worker/WorkerTest.java
+++ b/src/java/io/bazel/rulesscala/worker/WorkerTest.java
@@ -12,7 +12,6 @@ import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.AfterClass;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -21,60 +20,6 @@ import static org.junit.Assert.assertEquals;
 
 @RunWith(JUnit4.class)
 public class WorkerTest {
-
-  @Test
-  public void testEphemeralWorkerSystemExit() throws Exception {
-
-    // An ephemeral worker behaves like a regular main method,
-    // so we expect the worker to system exit normally
-
-    Worker.Interface worker =
-        new Worker.Interface() {
-          @Override
-          public void work(String[] args) {
-            System.exit(99);
-          }
-        };
-
-    int code =
-        assertThrows(Worker.ExitTrapped.class, () -> Worker.workerMain(new String[] {}, worker))
-            .code;
-
-    assert (code == 99);
-  }
-
-  @Test
-  public void testPersistentWorkerSystemExit() throws Exception {
-    // We're going to spin up a persistent worker and run a single
-    // work request. We expect System.exit calls to impact the
-    // worker request lifecycle without exiting the overall worker
-    // process.
-
-    try (PersistentWorkerHelper helper = new PersistentWorkerHelper(); ) {
-      WorkerProtocol.WorkRequest.newBuilder().build().writeDelimitedTo(helper.requestOut);
-
-      Worker.Interface worker =
-          new Worker.Interface() {
-            @Override
-            public void work(String[] args) {
-              // we should see this print statement
-              System.out.println("before exit");
-              System.exit(100);
-              // we should not see this print statement
-              System.out.println("after exit");
-            }
-          };
-
-      helper.runWorker(worker);
-
-      WorkerProtocol.WorkResponse response =
-          WorkerProtocol.WorkResponse.parseDelimitedFrom(helper.responseIn);
-
-      assert (response.getOutput().contains("before"));
-      assert (response.getExitCode() == 100);
-      assert (!response.getOutput().contains("after"));
-    }
-  }
 
   @Test
   public void testPersistentWorkerNoStdin() throws Exception {


### PR DESCRIPTION

### Description
WorkerTest was failing after https://github.com/bazelbuild/rules_scala/pull/1719
