### PR TITLE
Set the `module` version to the empty string

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -2,6 +2,10 @@
 
 module(
     name = "rules_scala",
+    # The publish-to-bcr GitHub workflow supplies the actual `version`. See:
+    # - https://bazel.build/external/faq#module-versioning-best-practices
+    # - https://github.com/bazel-contrib/publish-to-bcr/blob/v1.1.0/src/domain/create-entry.ts#L176-L216
+    version = "",
     bazel_compatibility = [">=7.1.0"],
     compatibility_level = 7,
 )

--- a/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel.lock
+++ b/dt_patches/test_dt_patches_user_srcjar/MODULE.bazel.lock
@@ -507,7 +507,7 @@
     },
     "@@rules_scala+//scala/extensions:deps.bzl%scala_deps": {
       "general": {
-        "bzlTransitiveDigest": "+HYwWeo8aAS1reeQ1JopSLU7+HyL5leaOScazD3ECAU=",
+        "bzlTransitiveDigest": "HkxJxz769jETusc4DwltK7OSUFTZvc0TpKyU2NqI048=",
         "usagesDigest": "RhEVxjy8CxkiGqP+oFg4mGxho35MdPAe4EvxntsGUHc=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},

--- a/test/compiler_sources_integrity/MODULE.bazel.lock
+++ b/test/compiler_sources_integrity/MODULE.bazel.lock
@@ -208,7 +208,7 @@
   "moduleExtensions": {
     "@@rules_scala+//scala/extensions:deps.bzl%scala_deps": {
       "general": {
-        "bzlTransitiveDigest": "R/Azcnn7t08HQuDl2Jen18fmyLVoDQaqiLPf8jwqivY=",
+        "bzlTransitiveDigest": "Uor/7mlsxEr9AjU8NvIZr4Y2Lgb6PbxWOy6ACr2odXg=",
         "usagesDigest": "++Pdd9JmPaPmU/O7KE5Zg3O8ijhTJkbehSpxeui8g8o=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},


### PR DESCRIPTION
### Description

Fixes the Bazel Central Registry publication breakage from bazelbuild/bazel-central-registry#7363 by restoring the `version` parameter to the `module` directive. Follows the guidance to set `version` to the empty string from:

- https://bazel.build/external/faq#module-versioning-best-practices

Also contains `MODULE.bazel.lock` updates that should've been included in #1803.

### Motivation

I pushed the `v7.2.0` tag after merging #1803, and the GitHub archive relase itself published successfully:

- https://github.com/bazel-contrib/rules_scala/releases/tag/v7.2.0

In bazelbuild/bazel-central-registry#7363, the Publish to BCR workflow for 7.2.0 updated the `bazel_skylib` version instead of the `module` version. The relevant code for the `version` replacement is:

- https://github.com/bazel-contrib/publish-to-bcr/blob/v1.1.0/src/domain/create-entry.ts#L176-L216
- https://github.com/bazel-contrib/publish-to-bcr/blob/v1.1.0/src/domain/module-file.ts#L44-L58

Apparently, the `this.version !== undefined` condition at `module-file.ts:45` evaluated to `true`. This may be because the `ModuleFile.version` regex isn't quite correct, and the existing test didn't catch it:

- https://github.com/bazel-contrib/publish-to-bcr/blob/v1.1.0/src/domain/module-file.ts#L34-L38
- https://github.com/bazel-contrib/publish-to-bcr/blob/v1.1.0/src/domain/module-file.spec.ts#L66-L73

It's a bug worth fixing in the workflow, and I'll investigate and possibly send a pull request later. For now, setting `version = ""` is a reasonable workaround to publish a new `rules_scala` release (which will have to be v7.2.1).