### PR TITLE
Remove `Label` wrappers for target string literals

### DIFF
--- a/jmh/jmh.bzl
+++ b/jmh/jmh.bzl
@@ -39,12 +39,12 @@ scala_generate_benchmark = rule(
         "_generator": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label(
-                "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator",
+            default = (
+                "//src/scala/io/bazel/rules_scala/jmh_support:benchmark_generator"
             ),
         ),
         "runtime_jdk": attr.label(
-            default = Label("@rules_java//toolchains:current_java_runtime"),
+            default = "@rules_java//toolchains:current_java_runtime",
             providers = [java_common.JavaRuntimeInfo],
         ),
     },

--- a/jmh/toolchain/toolchain.bzl
+++ b/jmh/toolchain/toolchain.bzl
@@ -39,7 +39,7 @@ jmh_toolchain = rule(
     },
 )
 
-_toolchain_type = Label("//jmh/toolchain:jmh_toolchain_type")
+_toolchain_type = "//jmh/toolchain:jmh_toolchain_type"
 
 def _export_toolchain_deps_impl(ctx):
     return expose_toolchain_deps(ctx, _toolchain_type)
@@ -64,7 +64,7 @@ def setup_jmh_toolchain(name):
     native.toolchain(
         name = name,
         toolchain = ":%s_impl" % name,
-        toolchain_type = _toolchain_type,
+        toolchain_type = Label(_toolchain_type),
         visibility = ["//visibility:public"],
     )
 

--- a/scala/plusone.bzl
+++ b/scala/plusone.bzl
@@ -10,7 +10,7 @@ PlusOneDeps = provider(
 )
 
 def _collect_plus_one_deps_aspect_impl(target, ctx):
-    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    toolchain = ctx.toolchains["//scala:toolchain_type"]
     if toolchain.dependency_mode != "plus-one":
         return []
 
@@ -26,5 +26,5 @@ def _collect_plus_one_deps_aspect_impl(target, ctx):
 collect_plus_one_deps_aspect = aspect(
     implementation = _collect_plus_one_deps_aspect_impl,
     attr_aspects = ["deps", "exports"],
-    toolchains = [Label("//scala:toolchain_type")],
+    toolchains = ["//scala:toolchain_type"],
 )

