### PR TITLE
Bump to rules_go 0.58.2, update Go in `WORKSPACE`

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_scala",
-    version = "7.1.3",
+    version = "7.1.4",
     bazel_compatibility = [">=7.1.0"],
     compatibility_level = 7,
 )
@@ -257,19 +257,10 @@ bazel_dep(
 )
 bazel_dep(
     name = "rules_go",
-    version = "0.57.0",
+    version = "0.58.2",
     dev_dependency = True,
     repo_name = "io_bazel_rules_go",  # for com_github_bazelbuild_buildtools
 )
-
-# Temporary workaround until rules_go > 0.57.0 becomes available to resolve:
-# https://github.com/bazel-contrib/rules_go/issues/4480
-git_override(
-    module_name = "rules_go",
-    commit = "74199c92e20399b6ef46684b2c6fdd94b50a7892",
-    remote = "https://github.com/bazel-contrib/rules_go.git",
-)
-
 bazel_dep(name = "gazelle", version = "0.45.0", dev_dependency = True)
 
 go_sdk = use_extension(

--- a/WORKSPACE
+++ b/WORKSPACE
@@ -106,10 +106,10 @@ local_repository(
 
 http_archive(
     name = "io_bazel_rules_go",
-    sha256 = "a729c8ed2447c90fe140077689079ca0acfb7580ec41637f312d650ce9d93d96",
+    sha256 = "54bbb67a4196170cc60ef3b52a2747ad1759cba4764b4c4752b744080ad99947",
     urls = [
-        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip",
-        "https://github.com/bazel-contrib/rules_go/releases/download/v0.57.0/rules_go-v0.57.0.zip",
+        "https://mirror.bazel.build/github.com/bazel-contrib/rules_go/releases/download/v0.58.2/rules_go-v0.58.2.zip",
+        "https://github.com/bazel-contrib/rules_go/releases/download/v0.58.2/rules_go-v0.58.2.zip",
     ],
 )
 
@@ -121,7 +121,7 @@ load(
 
 go_rules_dependencies()
 
-go_register_toolchains(version = "1.25.1")
+go_register_toolchains(version = "1.25.3")
 
 http_archive(
     name = "bazelci_rules",


### PR DESCRIPTION
### Description

Updates `rules_go` to 0.58.2 per bazel-contrib/rules_go#4480, and removes the temporary `git_override`. Updates Go to 1.25.3 in `WORKSPACE`.

Also bumps the module version in `MODULE.bazel` to 7.1.4 in advance of the next release.

### Motivation

The Go version update in `WORKSPACE` should've been in #1778, but I missed including it. `rules_go` is a dev dep only required for linting, so the impact of this oversight was minimal, but still worth correcting.

Bumped the `MODULE.bazel` version number to indicate that changes from this point will be part of the next release.