### PR TITLE
Replace `@scalafmt_default` with toolchains target

### DIFF
--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,1 @@
+exports_files([".scalafmt.conf"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -112,7 +112,6 @@ use_repo(
     dev_deps,
     "scala_proto_rules_scalapb_compilerplugin",
     "scala_proto_rules_scalapb_protoc_bridge",
-    "scalafmt_default",
 )
 
 # Default versions of version specific repos needed by some of our tests. Tests

--- a/docs/phase_scalafmt.md
+++ b/docs/phase_scalafmt.md
@@ -12,9 +12,21 @@ A phase extension `phase_scalafmt` can format Scala source code via [Scalafmt](h
 
 ## How to set up
 
-Add this snippet to `WORKSPACE`
+Add this snippet to `MODULE.bazel`:
 
 ```py
+# MODULE.bazel
+scala_deps = use_extension(
+    "@rules_scala//scala/extensions:deps.bzl",
+    "scala_deps",
+)
+scala_deps.scalafmt()
+```
+
+or to `WORKSPACE`:
+
+```py
+# WORKSPACE
 load(
     "@rules_scala//scala:toolchains.bzl",
     "scala_register_toolchains",
@@ -59,16 +71,23 @@ bazel run <TARGET>.format-test
 
 to check the format (without modifying source code).
 
-The extension provides default configuration, but there are 2 ways to use custom configuration
+The extension provides a default configuration, but there are 2 ways to use
+a custom configuration:
 
 - Put `.scalafmt.conf` at the root of your workspace
 - Pass `.scalafmt.conf` in via `scala_toolchains`:
 
     ```py
+    # MODULE.bazel
+    scala_deps.scalafmt(
+        default_config = "//path/to/my/custom:scalafmt.conf",
+    )
+
+    # WORKSPACE
     scala_toolchains(
         # Other toolchains settings...
         scalafmt = True,
-        scalafmt_default_config_path = "//path/to/my/custom:scalafmt.conf",
+        scalafmt_default_config = "//path/to/my/custom:scalafmt.conf",
     )
     ```
 

--- a/scala/extensions/deps.bzl
+++ b/scala/extensions/deps.bzl
@@ -90,16 +90,13 @@ _compiler_srcjar_attrs = {
 }
 
 _scalafmt_defaults = {
-    "default_config_path": ".scalafmt.conf",
+    "default_config": "//:.scalafmt.conf",
 }
 
 _scalafmt_attrs = {
-    "default_config_path": attr.string(
-        default = _scalafmt_defaults["default_config_path"],
-        doc = (
-            "The relative path to the default Scalafmt config file " +
-            "within the repository"
-        ),
+    "default_config": attr.label(
+        default = _scalafmt_defaults["default_config"],
+        doc = "The default config file for Scalafmt targets",
     ),
 }
 

--- a/scala/scalafmt/phase_scalafmt_ext.bzl
+++ b/scala/scalafmt/phase_scalafmt_ext.bzl
@@ -11,7 +11,7 @@ ext_scalafmt = {
     "attrs": {
         "config": attr.label(
             allow_single_file = [".conf"],
-            default = "@scalafmt_default//:config",
+            default = "@rules_scala_toolchains//scalafmt:config",
             doc = "The Scalafmt configuration file.",
         ),
         "format": attr.bool(

--- a/scala/scalafmt/scalafmt_repositories.bzl
+++ b/scala/scalafmt/scalafmt_repositories.bzl
@@ -1,25 +1,6 @@
 load("//scala:scala_cross_version.bzl", "extract_major_version")
 load("//scala_proto/default:repositories.bzl", "SCALAPB_COMPILE_ARTIFACT_IDS")
 
-def _scalafmt_config_impl(repository_ctx):
-    config_path = repository_ctx.attr.path
-    build = []
-    build.append("filegroup(")
-    build.append("    name = \"config\",")
-    build.append("    srcs = [\"{}\"],".format(config_path.name))
-    build.append("    visibility = [\"//visibility:public\"],")
-    build.append(")\n")
-
-    repository_ctx.file("BUILD", "\n".join(build), executable = False)
-    repository_ctx.symlink(repository_ctx.path(config_path), config_path.name)
-
-scalafmt_config = repository_rule(
-    implementation = _scalafmt_config_impl,
-    attrs = {
-        "path": attr.label(mandatory = True, allow_single_file = True),
-    },
-)
-
 _SCALAFMT_DEPS = [
     "com_lihaoyi_fansi",
     "com_typesafe_config",

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -7,11 +7,7 @@ load(
     "scala_version_artifact_ids",
     "setup_scala_compiler_sources",
 )
-load(
-    "//scala/scalafmt:scalafmt_repositories.bzl",
-    "scalafmt_artifact_ids",
-    "scalafmt_config",
-)
+load("//scala/scalafmt:scalafmt_repositories.bzl", "scalafmt_artifact_ids")
 load("//scala:scala_cross_version.bzl", "default_maven_server_urls")
 load("//scala:toolchains_repo.bzl", "scala_toolchains_repo")
 load("//scala_proto/default:repositories.bzl", "scala_proto_artifact_ids")
@@ -40,7 +36,7 @@ def scala_toolchains(
         junit = False,
         specs2 = False,
         scalafmt = False,
-        scalafmt_default_config_path = ".scalafmt.conf",
+        scalafmt_default_config = Label("//:.scalafmt.conf"),
         scala_proto = False,
         scala_proto_options = [],
         jmh = False,
@@ -87,8 +83,7 @@ def scala_toolchains(
         junit: whether to instantiate the JUnit toolchain
         specs2: whether to instantiate the Specs2 JUnit toolchain
         scalafmt: whether to instantiate the Scalafmt toolchain
-        scalafmt_default_config_path: the relative path to the default Scalafmt
-            config file within the repository
+        scalafmt_default_config: the default config file for Scalafmt targets
         scala_proto: whether to instantiate the scala_proto toolchain
         scala_proto_options: protobuf options, like 'scala3_sources' or 'grpc';
             `scala_proto` must also be `True` for this to take effect
@@ -111,10 +106,6 @@ def scala_toolchains(
         fail("unknown twitter_scrooge_deps:", ", ".join(unknown_ts_deps))
 
     setup_scala_compiler_sources(scala_compiler_srcjars)
-
-    if scalafmt:
-        scalafmt_conf_target = "//:" + scalafmt_default_config_path
-        scalafmt_config(name = "scalafmt_default", path = scalafmt_conf_target)
 
     if specs2:
         junit = True
@@ -187,6 +178,7 @@ def scala_toolchains(
         junit = junit,
         specs2 = specs2,
         scalafmt = scalafmt,
+        scalafmt_default_config = scalafmt_default_config,
         scala_proto = scala_proto,
         scala_proto_options = scala_proto_options,
         jmh = jmh,

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -47,6 +47,7 @@ def _scala_toolchains_repo_impl(repository_ctx):
     format_args = {
         "rules_scala_repo": Label("//:all").repo_name,
         "proto_options": repo_attr.scala_proto_options,
+        "scalafmt_default_config": repo_attr.scalafmt_default_config,
     }
     toolchains = {}
 
@@ -94,6 +95,10 @@ _scala_toolchains_repo = repository_rule(
         "junit": attr.bool(doc = "Instantiate the JUnit toolchain"),
         "specs2": attr.bool(doc = "Instantiate the Specs2 toolchain"),
         "scalafmt": attr.bool(doc = "Instantiate the Scalafmt toolchain"),
+        "scalafmt_default_config": attr.label(
+            doc = "Default Scalafmt config file",
+            allow_single_file = True,
+        ),
         "scala_proto": attr.bool(
             doc = "Instantiate the scala_proto toolchain",
         ),
@@ -197,6 +202,12 @@ _SCALAFMT_TOOLCHAIN_BUILD = """
 load(
     "@@{rules_scala_repo}//scala/scalafmt/toolchain:setup_scalafmt_toolchain.bzl",
     "setup_scalafmt_toolchains",
+)
+
+alias(
+    name = "config",
+    actual = "{scalafmt_default_config}",
+    visibility = ["//visibility:public"],
 )
 
 setup_scalafmt_toolchains()


### PR DESCRIPTION
### Description

Removes the `scalafmt_config()` macro and replaces it with the new `@rules_scala_toolchains//scalafmt:config` target. Part of #1482.

### Motivation

The new `test/shell/test_dependency_versions.sh` test found a problem with the previous implementation. The `dev_deps` extension in `MODULE.bazel` generated `@scalafmt_default`, leaving it invisible to `rules_scala` when it's not the main module:

```txt
ERROR: no such package
  '@@[unknown repo 'scalafmt_default' requested from @@rules_scala~]//':
  The repository
  '@@[unknown repo 'scalafmt_default' requested from @@rules_scala~]'
  could not be resolved:
  No repository visible as '@scalafmt_default'
  from repository '@@rules_scala~'

ERROR: .../tmp/test_dependency_versions/BUILD:52:20:
  every rule of type scalafmt_scala_test
  implicitly depends upon the target
  '@@[unknown repo 'scalafmt_default' requested from @@rules_scala~]//:config',
  but this target could not be found because of:
  no such package
  '@@[unknown repo 'scalafmt_default' requested from @@rules_scala~]//':
  The repository '@@[unknown repo 'scalafmt_default' requested from @@rules_scala~]'
  could not be resolved:
  No repository visible as '@scalafmt_default' from repository '@@rules_scala~'

Documentation for implicit attribute config of rules of type scalafmt_scala_test:
The Scalafmt configuration file.

ERROR: Analysis of target '//:ScalafmtTest' failed;
  build aborted: Analysis failed
```

The `scalafmt_default_config()` macro is already gone, and only `scala_toolchains()` invoked `scalafmt_config()`, making this a straightforward change.