### PR TITLE
expose build_ijar for scala_library

### DIFF
--- a/docs/scala_library.md
+++ b/docs/scala_library.md
@@ -172,5 +172,21 @@ In order to have a Java rule use this jar file, use the `java_import` rule.
         </p>
       </td>
     </tr>
+    <tr>
+      <td><code>build_ijar</code></td>
+      <td>
+        <p><code>Boolean; optional (default True)</code></p>
+        <p>
+          Enables building an interface jar.
+          You can also disable the interface jar (`ijar`) functionality, it may be useful in some specific cases.
+
+          Example: if you want to enable inlining the compiled code, when it is given as a dependency for another Scala target.
+          `ijar` does not contain an implementation, so it cannot be used for inlining, disable `ijar` in this usecase.
+
+          Only change this parameter if you have an explicit usecase like the above.
+          For macro code, use a specific rule: scala_macro_library.
+        </p>
+      </td>
+    </tr>
   </tbody>
 </table>

--- a/scala/private/phases/phase_compile.bzl
+++ b/scala/private/phases/phase_compile.bzl
@@ -33,15 +33,19 @@ def phase_compile_binary(ctx, p):
     return _phase_compile_default(ctx, p, args)
 
 def phase_compile_library(ctx, p):
-    args = struct(
-        srcjars = p.collect_srcjars,
-        unused_dependency_checker_ignored_targets = [
+    args = {
+        "srcjars": p.collect_srcjars,
+        "unused_dependency_checker_ignored_targets": [
             target.label
             for target in p.scalac_provider.default_classpath + ctx.attr.exports +
                           ctx.attr.unused_dependency_checker_ignored_targets
         ],
-    )
-    return _phase_compile_default(ctx, p, args)
+    }
+
+    if hasattr(ctx.attr, "build_ijar"):
+        args["buildijar"] = ctx.attr.build_ijar
+
+    return _phase_compile_default(ctx, p, struct(**args))
 
 def phase_compile_library_for_plugin_bootstrapping(ctx, p):
     args = struct(

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -85,6 +85,10 @@ _scala_library_attrs = {}
 
 _scala_library_attrs.update(implicit_deps)
 
+_scala_library_attrs.update({
+    "build_ijar": attr.bool(default = True),
+})
+
 _scala_library_attrs.update(common_attrs)
 
 _scala_library_attrs.update(_library_attrs)

--- a/test/BUILD
+++ b/test/BUILD
@@ -729,3 +729,25 @@ scala_junit_test(
     },
     suffixes = ["Test"],
 )
+
+# Targets with inlining support
+
+# If this target doesn't have build_ijar disabled, then InlinedExported will fail to compile.
+scala_library(
+    name = "InlinableExported",
+    srcs = ["Exported.scala"],
+    build_ijar = False,
+    runtime_deps = ["Runtime"],
+)
+
+scala_library(
+    name = "InlinedExported",
+    srcs = ["OtherLib.scala"],
+    scalacopts = [
+        "-opt:l:inline",
+        "-opt-inline-from:scalarules.test.**",
+        # We need fatal warnings to ensure that the inlining actually worked.
+        "-Xfatal-warnings",
+    ],
+    deps = [":InlinableExported"],
+)


### PR DESCRIPTION
### Description

Expose build_ijar to enable compiling scala code, that is not for macro
definitions, but would be used in inlining (so ijar support should be
disabled for it).

You may need strict dependency checks (transitive dependencies not on the
classpath) for code that is to be used in inlining.

Till now one would need to use scala_macro_library for that, but it was
recently switched to include all transitive dependencies on the compiler's
classpath, hence strict dependencies are not enforced there.

The new attribute enables having both:
a) code compiled for inlining
b) strict dependency checks
