### PR TITLE
Export .jar files from scala_maven_import_external

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -25,6 +25,12 @@ common --incompatible_enable_proto_toolchain_resolution
 # - https://protobuf.dev/news/2026-01-16/
 common --@rules_scala//protoc:prefer_prebuilt_protoc
 
+# Remove once bazelbuild/bazel@0b8a518ba4074d0be1dedd6a922663fd0bf1441c makes it
+# into the default release.
+# - https://bazel.build/reference/command-line-reference#common_options-flag--incompatible_no_implicit_file_export
+# - https://github.com/bazelbuild/bazel/pull/27674
+common --incompatible_no_implicit_file_export
+
 build --enable_platform_specific_config
 
 # Use Java 17+ required for Scala 3.8+

--- a/scala/scala_maven_import_external.bzl
+++ b/scala/scala_maven_import_external.bzl
@@ -103,6 +103,8 @@ def _jvm_import_external_impl(repository_ctx):
 
     lines.append("licenses(%s)" % repr(repository_ctx.attr.licenses))
     lines.append("")
+    lines.append("exports_files([\"%s\"])" % path)
+    lines.append("")
     lines.extend(
         _serialize_given_rule_import(
             repository_ctx.attr.rule_name,


### PR DESCRIPTION
### Description

Emits an `exports_files` directive for the `.jar` files included in repositories generated by `scala_maven_import_external`.

### Motivation

Follow-up from #1812 that fixes `last_green` builds, which now incorporate the `--incompatible_no_implicit_file_export` flag flip from:

- bazelbuild/bazel@0b8a518ba4074d0be1dedd6a922663fd0bf1441c
- bazelbuild/bazel#27674