### PR TITLE
Replace bazel_worker_java with bazel_worker_api

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -66,7 +66,8 @@ single_version_override(
     version = "32.0",
 )
 
-bazel_dep(name = "bazel_worker_java", version = "0.0.6")
+# See //src/java/io/bazel/rulesscala/worker:worker_protocol_java_proto.
+bazel_dep(name = "bazel_worker_api", version = "0.0.6")
 
 scala_protoc = use_extension(
     "//scala/extensions:protoc.bzl",

--- a/scala/private/macros/workspace_compat.bzl
+++ b/scala/private/macros/workspace_compat.bzl
@@ -10,6 +10,7 @@ load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
 load("@bazel_tools//tools/build_defs/repo:utils.bzl", "maybe")
 
 def _bazel_worker_api_repo(name, strip_prefix):
+    """See //src/java/io/bazel/rulesscala/worker:worker_protocol_java_proto."""
     maybe(
         http_archive,
         name = name,
@@ -24,9 +25,4 @@ def workspace_compat():
     _bazel_worker_api_repo(
         name = "bazel_worker_api",
         strip_prefix = "proto",
-    )
-
-    _bazel_worker_api_repo(
-        name = "bazel_worker_java",
-        strip_prefix = "java",
     )

--- a/src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD
+++ b/src/java/io/bazel/rulesscala/coverage/instrumenter/BUILD
@@ -16,7 +16,6 @@ java_binary(
         "//src/java/io/bazel/rulesscala/jar",
         "//src/java/io/bazel/rulesscala/worker",
         "@bazel_tools//tools/jdk:JacocoCoverage",
-        "@bazel_worker_java//:worker_protocol_java_proto",
     ],
 )
 

--- a/src/java/io/bazel/rulesscala/scalac/definitions.bzl
+++ b/src/java/io/bazel/rulesscala/scalac/definitions.bzl
@@ -11,7 +11,6 @@ DEFAULT_SCALAC_DEPS = [
         "//src/protobuf/io/bazel/rules_scala:diagnostics_java_proto",
         "//src/java/io/bazel/rulesscala/scalac/compileoptions",
         "//src/java/io/bazel/rulesscala/scalac/reporter",
-        "@bazel_worker_java//:worker_protocol_java_proto",
     ]
 ]
 

--- a/src/java/io/bazel/rulesscala/worker/BUILD
+++ b/src/java/io/bazel/rulesscala/worker/BUILD
@@ -1,3 +1,4 @@
+load("@com_google_protobuf//bazel:java_proto_library.bzl", "java_proto_library")
 load("@rules_java//java:defs.bzl", "java_library", "java_test")
 
 java_library(
@@ -5,7 +6,7 @@ java_library(
     srcs = ["Worker.java"],
     visibility = ["//visibility:public"],
     deps = [
-        "@bazel_worker_java//:worker_protocol_java_proto",
+        ":worker_protocol_java_proto",
     ],
 )
 
@@ -20,6 +21,16 @@ java_test(
     test_class = "io.bazel.rulesscala.worker.WorkerTest",
     deps = [
         ":worker",
-        "@bazel_worker_java//:worker_protocol_java_proto",
+        ":worker_protocol_java_proto",
     ],
+)
+
+# Duplicated from @bazel_worker_java//:worker_protocol_java_proto to resolve:
+# https://github.com/bazelbuild/bazel-worker-api/issues/7#issuecomment-3209882184
+#
+# rules_scala doesn't need anything else from @bazel_worker_java, so this
+# sidesteps the issue.
+java_proto_library(
+    name = "worker_protocol_java_proto",
+    deps = ["@bazel_worker_api//:worker_protocol_proto"],
 )

--- a/test/BUILD
+++ b/test/BUILD
@@ -476,8 +476,8 @@ scala_specs2_junit_test(
     name = "data_location_expansion",
     size = "small",
     srcs = ["src/main/scala/scalarules/test/location_expansion/LocationExpansionTest.scala"],
-    data = ["@bazel_worker_java//:worker_protocol_java_proto"],
-    jvm_flags = ["-Dlocation.expanded='$(rootpaths @bazel_worker_java//:worker_protocol_java_proto)'"],
+    data = ["//src/java/io/bazel/rulesscala/worker"],
+    jvm_flags = ["-Dlocation.expanded='$(rootpaths //src/java/io/bazel/rulesscala/worker)'"],
     suffixes = ["Test"],
 )
 

--- a/tools/BUILD
+++ b/tools/BUILD
@@ -23,7 +23,7 @@ WARNINGS_CONFIG = [
 buildifier_test(
     name = "lint_check",
     exclude_patterns = [
-        "./.ijwb/*",
+        ".*",
     ],
     lint_mode = "warn",
     lint_warnings = WARNINGS_CONFIG,
@@ -35,7 +35,7 @@ buildifier_test(
 buildifier(
     name = "lint_fix",
     exclude_patterns = [
-        "./.ijwb/*",
+        ".*",
     ],
     lint_mode = "fix",
     lint_warnings = WARNINGS_CONFIG,


### PR DESCRIPTION
### Description

Duplicates `@bazel_worker_java//:worker_protocol_java_proto` to avoid `bazel_worker_java` using `rules_jvm_external` to update `@maven` dependencies:

- https://github.com/bazelbuild/bazel-worker-api/issues/7#issuecomment-3209882184.

Also updates `exclude_patterns` in `//tools` to ignore all dotfile directories.

### Motivation

`rules_scala` doesn't need anything else from `@bazel_worker_java`, so this sidesteps the issue.

The `.bazelbsp` directory generated by VS Code started producing errors from `./test_lint.sh`, precipitating the `exclude_patterns` changes.