### PR TITLE
Remove unused imports from dependency_analyzer

### DIFF
--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/AstUsedJarFinder.scala
@@ -1,17 +1,16 @@
 package io.bazel.rulesscala.dependencyanalyzer
 
-import dotty.tools.dotc.core.{Annotations, Flags, NameKinds, StdNames}
 
 import scala.collection.mutable
 import dotty.tools.io.AbstractFile
+import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.util.SourcePosition
 import dotty.tools.dotc.core.Types.Type
 import dotty.tools.dotc.core.Constants.*
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.core.Symbols.*
-import dotty.tools.dotc.core.Annotations.Annotation
-import dotty.tools.dotc.ast.tpd.*
 import dotty.tools.dotc.core.StdNames.nme
+import dotty.tools.dotc.core.NameKinds
 
 extension (value: String) {
   def isTastyFile: Boolean = value.endsWith(".tasty")

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala
@@ -1,28 +1,18 @@
 package io.bazel.rulesscala.dependencyanalyzer
 
-import dotty.tools.dotc.ast.Trees.*
-import dotty.tools.dotc.ast.tpd
-import dotty.tools.dotc.core.Constants.Constant
 import dotty.tools.dotc.core.Contexts.{Context, ctx}
-import dotty.tools.dotc.core.Decorators.*
-import dotty.tools.dotc.core.Phases
-import dotty.tools.dotc.core.StdNames.*
-import dotty.tools.dotc.core.Symbols.*
 import dotty.tools.dotc.util.{NoSourcePosition, SrcPos}
 import dotty.tools.dotc.plugins.{PluginPhase, StandardPlugin}
 import dotty.tools.dotc.report
-import dotty.tools.dotc.typer.Typer
 import dotty.tools.backend.jvm
 import dotty.tools.dotc.transform
 
 import java.util.jar.JarFile
 import dotty.tools.io.AbstractFile
-import io.bazel.rulesscala.dependencyanalyzer.DependencyTrackingMethod.Ast
 import io.bazel.rulesscala.scalac.reporter.DepsTrackingReporter
 
 import java.util.Locale
 import scala.jdk.CollectionConverters.*
-import scala.util.control.NonFatal
 
 class DependencyAnalyzer extends StandardPlugin:
   override val name: String = "dependency-analyzer"

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/HighLevelCrawlUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/HighLevelCrawlUsedJarFinder.scala
@@ -5,7 +5,6 @@ import dotty.tools.dotc.util.{NoSourcePosition, SourcePosition}
 import dotty.tools.dotc.core.Contexts.{Context, atPhase, ctx}
 import dotty.tools.dotc.core.{Flags, Phases}
 import dotty.tools.dotc.core.Symbols.Symbol
-import dotty.tools.dotc.core.Types.Type
 
 import scala.collection.mutable
 


### PR DESCRIPTION
Removes unused imports from dependency_analyzer - these would warn when building in user projects