### PR TITLE
Restore compatibility_level, yank 7.2.3

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -3,7 +3,7 @@ validate_config: 1
 
 matrix:
   bcr_platform: ["debian10", "macos", "ubuntu2004", "windows"]
-  bcr_bazel: ["7.x", "8.x", "9.x", "rolling", "last_green"]
+  bcr_bazel: [7.x, 8.x, 9.x, rolling, last_green]
 
 tasks:
   ubuntu2004:

--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -3,7 +3,7 @@ bcr_test_module:
   module_path: "examples/crossbuild"
   matrix:
     platform: ["debian10", "macos", "ubuntu2004", "windows"]
-    bazel: ["7.x", "8.x", "9.x", "rolling", "last_green"]
+    bazel: [7.x, 8.x, 9.x, rolling, last_green]
   tasks:
     run_tests:
       name: "Build and test the example module"


### PR DESCRIPTION
### Description

Restores `compatibility_level = 7` to the `module` directive and yanks version 7.2.3 from the Bazel Central Registry.

### Motivation

Per #1816, #1815 removed the `compatibility_level` attribute of the `module` directive too soon. Builds using Bazel <8.6.0 or <9.1.0 with other `rules_scala` 7.x dependencies in the build graph would break once any module introduces `rules_scala` 7.2.3.