### PR TITLE
Improve test efficiency, reduce lock file size

### DIFF
--- a/dt_patches/dt_patch_test.sh
+++ b/dt_patches/dt_patch_test.sh
@@ -16,7 +16,6 @@ run_in_test_repo() {
   cd "${dir}/${test_repo}" || return 1
   "${test_command[@]}" || response_code=$?
 
-  bazel shutdown
   cd ../..
   return $response_code
 }
@@ -120,6 +119,8 @@ $runner test_compiler_patch 3.5.2
 $runner test_compiler_patch 3.6.4
 $runner test_compiler_patch 3.7.3
 
+run_in_test_repo 'test_dt_patches' bazel shutdown
+
 $runner test_compiler_srcjar_error 2.12.11
 $runner test_compiler_srcjar_error 2.12.12
 $runner test_compiler_srcjar_error 2.12.13
@@ -152,3 +153,5 @@ $runner test_compiler_srcjar 3.4.3
 $runner test_compiler_srcjar_nonhermetic 3.5.2
 $runner test_compiler_srcjar_nonhermetic 3.6.4
 $runner test_compiler_srcjar_nonhermetic 3.7.3
+
+run_in_test_repo 'test_dt_patches_user_srcjar' bazel shutdown

--- a/dt_patches/test_dt_patches/MODULE.bazel
+++ b/dt_patches/test_dt_patches/MODULE.bazel
@@ -56,7 +56,6 @@ scala_deps.settings(
     fetch_sources = True,
     validate_scala_version = False,
 )
-scala_deps.scala()
 
 scala_protoc = use_extension(
     "@rules_scala//scala/extensions:protoc.bzl",

--- a/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel
+++ b/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel
@@ -66,7 +66,6 @@ scala_deps.settings(
     fetch_sources = True,
     validate_scala_version = False,
 )
-scala_deps.scala()
 
 # The `scala_deps.compiler_srcjar()` tag prevents some of the kinds of errors
 # represented in the corresponding `WORKSPACE` file, so we have to force

--- a/test/compiler_sources_integrity/MODULE.bazel
+++ b/test/compiler_sources_integrity/MODULE.bazel
@@ -23,7 +23,6 @@ scala_deps = use_extension(
     "@rules_scala//scala/extensions:deps.bzl",
     "scala_deps",
 )
-scala_deps.scala()
 scala_deps.settings(
     # Since we're using a bogus Scala version in the compiler_srcjar.
     validate_scala_version = False,

--- a/test/shell/test_examples.sh
+++ b/test/shell/test_examples.sh
@@ -17,7 +17,11 @@ run_in_example_dir(){
   set -e
   cd "examples/${test_dir}"
   "$@"
-  bazel shutdown
+
+  # Don't shut down in `scala3` since multiple test cases run there.
+  if [[ "$test_dir" != 'scala3' ]]; then
+    bazel shutdown
+  fi
   cd "$dir"
 }
 


### PR DESCRIPTION
### Description

Removes unnecessary `scala_deps.scala()` tags from the `dt_patches/test_dt_patches{,_user_srcjar}` and
`test/compiler_sources_integrity` modules. Removes `bazel shutdown` commands to speed up several tests, notably
`dt_patches/dt_patch_test.sh` and `test/shell/test_examples.sh`.

### Motivation

These changes are broken out from a larger change to commit `MODULE.bazel.lock` files. That upcoming change will explain the rationale for doing so, but these changes stand alone as incremental improvements in their own right.

Removing the `scala_deps.scala()` tags prevents the `scala_deps` extension from creating repos for the default Scala toolchain. These particular tests define their own Scala toolchains, so the tests still pass without the extra default Scala toolchain footprint. This has the additional benefit of making the resulting `MODULE.bazel.lock` files much smaller.

The test speedups from removing `bazel shutdown` were opportunistic improvements during the course of the `MODULE.bazel.lock` investigation.