--- a/scala/private/common_attributes.bzl
+++ b/scala/private/common_attributes.bzl
@@ -29,7 +29,7 @@ common_attrs_for_plugin_bootstrapping = {
     "resource_strip_prefix": attr.string(),
     "resource_jars": attr.label_list(allow_files = True),
     "java_compile_toolchain": attr.label(
-        default = Label("@rules_java//toolchains:current_java_toolchain"),
+        default = "@rules_java//toolchains:current_java_toolchain",
         providers = [java_common.JavaToolchainInfo],
     ),
     "scalacopts": attr.string_list(),
@@ -56,8 +56,8 @@ common_attrs.update(common_attrs_for_plugin_bootstrapping)
 
 common_attrs.update({
     "_dependency_analyzer_plugin": attr.label(
-        default = Label(
-            "//third_party/dependency_analyzer/src/main:dependency_analyzer",
+        default = (
+            "//third_party/dependency_analyzer/src/main:dependency_analyzer"
         ),
         allow_files = [".jar"],
         mandatory = False,
@@ -73,9 +73,7 @@ common_attrs.update({
     ),
     "unused_dependency_checker_ignored_targets": attr.label_list(default = []),
     "_code_coverage_instrumentation_worker": attr.label(
-        default = Label(
-            "//src/java/io/bazel/rulesscala/coverage/instrumenter",
-        ),
+        default = "//src/java/io/bazel/rulesscala/coverage/instrumenter",
         allow_files = True,
         executable = True,
         cfg = "exec",
@@ -84,27 +82,27 @@ common_attrs.update({
 
 implicit_deps = {
     "_java_runtime": attr.label(
-        default = Label("@rules_java//toolchains:current_java_runtime"),
+        default = "@rules_java//toolchains:current_java_runtime",
     ),
     "_java_host_runtime": attr.label(
-        default = Label("@rules_java//toolchains:current_host_java_runtime"),
+        default = "@rules_java//toolchains:current_host_java_runtime",
     ),
     "_scalac": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label("//src/java/io/bazel/rulesscala/scalac"),
+        default = "//src/java/io/bazel/rulesscala/scalac",
         allow_files = True,
     ),
     "_exe": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label("//src/java/io/bazel/rulesscala/exe:exe"),
+        default = "//src/java/io/bazel/rulesscala/exe:exe",
     ),
 }
 
 launcher_template = {
     "_java_stub_template": attr.label(
-        default = Label("//java_stub_template/file"),
+        default = "//java_stub_template/file",
     ),
 }
 
@@ -112,7 +110,7 @@ launcher_template = {
 resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [
-            Label("//scala/private/toolchain_deps:scala_library_classpath"),
+            "//scala/private/toolchain_deps:scala_library_classpath",
         ],
         allow_files = False,
     ),

--- a/scala/private/coverage_replacements_provider.bzl
+++ b/scala/private/coverage_replacements_provider.bzl
@@ -67,7 +67,7 @@ def _aspect_impl(target, ctx):
 _aspect = aspect(
     attr_aspects = _dependency_attributes,
     implementation = _aspect_impl,
-    toolchains = [Label("//scala:toolchain_type")],
+    toolchains = ["//scala:toolchain_type"],
 )
 
 coverage_replacements_provider = struct(

--- a/scala/private/dependency.bzl
+++ b/scala/private/dependency.bzl
@@ -43,13 +43,13 @@ def get_strict_deps_mode(ctx):
     if not hasattr(ctx.attr, "_dependency_analyzer_plugin"):
         return "off"
 
-    return ctx.toolchains[Label("//scala:toolchain_type")].strict_deps_mode
+    return ctx.toolchains["//scala:toolchain_type"].strict_deps_mode
 
 def get_compiler_deps_mode(ctx):
     if not hasattr(ctx.attr, "_dependency_analyzer_plugin"):
         return "off"
 
-    return ctx.toolchains[Label("//scala:toolchain_type")].compiler_deps_mode
+    return ctx.toolchains["//scala:toolchain_type"].compiler_deps_mode
 
 def _is_strict_deps_on(ctx):
     return get_strict_deps_mode(ctx) != "off"

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -91,7 +91,7 @@ def phase_compile_common(ctx, p):
     return _phase_compile_default(ctx, p)
 
 def _phase_compile_default(ctx, p, _args = struct()):
-    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    toolchain = ctx.toolchains["//scala:toolchain_type"]
     buildijar_default_value = toolchain.scala_version.startswith("2.")
 
     return _phase_compile(

--- a/scala/private/phases/phase_coverage_runfiles.bzl
+++ b/scala/private/phases/phase_coverage_runfiles.bzl
@@ -21,7 +21,7 @@ def phase_coverage_runfiles(ctx, p):
             coverage_replacements[jar] if jar in coverage_replacements else jar
             for jar in rjars.to_list()
         ])
-        jacocorunner = ctx.toolchains[Label("//scala:toolchain_type")].jacocorunner
+        jacocorunner = ctx.toolchains["//scala:toolchain_type"].jacocorunner
         coverage_runfiles = jacocorunner.files.to_list() + ctx.files._lcov_merger + coverage_replacements.values()
     return struct(
         coverage_runfiles = coverage_runfiles,

--- a/scala/private/phases/phase_dependency.bzl
+++ b/scala/private/phases/phase_dependency.bzl
@@ -35,7 +35,7 @@ def _phase_dependency(
         p,
         unused_deps_always_off,
         strict_deps_always_off):
-    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    toolchain = ctx.toolchains["//scala:toolchain_type"]
 
     target_label = str(ctx.label)
 
@@ -81,7 +81,7 @@ def _get_unused_deps_mode(ctx):
     if ctx.attr.unused_dependency_checker_mode:
         return ctx.attr.unused_dependency_checker_mode
     else:
-        return ctx.toolchains[Label("//scala:toolchain_type")].unused_dependency_checker_mode
+        return ctx.toolchains["//scala:toolchain_type"].unused_dependency_checker_mode
 
 def _is_target_included(target, includes, excludes):
     for exclude in excludes:

--- a/scala/private/phases/phase_scalac_provider.bzl
+++ b/scala/private/phases/phase_scalac_provider.bzl
@@ -7,7 +7,7 @@ load("//scala/private/toolchain_deps:toolchain_deps.bzl", "find_deps_info_on")
 load("//scala:providers.bzl", _ScalacProvider = "ScalacProvider")
 
 def phase_scalac_provider(ctx, p):
-    toolchain_type_label = Label("//scala:toolchain_type")
+    toolchain_type_label = "//scala:toolchain_type"
 
     library_classpath = find_deps_info_on(ctx, toolchain_type_label, "scala_library_classpath").deps
     compile_classpath = find_deps_info_on(ctx, toolchain_type_label, "scala_compile_classpath").deps

--- a/scala/private/phases/phase_scalacopts.bzl
+++ b/scala/private/phases/phase_scalacopts.bzl
@@ -1,3 +1,3 @@
 def phase_scalacopts(ctx, p):
-    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    toolchain = ctx.toolchains["//scala:toolchain_type"]
     return toolchain.scalacopts + ctx.attr.scalacopts

--- a/scala/private/phases/phase_semanticdb.bzl
+++ b/scala/private/phases/phase_semanticdb.bzl
@@ -9,7 +9,7 @@ def phase_semanticdb(ctx, p):
 
     #Scala3: Semanticdb is built into scalac. Currently, if semanticdb-target is used, the semanticdb files are written and not bundled, otherwise, the semanticdb files are not written as files and only available inside the jar.
 
-    toolchain_type_label = Label("//scala:toolchain_type")
+    toolchain_type_label = "//scala:toolchain_type"
     toolchain = ctx.toolchains[toolchain_type_label]
 
     if toolchain.enable_semanticdb == True:

--- a/scala/private/phases/phase_write_executable.bzl
+++ b/scala/private/phases/phase_write_executable.bzl
@@ -20,7 +20,7 @@ def phase_write_executable_scalatest(ctx, p):
     # toolchain
     final_jvm_flags = first_non_empty(
         ctx.attr.jvm_flags,
-        ctx.toolchains[Label("//scala:toolchain_type")].scala_test_jvm_flags,
+        ctx.toolchains["//scala:toolchain_type"].scala_test_jvm_flags,
     )
 
     args = struct(
@@ -115,7 +115,7 @@ def _write_executable_non_windows(ctx, executable, rjars, main_class, jvm_flags,
         wrapper.short_path,
     )
 
-    scala_toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    scala_toolchain = ctx.toolchains["//scala:toolchain_type"]
 
     test_runner_classpath_mode = "argsfile" if scala_toolchain.use_argument_file_in_runner else "manifest"
 

--- a/scala/private/rule_impls.bzl
+++ b/scala/private/rule_impls.bzl
@@ -64,7 +64,7 @@ def compile_scala(
     if dependency_info.use_analyzer:
         plugins = depset(transitive = [plugins, ctx.attr._dependency_analyzer_plugin.files])
 
-    toolchain = ctx.toolchains[Label("//scala:toolchain_type")]
+    toolchain = ctx.toolchains["//scala:toolchain_type"]
     compiler_classpath_jars = cjars if dependency_info.dependency_mode == "direct" else transitive_compile_jars
     classpath_resources = getattr(ctx.files, "classpath_resources", [])
     scalacopts_expanded = [ctx.expand_location(v, input_plugins) for v in scalacopts]

--- a/scala/private/rules/scala_binary.bzl
+++ b/scala/private/rules/scala_binary.bzl
@@ -60,7 +60,7 @@ _scala_binary_attrs = {
     "classpath_resources": attr.label_list(allow_files = True),
     "jvm_flags": attr.string_list(),
     "runtime_jdk": attr.label(
-        default = Label("@rules_java//toolchains:current_java_runtime"),
+        default = "@rules_java//toolchains:current_java_runtime",
         providers = [java_common.JavaRuntimeInfo],
     ),
 }
@@ -89,7 +89,7 @@ def make_scala_binary(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            Label("//scala:toolchain_type"),
+            "//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_doc.bzl
+++ b/scala/private/rules/scala_doc.bzl
@@ -126,7 +126,7 @@ def make_scala_doc_rule(aspect = _scaladoc_transitive_aspect):
             "_scaladoc": attr.label(
                 cfg = "exec",
                 executable = True,
-                default = Label("//src/scala/io/bazel/rules_scala/scaladoc_support:scaladoc_generator"),
+                default = "//src/scala/io/bazel/rules_scala/scaladoc_support:scaladoc_generator",
             ),
         },
         doc = "Generate Scaladoc HTML documentation for source files in from the given dependencies.",

--- a/scala/private/rules/scala_junit_test.bzl
+++ b/scala/private/rules/scala_junit_test.bzl
@@ -68,8 +68,8 @@ _scala_junit_test_attrs = {
     "prefixes": attr.string_list(default = []),
     "suffixes": attr.string_list(default = []),
     "suite_label": attr.label(
-        default = Label(
-            "//src/java/io/bazel/rulesscala/test_discovery:test_discovery",
+        default = (
+            "//src/java/io/bazel/rulesscala/test_discovery:test_discovery"
         ),
     ),
     "suite_class": attr.string(
@@ -81,21 +81,21 @@ _scala_junit_test_attrs = {
     ),
     "jvm_flags": attr.string_list(),
     "runtime_jdk": attr.label(
-        default = Label("@rules_java//toolchains:current_java_runtime"),
+        default = "@rules_java//toolchains:current_java_runtime",
         providers = [java_common.JavaRuntimeInfo],
     ),
     "env": attr.string_dict(default = {}),
     "env_inherit": attr.string_list(),
     "_junit_classpath": attr.label(
-        default = Label("//testing/toolchain:junit_classpath"),
+        default = "//testing/toolchain:junit_classpath",
     ),
     "_bazel_test_runner": attr.label(
-        default = Label("//scala:bazel_test_runner_deploy"),
+        default = "//scala:bazel_test_runner_deploy",
         allow_files = True,
     ),
     "_lcov_merger": attr.label(
-        default = Label(
-            "@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main",
+        default = (
+            "@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"
         ),
     ),
 }
@@ -103,8 +103,8 @@ _scala_junit_test_attrs = {
 _junit_resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [
-            Label("//scala/private/toolchain_deps:scala_library_classpath"),
-            Label("//testing/toolchain:junit_classpath"),
+            "//scala/private/toolchain_deps:scala_library_classpath",
+            "//testing/toolchain:junit_classpath",
         ],
         allow_files = False,
     ),
@@ -138,8 +138,8 @@ def make_scala_junit_test(*extras):
         ),
         test = True,
         toolchains = [
-            Label("//scala:toolchain_type"),
-            Label("//testing/toolchain:testing_toolchain_type"),
+            "//scala:toolchain_type",
+            "//testing/toolchain:testing_toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -105,7 +105,7 @@ def make_scala_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            Label("//scala:toolchain_type"),
+            "//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,
@@ -179,9 +179,7 @@ _scala_library_for_plugin_bootstrapping_attrs.update({
     "_scalac": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label(
-            "//src/java/io/bazel/rulesscala/scalac:scalac_bootstrap",
-        ),
+        default = "//src/java/io/bazel/rulesscala/scalac:scalac_bootstrap",
         allow_files = True,
     ),
 })
@@ -209,7 +207,7 @@ def make_scala_library_for_plugin_bootstrapping(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            Label("//scala:toolchain_type"),
+            "//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,
@@ -285,7 +283,7 @@ def make_scala_macro_library(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            Label("//scala:toolchain_type"),
+            "//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_repl.bzl
+++ b/scala/private/rules/scala_repl.bzl
@@ -84,7 +84,7 @@ def make_scala_repl(*extras):
             *[extra["outputs"] for extra in extras if "outputs" in extra]
         ),
         toolchains = [
-            Label("//scala:toolchain_type"),
+            "//scala:toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/rules/scala_test.bzl
+++ b/scala/private/rules/scala_test.bzl
@@ -70,19 +70,17 @@ _scala_test_attrs = {
         default = "io.bazel.rules.scala.JUnitXmlReporter",
     ),
     "_scalatest": attr.label(
-        default = Label(
-            "//testing/toolchain:scalatest_classpath",
-        ),
+        default = "//testing/toolchain:scalatest_classpath",
     ),
     "_scalatest_runner": attr.label(
         cfg = "exec",
-        default = Label("//src/java/io/bazel/rulesscala/scala_test:runner"),
+        default = "//src/java/io/bazel/rulesscala/scala_test:runner",
     ),
     "_scalatest_reporter": attr.label(
-        default = Label("//scala/support:test_reporter"),
+        default = "//scala/support:test_reporter",
     ),
     "_lcov_merger": attr.label(
-        default = Label("@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main"),
+        default = "@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main",
         cfg = "exec",
     ),
     "env": attr.string_dict(default = {}),
@@ -92,12 +90,8 @@ _scala_test_attrs = {
 _test_resolve_deps = {
     "_scala_toolchain": attr.label_list(
         default = [
-            Label(
-                "//scala/private/toolchain_deps:scala_library_classpath",
-            ),
-            Label(
-                "//testing/toolchain:scalatest_classpath",
-            ),
+            "//scala/private/toolchain_deps:scala_library_classpath",
+            "//testing/toolchain:scalatest_classpath",
         ],
         allow_files = False,
     ),
@@ -128,8 +122,8 @@ def make_scala_test(*extras):
         ),
         test = True,
         toolchains = [
-            Label("//scala:toolchain_type"),
-            Label("//testing/toolchain:testing_toolchain_type"),
+            "//scala:toolchain_type",
+            "//testing/toolchain:testing_toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
         cfg = scala_version_transition,

--- a/scala/private/toolchain_deps/toolchain_dep_rules.bzl
+++ b/scala/private/toolchain_deps/toolchain_dep_rules.bzl
@@ -3,7 +3,7 @@ load(
     "expose_toolchain_deps",
 )
 
-_TOOLCHAIN_TYPE = Label("//scala:toolchain_type")
+_TOOLCHAIN_TYPE = "//scala:toolchain_type"
 
 def _common_toolchain_deps(ctx):
     return expose_toolchain_deps(ctx, _TOOLCHAIN_TYPE)

--- a/scala/scala_import.bzl
+++ b/scala/scala_import.bzl
@@ -136,16 +136,16 @@ scala_import = rule(
         "srcjar": attr.label(allow_single_file = True),
         "_placeholder_jar": attr.label(
             allow_single_file = True,
-            default = Label(
-                "//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar",
+            default = (
+                "//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar"
             ),
         ),
         "stamp": attr.label(
             doc = "Adds Target-Label attribute to MANIFEST.MF for dep tracking",
-            default = Label("//scala/settings:stamp_scala_import"),
+            default = "//scala/settings:stamp_scala_import",
         ),
         "java_compile_toolchain": attr.label(
-            default = Label("@rules_java//toolchains:current_java_toolchain"),
+            default = "@rules_java//toolchains:current_java_toolchain",
         ),
     },
     toolchains = ["@bazel_tools//tools/jdk:toolchain_type"],

--- a/scala/scala_toolchain.bzl
+++ b/scala/scala_toolchain.bzl
@@ -160,7 +160,7 @@ _scala_toolchain = rule(
             doc = "Enable the output of structured diagnostics through the BEP",
         ),
         "jacocorunner": attr.label(
-            default = Label("@bazel_tools//tools/jdk:JacocoCoverage"),
+            default = "@bazel_tools//tools/jdk:JacocoCoverage",
         ),
         "enable_stats_file": attr.bool(
             default = True,
@@ -176,7 +176,7 @@ _scala_toolchain = rule(
             doc = "Changes java binaries scripts (including tests) to use argument files and not classpath jars to improve performance, requires java > 8",
         ),
         "_scala_version": attr.label(
-            default = Label("@rules_scala_config//:scala_version"),
+            default = "@rules_scala_config//:scala_version",
         ),
     },
     fragments = ["java"],

--- a/scala/scalafmt/phase_scalafmt_ext.bzl
+++ b/scala/scalafmt/phase_scalafmt_ext.bzl
@@ -20,21 +20,19 @@ ext_scalafmt = {
         ),
         "_fmt": attr.label(
             cfg = "exec",
-            default = Label("//scala/scalafmt"),
+            default = "//scala/scalafmt",
             executable = True,
         ),
         "_java_host_runtime": attr.label(
-            default = Label(
-                "@rules_java//toolchains:current_host_java_runtime",
-            ),
+            default = "@rules_java//toolchains:current_host_java_runtime",
         ),
         "_runner": attr.label(
             allow_single_file = True,
-            default = Label("//scala/scalafmt:runner"),
+            default = "//scala/scalafmt:runner",
         ),
         "_testrunner": attr.label(
             allow_single_file = True,
-            default = Label("//scala/scalafmt:testrunner"),
+            default = "//scala/scalafmt:testrunner",
         ),
     },
     "outputs": {
@@ -42,7 +40,7 @@ ext_scalafmt = {
         "scalafmt_testrunner": "%{name}.format-test",
     },
     "phase_providers": [
-        Label("//scala/scalafmt:phase_scalafmt"),
+        "//scala/scalafmt:phase_scalafmt",
     ],
 }
 

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -199,5 +199,5 @@ def scala_register_toolchains():
 
 def scala_register_unused_deps_toolchains():
     native.register_toolchains(
-        str(Label("//scala:unused_dependency_checker_error_toolchain")),
+        "//scala:unused_dependency_checker_error_toolchain",
     )

--- a/scala_proto/private/scala_proto_aspect.bzl
+++ b/scala_proto/private/scala_proto_aspect.bzl
@@ -37,12 +37,14 @@ def _code_should_be_generated(ctx, toolchain):
     # so we make the local target we are looking at absolute too
     target_absolute_label = ctx.label
     if not str(target_absolute_label)[0] == "@":
-        target_absolute_label = Label("@%s//%s:%s" % (ctx.workspace_name, ctx.label.package, ctx.label.name))
+        target_absolute_label = Label(
+            "@@%s//%s:%s" % (ctx.repo_name, ctx.label.package, ctx.label.name),
+        )
 
     return toolchain.blacklisted_protos.get(target_absolute_label) == None
 
 def _compile_deps(ctx, toolchain):
-    deps_toolchain_type_label = Label("//scala_proto:deps_toolchain_type")
+    deps_toolchain_type_label = "//scala_proto:deps_toolchain_type"
     return [
         dep[JavaInfo]
         for id in toolchain.compile_dep_ids
@@ -145,14 +147,14 @@ def _phase_deps(ctx, p):
     return [d[ScalaProtoAspectInfo].java_info for d in ctx.rule.attr.deps]
 
 def _phase_scalacopts(ctx, p):
-    return ctx.toolchains[Label("//scala:toolchain_type")].scalacopts
+    return ctx.toolchains["//scala:toolchain_type"].scalacopts
 
 def _phase_generate_and_compile(ctx, p):
     proto = p.proto_info
     deps = p.deps
     scalacopts = p.scalacopts
     stamp_label = p.stamp_label
-    toolchain = ctx.toolchains[Label("//scala_proto:toolchain_type")]
+    toolchain = ctx.toolchains["//scala_proto:toolchain_type"]
 
     if proto.direct_sources and _code_should_be_generated(ctx, toolchain):
         src_jars = _generate_sources(ctx, toolchain, proto)
@@ -177,7 +179,7 @@ def _strip_suffix(str, suffix):
 
 def _phase_stamp_label(ctx, p):
     rule_label = str(p.target.label)
-    toolchain = ctx.toolchains[Label("//scala_proto:toolchain_type")]
+    toolchain = ctx.toolchains["//scala_proto:toolchain_type"]
 
     if toolchain.stamp_by_convention and rule_label.endswith("_proto"):
         return _strip_suffix(rule_label, "_proto") + "_scala_proto"
@@ -205,12 +207,10 @@ def _scala_proto_aspect_impl(target, ctx):
 def make_scala_proto_aspect(*extras):
     attrs = {
         "_java_toolchain": attr.label(
-            default = Label("@rules_java//toolchains:current_java_toolchain"),
+            default = "@rules_java//toolchains:current_java_toolchain",
         ),
         "_java_host_runtime": attr.label(
-            default = Label(
-                "@rules_java//toolchains:current_host_java_runtime",
-            ),
+            default = "@rules_java//toolchains:current_host_java_runtime",
         ),
     }
     return aspect(
@@ -223,9 +223,9 @@ def make_scala_proto_aspect(*extras):
             *[extra["attrs"] for extra in extras if "attrs" in extra]
         ),
         toolchains = [
-            Label("//scala:toolchain_type"),
-            Label("//scala_proto:toolchain_type"),
-            Label("//scala_proto:deps_toolchain_type"),
+            "//scala:toolchain_type",
+            "//scala_proto:toolchain_type",
+            "//scala_proto:deps_toolchain_type",
             "@bazel_tools//tools/jdk:toolchain_type",
         ],
     )

--- a/scala_proto/private/toolchain_deps.bzl
+++ b/scala_proto/private/toolchain_deps.bzl
@@ -3,7 +3,7 @@ load(
     "expose_toolchain_deps",
 )
 
-_DEPS_TOOLCHAIN_TYPE = Label("//scala_proto:deps_toolchain_type")
+_DEPS_TOOLCHAIN_TYPE = "//scala_proto:deps_toolchain_type"
 
 def _export_scalapb_toolchain_deps(ctx):
     return expose_toolchain_deps(ctx, _DEPS_TOOLCHAIN_TYPE)

--- a/scala_proto/scala_proto_toolchain.bzl
+++ b/scala_proto/scala_proto_toolchain.bzl
@@ -61,7 +61,7 @@ scala_proto_toolchain = rule(
         "code_generator": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label("//src/scala/scripts:scalapb_worker"),
+            default = "//src/scala/scripts:scalapb_worker",
             allow_files = True,
         ),
         "generators": attr.string_dict(),
@@ -72,7 +72,7 @@ scala_proto_toolchain = rule(
         "scalac": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label("//src/java/io/bazel/rulesscala/scalac"),
+            default = "//src/java/io/bazel/rulesscala/scalac",
             allow_files = True,
         ),
         "stamp_by_convention": attr.bool(
@@ -95,9 +95,7 @@ scala_proto_toolchain = rule(
         # remove `_main_generator_dep`, and delete
         # `//src/scala/scripts:scalapb_codegenerator_wrapper` and its files.
         "_main_generator_dep": attr.label(
-            default = Label(
-                "//src/scala/scripts:scalapb_codegenerator_wrapper",
-            ),
+            default = "//src/scala/scripts:scalapb_codegenerator_wrapper",
             allow_single_file = True,
             executable = False,
             cfg = "exec",

--- a/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
+++ b/test_expect_failure/missing_direct_deps/internal_deps/custom-jvm-rule.bzl
@@ -15,8 +15,8 @@ custom_jvm = rule(
         "deps": attr.label_list(),
         "jar": attr.label(
             allow_single_file = True,
-            default = Label(
-                "//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar",
+            default = (
+                "//scala:libPlaceHolderClassToCreateEmptyJarForScalaImport.jar"
             ),
         ),
     },

--- a/test_expect_failure/missing_direct_deps/scala_proto_deps/customized_scala_proto.bzl
+++ b/test_expect_failure/missing_direct_deps/scala_proto_deps/customized_scala_proto.bzl
@@ -3,7 +3,7 @@ load("//scala:advanced_usage/providers.bzl", "ScalaRulePhase")
 
 def _phase_custom_stamping_convention(ctx, p):
     rule_label = str(p.target.label)
-    toolchain = ctx.toolchains[Label("//scala_proto:toolchain_type")]
+    toolchain = ctx.toolchains["//scala_proto:toolchain_type"]
 
     if toolchain.stamp_by_convention:
         return rule_label + "_custom_suffix"

--- a/testing/toolchain/toolchain_deps.bzl
+++ b/testing/toolchain/toolchain_deps.bzl
@@ -3,7 +3,7 @@ load(
     "expose_toolchain_deps",
 )
 
-_toolchain_type = Label("//testing/toolchain:testing_toolchain_type")
+_toolchain_type = "//testing/toolchain:testing_toolchain_type"
 
 def _testing_toolchain_deps(ctx):
     return expose_toolchain_deps(ctx, _toolchain_type)

--- a/thrift/thrift.bzl
+++ b/thrift/thrift.bzl
@@ -172,7 +172,7 @@ thrift_library = rule(
         "_zipper": attr.label(
             executable = True,
             cfg = "exec",
-            default = Label("@bazel_tools//tools/zip:zipper"),
+            default = "@bazel_tools//tools/zip:zipper",
             allow_files = True,
         ),
     },

--- a/twitter_scrooge/toolchain/toolchain.bzl
+++ b/twitter_scrooge/toolchain/toolchain.bzl
@@ -63,7 +63,7 @@ scrooge_toolchain = rule(
     },
 )
 
-_toolchain_type = Label("//twitter_scrooge/toolchain:scrooge_toolchain_type")
+_toolchain_type = "//twitter_scrooge/toolchain:scrooge_toolchain_type"
 
 def _export_scrooge_deps_impl(ctx):
     return expose_toolchain_deps(ctx, _toolchain_type)

--- a/twitter_scrooge/twitter_scrooge.bzl
+++ b/twitter_scrooge/twitter_scrooge.bzl
@@ -161,7 +161,7 @@ def _compile_generated_scala(
         print_compile_time = False,
         expect_java_output = False,
         scalac_jvm_flags = [],
-        scalacopts = ctx.toolchains[Label("//scala:toolchain_type")].scalacopts,
+        scalacopts = ctx.toolchains["//scala:toolchain_type"].scalacopts,
         scalac = ctx.executable._scalac,
         dependency_info = legacy_unclear_dependency_info_for_protobuf_scrooge(ctx),
         unused_dependency_checker_ignored_targets = [],
@@ -303,15 +303,15 @@ common_attrs = {
     "_pluck_scrooge_scala": attr.label(
         executable = True,
         cfg = "exec",
-        default = Label("//src/scala/scripts:scrooge_worker"),
+        default = "//src/scala/scripts:scrooge_worker",
         allow_files = True,
     ),
     "_implicit_compile_deps": attr.label_list(
         providers = [JavaInfo],
-        default = [Label("//twitter_scrooge:aspect_compile_classpath")],
+        default = ["//twitter_scrooge:aspect_compile_classpath"],
     ),
     "_java_host_runtime": attr.label(
-        default = Label("@rules_java//toolchains:current_host_java_runtime"),
+        default = "@rules_java//toolchains:current_host_java_runtime",
     ),
 }
 
@@ -321,8 +321,8 @@ common_aspect_providers = [
 ]
 
 common_toolchains = [
-    Label("//scala:toolchain_type"),
-    Label("//twitter_scrooge/toolchain:scrooge_toolchain_type"),
+    "//scala:toolchain_type",
+    "//twitter_scrooge/toolchain:scrooge_toolchain_type",
     "@bazel_tools//tools/jdk:toolchain_type",
 ]
 
@@ -335,7 +335,7 @@ scrooge_scala_aspect = aspect(
             "_scalac": attr.label(
                 executable = True,
                 cfg = "exec",
-                default = Label("//src/java/io/bazel/rulesscala/scalac"),
+                default = "//src/java/io/bazel/rulesscala/scalac",
                 allow_files = True,
             ),
         },
@@ -351,9 +351,9 @@ scrooge_java_aspect = aspect(
     attrs = dicts.add(
         common_attrs,
         {
-            "_java_toolchain": attr.label(default = Label(
-                "@rules_java//toolchains:current_java_toolchain",
-            )),
+            "_java_toolchain": attr.label(
+                default = "@rules_java//toolchains:current_java_toolchain",
+            ),
         },
     ),
     provides = [ScroogeAspectInfo],
@@ -426,12 +426,12 @@ scrooge_scala_import = rule(
         "scala_jars": attr.label_list(allow_files = [".jar"]),
         "_implicit_compile_deps": attr.label_list(
             providers = [JavaInfo],
-            default = [Label("//twitter_scrooge:compile_classpath")],
+            default = ["//twitter_scrooge:compile_classpath"],
         ),
     },
     provides = [ThriftInfo, JavaInfo, ScroogeImport],
     toolchains = [
-        Label("//twitter_scrooge/toolchain:scrooge_toolchain_type"),
+        "//twitter_scrooge/toolchain:scrooge_toolchain_type",
         "@bazel_tools//tools/jdk:toolchain_type",
     ],
 )


### PR DESCRIPTION
### Description

Removes all the `Label` wrappers added in #1696 that aren't strictly necessary.

Removed instances:

```sh
$ git show -p | grep '^- .*Label(' | wc -l
    88
```

Remaining instances:

```sh
$ git ls-files | xargs grep '[^A-Za-z0-9]Label(' | wc -l
    31
```

### Motivation

Inspired by research I did while writing a blog post reflecting upon the motivations behind #1696.

Bazel evaluates target string literals in the context of the repository that appears to contain the assignment of the literal to a `Label` attribute. `Label` wrappers are necessary for target string literals within macros, passed to external functions, and included in files generated by a repository rule. This ensures that the targets refer to the originating repository by preventing Bazel from interpreting them within the context of the repository using them.

Keeping the `Label` wrappers doesn't hurt, but leaving only the ones that are required helps those instances stand out.