### PR TITLE
Fix Bazel 8.2.1 WORKSPACE builds, bump dev deps

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,5 +1,9 @@
 # Remove once Bazel 8 becomes the minimum supported version.
-common --noenable_workspace --incompatible_use_plus_in_repo_names
+common --noenable_workspace --incompatible_use_plus_in_repo_names --incompatible_autoload_externally=
+
+# Uncomment to run tests under `WORKSPACE`. Remove once Bazel 9 becomes the
+# minimum supported version.
+#common --enable_workspace --noenable_bzlmod
 
 # Uncomment for WORKSPACE builds for Bazel [8.0.0, 8.3.0) per:
 # https://github.com/bazelbuild/rules_java/releases/tag/8.12.0

--- a/BUILD
+++ b/BUILD
@@ -1,0 +1,4 @@
+# For //tools:lint_check, which requires a `workspace` attribute. However, this
+# can be any file, and `WORKSPACE` is going away one day. See:
+# https://github.com/bazelbuild/buildtools/blob/v8.2.1/buildifier/runner.bash.template
+exports_files(["MODULE.bazel"])

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -302,4 +302,4 @@ use_repo(
 )
 
 bazel_dep(name = "rules_python", version = "1.4.1", dev_dependency = True)
-bazel_dep(name = "rules_shell", version = "0.4.1", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.5.0", dev_dependency = True)

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -151,9 +151,9 @@ register_toolchains("//test/toolchains:java21_toolchain_definition")
 
 http_archive(
     name = "rules_shell",
-    sha256 = "bc61ef94facc78e20a645726f64756e5e285a045037c7a61f65af2941f4c25e1",
-    strip_prefix = "rules_shell-0.4.1",
-    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.4.1/rules_shell-v0.4.1.tar.gz",
+    sha256 = "b15cc2e698a3c553d773ff4af35eb4b3ce2983c319163707dddd9e70faaa062d",
+    strip_prefix = "rules_shell-0.5.0",
+    url = "https://github.com/bazelbuild/rules_shell/releases/download/v0.5.0/rules_shell-v0.5.0.tar.gz",
 )
 
 load(

--- a/scala/latest_deps.bzl
+++ b/scala/latest_deps.bzl
@@ -51,3 +51,21 @@ def rules_scala_dependencies():
         strip_prefix = "rules_proto-7.1.0",
         url = "https://github.com/bazelbuild/rules_proto/releases/download/7.1.0/rules_proto-7.1.0.tar.gz",
     )
+
+    # Resolves the following error when building under `WORKSPACE` with Bazel 8.2.1,
+    # `protobuf` v31.1, and `rules_java` 8.12.0:
+    # https://github.com/protocolbuffers/protobuf/pull/19129#issuecomment-2968934424
+    rules_jvm_external_tag = "6.7"
+    rules_jvm_external_sha = (
+        "a1e351607f04fed296ba33c4977d3fe2a615ed50df7896676b67aac993c53c18"
+    )
+    maybe(
+        http_archive,
+        name = "rules_jvm_external",
+        sha256 = rules_jvm_external_sha,
+        strip_prefix = "rules_jvm_external-%s" % rules_jvm_external_tag,
+        url = "https://github.com/bazel-contrib/rules_jvm_external/releases/download/%s/rules_jvm_external-%s.tar.gz" % (
+            rules_jvm_external_tag,
+            rules_jvm_external_tag,
+        ),
+    )

--- a/scala/private/extensions/dev_deps.bzl
+++ b/scala/private/extensions/dev_deps.bzl
@@ -10,7 +10,8 @@ load(
 )
 load("//third_party/repositories:repositories.bzl", "repositories")
 
-_BUILD_TOOLS_RELEASE = "5.1.0"
+_BUILD_TOOLS_RELEASE = "8.2.1"
+_BUILD_TOOLS_INTEGRITY = "sha256-UxGTl7vOHNfkxZDhF9zaNDwghhmd5ikyEGyAczUmwmE="
 
 _settings_defaults = {
     "maven_servers": default_maven_server_urls(),
@@ -41,12 +42,16 @@ def dev_deps_repositories(
         maven_servers: servers to use when resolving Maven artifacts
         fetch_sources: retrieve Maven artifact sources when True
     """
+
+    # gazelle is still getting `buildtools` from its `go.mod` file, which breaks
+    # `bazel run //tools:lint_check` when we don't import it like this. See:
+    # - https://github.com/bazel-contrib/bazel-gazelle/blob/v0.43.0/MODULE.bazel#L32-L44
     http_archive(
         name = "com_github_bazelbuild_buildtools",
-        sha256 = "e3bb0dc8b0274ea1aca75f1f8c0c835adbe589708ea89bf698069d0790701ea3",
+        integrity = _BUILD_TOOLS_INTEGRITY,
         strip_prefix = "buildtools-%s" % _BUILD_TOOLS_RELEASE,
         url = (
-            "https://github.com/bazelbuild/buildtools/archive/%s.tar.gz" %
+            "https://github.com/bazelbuild/buildtools/archive/v%s.tar.gz" %
             _BUILD_TOOLS_RELEASE
         ),
     )

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -40,6 +40,9 @@ load("@bazel_tools//tools/build_defs/repo:utils.bzl", "read_netrc", "read_user_n
 _SCALA_IMPORT_RULE_LOAD = (
     "load(\"%s\", \"scala_import\")" % Label("//scala:scala_import.bzl")
 )
+_JAVA_IMPORT_RULE_LOAD = (
+    "load(\"@rules_java//java:java_import.bzl\", \"java_import\")"
+)
 
 # https://github.com/bazelbuild/bazel/issues/13709#issuecomment-1336699672
 def _get_auth(ctx, urls):
@@ -97,6 +100,7 @@ def _jvm_import_external_impl(repository_ctx):
         lines.append("package(default_visibility = %s)" %
                      (repository_ctx.attr.default_visibility))
         lines.append("")
+
     lines.append("licenses(%s)" % repr(repository_ctx.attr.licenses))
     lines.append("")
     lines.extend(
@@ -229,6 +233,7 @@ def _serialize_given_rule_import(
     lines.append("")
     return lines
 
+# buildifier: disable=attr-licenses
 _jvm_import_external = repository_rule(
     implementation = _jvm_import_external_impl,
     attrs = {
@@ -237,7 +242,7 @@ _jvm_import_external = repository_rule(
         "jar_urls": attr.string_list(mandatory = True, allow_empty = False),
         "jar_sha256": attr.string(doc = "'jar_sha256' is deprecated. Please use 'artifact_sha256'"),
         "artifact_sha256": attr.string(),
-        "rule_load": attr.string(),
+        "rule_load": attr.string(default = _JAVA_IMPORT_RULE_LOAD),
         "additional_rule_attrs": attr.string_dict(),
         "srcjar_urls": attr.string_list(),
         "srcjar_sha256": attr.string(),

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -1,4 +1,8 @@
-load("@com_github_bazelbuild_buildtools//buildifier:def.bzl", "buildifier")
+load(
+    "@com_github_bazelbuild_buildtools//buildifier:def.bzl",
+    "buildifier",
+    "buildifier_test",
+)
 
 WARNINGS_CONFIG = [
     "-module-docstring",
@@ -16,7 +20,7 @@ WARNINGS_CONFIG = [
     "-unused-variable",
 ]
 
-buildifier(
+buildifier_test(
     name = "lint_check",
     exclude_patterns = [
         "./.ijwb/*",
@@ -24,6 +28,8 @@ buildifier(
     lint_mode = "warn",
     lint_warnings = WARNINGS_CONFIG,
     mode = "check",
+    no_sandbox = True,
+    workspace = "//:MODULE.bazel",
 )
 
 buildifier(


### PR DESCRIPTION
### Description

Fixes a few problems when building under `WORKSPACE` with Bazel 8.2.1 (7.6.1 doesn't require these changes). Adds to `.bazelrc` the `--incompatible_autoload_externally=` flag as a common option for all builds, and a (disabled) line of options for `WORKSPACE` builds.

Bumps these development dependency versions:

- `com_google_buildifier_buildtools`: 5.1.0 => 8.2.1
- `rules_shell`: 0.4.1 => 0.5.0

### Motivation

Though `WORKSPACE` is on the way out, we should ensure that `rules_scala` remains as compatible as it can be until it's totally gone. All of these errors happened when running `./test_all` with Bazel 8.2.1 and `WORKSPACE` enabled while working on #1747.

The first error was the following "cycle". (I later realized it's somehow due to bazelbuild/rules_java#294 from `rules_java` 8.12.0. See the note at the very end below.)

```sh
$ bazel run //tools:lint_check

ERROR: Cycle caused by autoloads, failed to load .bzl file
  '@@bazel_features_version//:version.bzl'.
Add 'bazel_features_version' to --repositories_without_autoloads
  or disable autoloads by setting '--incompatible_autoload_externally='
More information on https://github.com/bazelbuild/bazel/issues/23043.
```

`--incompatible_autoload_externally=` fixed this problem, but also precipitated all the other errors below.

- bazelbuild/bazel#23043
- https://bazel.build/reference/command-line-reference#common_options-flag--incompatible_autoload_externally

Updating `com_github_bazelbuild_buildtools` to v8.2.1 fixes the next error, whereby Bazel no longer autoloaded `sh_test`. v5.1.0 was missing the required `load("@rules_shell//shell:sh_test.bzl", "sh_test")` statement, added in v8.0.3 by bazelbuild/buildtools#1332:

```sh
$ bazel run //tools:lint_check

ERROR: .../external/com_github_bazelbuild_buildtools/buildifier/BUILD.bazel:60:1:
  name 'sh_test' is not defined (did you mean 'cc_test'?)

ERROR: .../external/com_github_bazelbuild_buildtools/buildifier/BUILD.bazel:
  no such target '@@com_github_bazelbuild_buildtools//buildifier:runner.bash.template':
  target 'runner.bash.template' not declared in package 'buildifier' defined by
  .../external/com_github_bazelbuild_buildtools/buildifier/BUILD.bazel;
  however, a source file of this name exists.
  (Perhaps add 'exports_files(["runner.bash.template"])' to buildifier/BUILD?)

ERROR: /Users/mbland/src/bazel-contrib/rules_scala/tools/BUILD:19:11:
  every rule of type _buildifier implicitly depends upon the target
  '@@com_github_bazelbuild_buildtools//buildifier:runner.bash.template',
  but this target could not be found because of: no such target
  '@@com_github_bazelbuild_buildtools//buildifier:runner.bash.template':
  target 'runner.bash.template' not declared in package 'buildifier' defined by
  .../external/com_github_bazelbuild_buildtools/buildifier/BUILD.bazel;
  however, a source file of this name exists.
  (Perhaps add 'exports_files(["runner.bash.template"])' to buildifier/BUILD?)

ERROR: Analysis of target '//tools:lint_check' failed;
  build aborted: Analysis failed
```

Upgrading to v8.2.1 and updating `//tools:lint_check` to become a `buildifier_test` also finally got rid of this next warning. This required exporting the `MODULE.bazel` file from the root package, disabling one lint warning, and accepting a couple of new lint fixes:

```txt
DEBUG: .../external/+dev_deps+com_github_bazelbuild_buildtools/buildifier/internal/factory.bzl:17:10:
DEPRECATION NOTICE: value 'check' for attribute 'mode' will be removed
in the future. Migrate '@@//tools:lint_check' to buildifier_test.
```

Adding `rules_jvm_external` 6.7 to `//scala:latest_deps.bzl` fixes this next error, described in detail in:

- https://github.com/protocolbuffers/protobuf/pull/19129#issuecomment-2968934424

```sh
$ bazel build --test_output=errors src/... test/...

ERROR: .../external/com_google_protobuf/java/core/BUILD.bazel:169:21:
  @@com_google_protobuf//java/core:lite_mvn-lib:
  no such attribute 'javacopts' in 'java_library' rule

ERROR: .../external/com_google_protobuf/java/core/BUILD.bazel:169:21:
  @@com_google_protobuf//java/core:lite_mvn-lib:
  no such attribute 'resources' in 'java_library' rule
  (did you mean 'features'?)

ERROR: .../external/com_google_protobuf/java/core/BUILD.bazel:169:21:
  @@com_google_protobuf//java/core:lite_mvn-lib:
  no such attribute 'runtime_deps' in 'java_library' rule

ERROR: .../external/com_google_protobuf/java/core/BUILD.bazel:287:21:
  @@com_google_protobuf//java/core:core_mvn-lib:
  no such attribute 'javacopts' in 'java_library' rule

ERROR: .../external/com_google_protobuf/java/core/BUILD.bazel:287:21:
  @@com_google_protobuf//java/core:core_mvn-lib:
  no such attribute 'resources' in 'java_library' rule (did you mean 'features'?)

ERROR: .../external/com_google_protobuf/java/core/BUILD.bazel:287:21:
  @@com_google_protobuf//java/core:core_mvn-lib:
  no such attribute 'runtime_deps' in 'java_library' rule

ERROR: .../external/com_google_protobuf/BUILD.bazel:475:6:
  Target '@@com_google_protobuf//java/core:core'
  contains an error and its package is in error
  and referenced by '@@com_google_protobuf//:protobuf_java'

ERROR: Analysis of target
  '//test/proto/custom_generator:failing_scala_proto_deps_toolchain_def'
  failed; build aborted: Analysis failed
```

All of the previous errors only affected `rules_scala`'s own development builds and test runs, when it is the main repository/root module. This final error is something users could possibly run into when using `--incompatible_autoload_externally=` with `rules_scala`.

`jvm_import` statements in Maven dependency repos generated by `jvm_import_external` from `//scala:scala_maven_import_external.bzl` began to fail. Defining `_JAVA_IMPORT_RULE_LOAD` and using it as the default value for the `rule_load` attribute of the `_jvm_import_external` rule fixed this:

```sh
$ bazel test --test_output=errors third_party/...

ERROR: .../external/org_apache_commons_commons_lang_3_5_without_file/BUILD:7:12:
  @@org_apache_commons_commons_lang_3_5_without_file//:org_apache_commons_commons_lang_3_5_without_file:
  no such attribute 'jars' in 'java_import' rule

ERROR: .../external/org_apache_commons_commons_lang_3_5_without_file/BUILD:7:12:
  @@org_apache_commons_commons_lang_3_5_without_file//:org_apache_commons_commons_lang_3_5_without_file:
  no such attribute 'neverlink' in 'java_import' rule

ERROR: .../external/org_apache_commons_commons_lang_3_5_without_file/BUILD:14:12:
  @@org_apache_commons_commons_lang_3_5_without_file//:linkable_org_apache_commons_commons_lang_3_5_without_file:
  no such attribute 'jars' in 'java_import' rule

ERROR: .../third_party/dependency_analyzer/src/test/BUILD:4:6:
  Target '@@org_apache_commons_commons_lang_3_5_without_file//:linkable_org_apache_commons_commons_lang_3_5_without_file'
  contains an error and its package is in error and referenced by
  '//third_party/dependency_analyzer/src/test:strict_deps_test'

ERROR: Analysis of target
  '//third_party/dependency_analyzer/src/test:strict_deps_test' failed;
  build aborted: Analysis failed
```

---

And just now, I'm noticing that I'd already added the following to `.bazelrc`, where the `rules_java` release references bazelbuild/bazel#26119:

```sh
  # Uncomment for WORKSPACE builds for Bazel [8.0.0, 8.3.0) per:
  # https://github.com/bazelbuild/rules_java/releases/tag/8.12.0
  #common --repositories_without_autoloads=bazel_features_version,bazel_features_globals
```

Oh well. But now we're future proof.