### PR TITLE
Bump MODULE.bazel version to 7.1.6

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,7 +2,7 @@
 
 module(
     name = "rules_scala",
-    version = "7.1.5",
+    version = "7.1.6",
     bazel_compatibility = [">=7.1.0"],
     compatibility_level = 7,
 )

--- a/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel.lock
+++ b/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel.lock
@@ -453,7 +453,7 @@
     "@@rules_scala+//scala/extensions:deps.bzl%scala_deps": {
       "general": {
         "bzlTransitiveDigest": "Pbs3qR6XxBIU3KPkBHWgGRo9+CX2tOYxACqqBnelySs=",
-        "usagesDigest": "8IXUR0nfFUw8lL2Iq/Hri8opy/YvV/YptUPCf4yOUKQ=",
+        "usagesDigest": "ruoPS+B0GFzUh+gGVmZLW6MncjrYOsIoA80c66fnxs4=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},

--- a/test/compiler_sources_integrity/MODULE.bazel.lock
+++ b/test/compiler_sources_integrity/MODULE.bazel.lock
@@ -154,7 +154,7 @@
     "@@rules_scala+//scala/extensions:deps.bzl%scala_deps": {
       "general": {
         "bzlTransitiveDigest": "VJ/Onb2HehVphO/ZgQSm9V+fF+D9X+RMLwpYAp+QzcY=",
-        "usagesDigest": "9WfEiaTUYgMHAMuVJWU2JX5TpPXP+8Yo9/9vCyNs/lM=",
+        "usagesDigest": "E48xjJvy1fbKD6elEvwuRwO2acCG0h5IEYCj4D9+wwo=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},


### PR DESCRIPTION
### Description

Also updates `usagesDigest` in a couple of test repo `MODULE.bazel.lock` files.

### Motivation

This is minor housekeeping before publishing the v7.1.6 release.

We may consider whether it's worth continuing to update the version number like this or using a different schema. The Bazel Central Registry will always update the published `MODULE.bazel` file to contain the correct version number. See:

- https://github.com/bazel-contrib/publish-to-bcr/blob/v1.0.0/src/domain/create-entry.ts#L176-L216