### PR TITLE
Upgrade Scala to 3.7.3 (was 3.7.2)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -22,7 +22,7 @@ SCALA_3_VERSIONS = [
     "3.3.6",
     "3.5.2",
     "3.6.4",
-    "3.7.2",
+    "3.7.3",
 ]
 
 SCALA_VERSIONS = SCALA_2_VERSIONS + SCALA_3_VERSIONS

--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -118,7 +118,7 @@ $runner test_compiler_patch 3.3.6
 $runner test_compiler_patch 3.4.3
 $runner test_compiler_patch 3.5.2
 $runner test_compiler_patch 3.6.4
-$runner test_compiler_patch 3.7.2
+$runner test_compiler_patch 3.7.3
 
 $runner test_compiler_srcjar_error 2.12.11
 $runner test_compiler_srcjar_error 2.12.12
@@ -151,4 +151,4 @@ $runner test_compiler_srcjar_nonhermetic 3.3.6
 $runner test_compiler_srcjar 3.4.3
 $runner test_compiler_srcjar_nonhermetic 3.5.2
 $runner test_compiler_srcjar_nonhermetic 3.6.4
-$runner test_compiler_srcjar_nonhermetic 3.7.2
+$runner test_compiler_srcjar_nonhermetic 3.7.3

--- a/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel
+++ b/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel
@@ -170,8 +170,8 @@ scala_deps.compiler_srcjar(
     version = "3.6.4",
 )
 scala_deps.compiler_srcjar(
-    url = "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.2/scala3-compiler_3-3.7.2-sources.jar",
-    version = "3.7.2",
+    url = "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.3/scala3-compiler_3-3.7.3-sources.jar",
+    version = "3.7.3",
 )
 
 scala_protoc = use_extension(

--- a/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
+++ b/dt_patches/test_dt_patches_user_srcjar/WORKSPACE
@@ -142,8 +142,8 @@ srcjars_by_version = {
     "3.6.4": {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.6.4/scala3-compiler_3-3.6.4-sources.jar",
     },
-    "3.7.2": {
-        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.2/scala3-compiler_3-3.7.2-sources.jar",
+    "3.7.3": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.3/scala3-compiler_3-3.7.3-sources.jar",
     },
 }
 

--- a/examples/scala3/WORKSPACE
+++ b/examples/scala3/WORKSPACE
@@ -57,7 +57,7 @@ scala_protoc_toolchains(name = "rules_scala_protoc_toolchains")
 
 load("@rules_scala//:scala_config.bzl", "scala_config")
 
-scala_config(scala_version = "3.7.2")
+scala_config(scala_version = "3.7.3")
 
 load(
     "@rules_scala//scala:toolchains.bzl",

--- a/scala/private/macros/compiler_sources_integrity.bzl
+++ b/scala/private/macros/compiler_sources_integrity.bzl
@@ -277,4 +277,8 @@ COMPILER_SOURCES = {
         "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.2/scala3-compiler_3-3.7.2-sources.jar",
         "integrity": "sha256-OTs9ZH2xRRy074xVBiFgxnm56RmOQ+gfnyv3BiL1JDQ=",
     },
+    "3.7.3": {
+        "url": "https://repo1.maven.org/maven2/org/scala-lang/scala3-compiler_3/3.7.3/scala3-compiler_3-3.7.3-sources.jar",
+        "integrity": "sha256-NKSflC15KDDBJ/GLEr0BCSVr7FnxX20VF9VyrbhbGXQ=",
+    },
 }

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -51,7 +51,7 @@ options:
                         Scala version for which to update repository
                         information; if not provided, updates all supported
                         versions: 2.11.12, 2.12.20, 2.13.16, 3.1.3, 3.2.2,
-                        3.3.6, 3.4.3, 3.5.2, 3.6.4, 3.7.2
+                        3.3.6, 3.4.3, 3.5.2, 3.6.4, 3.7.3
   --output_dir OUTPUT_DIR
                         Directory in which to generate or update repository
                         files (default: .../third_party/repositories)

--- a/scripts/create_repository.py
+++ b/scripts/create_repository.py
@@ -24,7 +24,7 @@ ROOT_SCALA_VERSIONS = [
     "3.4.3",
     "3.5.2",
     "3.6.4",
-    "3.7.2",
+    "3.7.3",
 ]
 PARSER_COMBINATORS_VERSION = '1.1.2'
 SBT_COMPILER_INTERFACE_VERSION = '1.10.8'

--- a/scripts/update_compiler_sources_integrity.py
+++ b/scripts/update_compiler_sources_integrity.py
@@ -37,7 +37,7 @@ SCALA_VERSIONS = [
 ] + [
     f'3.6.{patch}' for patch in range(0, 5)    # 3.6.0  to 3.6.4
 ] + [
-    f'3.7.{patch}' for patch in range(0, 3)    # 3.7.0  to 3.7.2
+    f'3.7.{patch}' for patch in range(0, 4)    # 3.7.0  to 3.7.3
 ]
 
 DATA_MARKER = "COMPILER_SOURCES = "

--- a/test/shell/test_examples.sh
+++ b/test/shell/test_examples.sh
@@ -58,7 +58,7 @@ test_scala3_6_example() {
 }
 
 test_scala3_7_example() {
-   run_in_example_dir scala3 bazel build --repo_env=SCALA_VERSION=3.7.2 //...
+   run_in_example_dir scala3 bazel build --repo_env=SCALA_VERSION=3.7.3 //...
 }
 
 test_semanticdb_example() {

--- a/test_thirdparty_version.sh
+++ b/test_thirdparty_version.sh
@@ -15,7 +15,7 @@ runner=$(get_test_runner "${1:-local}")
 
 
 # Latest version of each major version
-$runner test_scala_version "3.7.2" # Latest Next version
+$runner test_scala_version "3.7.3" # Latest Next version
 $runner test_scala_version "3.3.6" # Latest LTS version
 $runner test_scala_version "3.1.3" # First supported major for Scala 3, max supported JDK=18
 $runner test_scala_version "2.13.16"

--- a/third_party/repositories/scala_3_7.bzl
+++ b/third_party/repositories/scala_3_7.bzl
@@ -3,7 +3,7 @@
 Mostly generated and updated by scripts/create_repository.py.
 """
 
-scala_version = "3.7.2"
+scala_version = "3.7.3"
 
 artifacts = {
     "com_github_jnr_jffi_native": {
@@ -190,8 +190,8 @@ artifacts = {
         "sha256": "86af037580bdf9ce9c05f8b2afd734daf1a8564c38cd10ca5d08bf81508ad2e4",
     },
     "io_bazel_rules_scala_scala_compiler": {
-        "artifact": "org.scala-lang:scala3-compiler_3:3.7.2",
-        "sha256": "3ecbe87d6b0f8d86cccc8eb6ad83b62126ad714a4cc8eb00afa3e7b481518303",
+        "artifact": "org.scala-lang:scala3-compiler_3:3.7.3",
+        "sha256": "83c0666d468878edd7671f28472c759e5ac16a6e94180b2e5a45298a9e1de26e",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@io_bazel_rules_scala_scala_interfaces",
@@ -214,12 +214,12 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_scala_interfaces": {
-        "artifact": "org.scala-lang:scala3-interfaces:3.7.2",
-        "sha256": "d151e52bfcc44c071e32baaca73f2d73dc7eca3f942ec5ce16f221d1a7b69ef2",
+        "artifact": "org.scala-lang:scala3-interfaces:3.7.3",
+        "sha256": "1600b0f69299f89f7655ae48722465db46e5d966a3c5019e39dfe855d486d001",
     },
     "io_bazel_rules_scala_scala_library": {
-        "artifact": "org.scala-lang:scala3-library_3:3.7.2",
-        "sha256": "241209cceff9876f491865e683109d02f32cf90bdff5cc6c2034661f56145e95",
+        "artifact": "org.scala-lang:scala3-library_3:3.7.3",
+        "sha256": "265c593f80d3391b869e2daa206155cdd00702b35ec5a096fcf18dddad10e1b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -250,8 +250,8 @@ artifacts = {
         ],
     },
     "io_bazel_rules_scala_scala_tasty_core": {
-        "artifact": "org.scala-lang:tasty-core_3:3.7.2",
-        "sha256": "125b791d4ddcf5a187afae1de5158067dfbbfe96f7eaea73400d97cc60e74ad1",
+        "artifact": "org.scala-lang:tasty-core_3:3.7.3",
+        "sha256": "26d6f7cac567090bc0cbb7aba63e5aa9608c894a94f8203602eea186fd46dee8",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],


### PR DESCRIPTION
### Description
Upgrades Scala 3.7 to 3.7.3 as part of release process procedure https://github.com/scala/scala3/issues/23887

### Motivation

https://github.com/scala/scala3/issues/23887