### PR TITLE
[gazelle][1/5] add gotreesitter scala parser proof (no cgo)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -281,13 +281,25 @@ go_deps.module(
     version = "v0.42.0",
 )
 go_deps.module(
+    path = "github.com/odvcencio/gotreesitter",
+    sum = "h1:L+EJxVoPsnfPPGaPfrd6DVRy1BI8zRRSQUitDH4vFzE=",
+    version = "v0.6.1-0.20260304061736-42d29f901563",
+)
+go_deps.module(
     path = "github.com/golang/protobuf",
     sum = "h1:i7eJL8qZTpSEXOPTxNKhASYpMn+8e5Q6AdndVa1dWek=",
     version = "v1.5.4",
 )
+go_deps.module(
+    path = "gopkg.in/yaml.v3",
+    sum = "h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=",
+    version = "v3.0.1",
+)
 use_repo(
     go_deps,
     "com_github_golang_protobuf",
+    "com_github_odvcencio_gotreesitter",
+    "in_gopkg_yaml_v3",
     "org_golang_x_tools",
 )
 

--- a/src/gazelle/private/scalaparser/BUILD.bazel
+++ b/src/gazelle/private/scalaparser/BUILD.bazel
@@ -1,0 +1,19 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
+
+go_library(
+    name = "scalaparser",
+    srcs = ["parser.go"],
+    importpath = "github.com/bazelbuild/rules_scala/src/gazelle/private/scalaparser",
+    visibility = ["//visibility:public"],
+    deps = [
+        "@com_github_odvcencio_gotreesitter//:gotreesitter",
+        "@com_github_odvcencio_gotreesitter//grammars",
+    ],
+)
+
+go_test(
+    name = "scalaparser_test",
+    srcs = ["parser_test.go"],
+    embed = [":scalaparser"],
+    pure = "on",
+)

--- a/src/gazelle/private/scalaparser/parser.go
+++ b/src/gazelle/private/scalaparser/parser.go
@@ -1,0 +1,316 @@
+package scalaparser
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"unicode"
+	"unicode/utf8"
+
+	"github.com/odvcencio/gotreesitter"
+	"github.com/odvcencio/gotreesitter/grammars"
+)
+
+var (
+	scalaLang       = grammars.DetectLanguage("Test.scala").Language()
+	scalaParserPool = gotreesitter.NewParserPool(scalaLang)
+)
+
+type FileMetadata struct {
+	Package          string
+	ImportedClasses  []string
+	ImportedPackages []string
+	ExportedSymbols  []string
+}
+
+type Parser struct {
+	parserPool *gotreesitter.ParserPool
+	lang       *gotreesitter.Language
+}
+
+func New() *Parser {
+	return &Parser{
+		parserPool: scalaParserPool,
+		lang:       scalaLang,
+	}
+}
+
+func Parse(content []byte) (*FileMetadata, error) {
+	return New().Parse(content)
+}
+
+func (p *Parser) Parse(content []byte) (*FileMetadata, error) {
+	tree, err := p.parserPool.Parse(content)
+	if err != nil {
+		return nil, fmt.Errorf("parse scala: %w", err)
+	}
+	if tree == nil || tree.RootNode() == nil {
+		return nil, fmt.Errorf("parse scala: nil tree")
+	}
+	defer tree.Release()
+
+	root := tree.RootNode()
+	classImports := map[string]struct{}{}
+	pkgImports := map[string]struct{}{}
+	exported := map[string]struct{}{}
+	parsedPackage := ""
+
+	for i := 0; i < root.NamedChildCount(); i++ {
+		child := root.NamedChild(i)
+		switch child.Type(p.lang) {
+		case "package_clause":
+			pkgPart := parsePackageClause(child, p.lang, content)
+			if pkgPart == "" {
+				continue
+			}
+			if parsedPackage == "" {
+				parsedPackage = pkgPart
+			} else {
+				parsedPackage += "." + pkgPart
+			}
+		case "import_declaration":
+			extractImportDeclaration(child, p.lang, content, classImports, pkgImports)
+		case "class_definition", "trait_definition":
+			if name := parseTopLevelTypeName(child, p.lang, content); name != "" &&
+				!hasPrivateOrProtectedModifier(child, p.lang, content) {
+				exported[name] = struct{}{}
+			}
+		case "object_definition":
+			if name := parseTopLevelTypeName(child, p.lang, content); name != "" &&
+				!hasPrivateOrProtectedModifier(child, p.lang, content) {
+				exported[name] = struct{}{}
+			}
+		case "postfix_expression", "infix_expression":
+			_, name, privateLike := extractScalaPostfixLikeDecl(child, p.lang, content)
+			if name != "" && !privateLike {
+				exported[name] = struct{}{}
+			}
+		}
+	}
+
+	exportedFQNs := make([]string, 0, len(exported))
+	for symbol := range exported {
+		if parsedPackage == "" {
+			exportedFQNs = append(exportedFQNs, symbol)
+		} else {
+			exportedFQNs = append(exportedFQNs, parsedPackage+"."+symbol)
+		}
+	}
+	sort.Strings(exportedFQNs)
+
+	return &FileMetadata{
+		Package:          parsedPackage,
+		ImportedClasses:  sortedKeys(classImports),
+		ImportedPackages: sortedKeys(pkgImports),
+		ExportedSymbols:  exportedFQNs,
+	}, nil
+}
+
+func parsePackageClause(node *gotreesitter.Node, lang *gotreesitter.Language, content []byte) string {
+	packageIdentifier := findFirstNamedChild(node, lang, "package_identifier")
+	if packageIdentifier == nil {
+		return ""
+	}
+	return normalizeQualified(packageIdentifier.Text(content))
+}
+
+func parseTopLevelTypeName(node *gotreesitter.Node, lang *gotreesitter.Language, content []byte) string {
+	return findFirstNamedChildText(node, content, lang, "identifier")
+}
+
+func extractImportDeclaration(
+	node *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	content []byte,
+	classImports map[string]struct{},
+	pkgImports map[string]struct{},
+) {
+	identifiers := make([]string, 0, 4)
+	var selectors *gotreesitter.Node
+	hasWildcard := false
+
+	for i := 0; i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		switch child.Type(lang) {
+		case "identifier":
+			identifiers = append(identifiers, child.Text(content))
+		case "namespace_wildcard":
+			hasWildcard = true
+		case "namespace_selectors":
+			selectors = child
+		}
+	}
+
+	if len(identifiers) == 0 {
+		return
+	}
+
+	prefix := normalizeQualified(strings.Join(identifiers, "."))
+	if prefix == "" {
+		return
+	}
+
+	if hasWildcard {
+		pkgImports[prefix] = struct{}{}
+		return
+	}
+
+	if selectors != nil {
+		importedAnyClass := false
+		for _, sel := range extractScalaImportSelectors(selectors, lang, content) {
+			if sel.original == "" || !isLikelyTypeName(sel.original) {
+				continue
+			}
+			classImports[prefix+"."+sel.original] = struct{}{}
+			importedAnyClass = true
+		}
+		if !importedAnyClass {
+			pkgImports[prefix] = struct{}{}
+		}
+		return
+	}
+
+	last := identifiers[len(identifiers)-1]
+	if isLikelyTypeName(last) {
+		classImports[prefix] = struct{}{}
+		return
+	}
+
+	if pkg := pathWithoutLastSegment(prefix); pkg != "" {
+		pkgImports[pkg] = struct{}{}
+	} else {
+		pkgImports[prefix] = struct{}{}
+	}
+}
+
+type scalaImportSelector struct {
+	original string
+}
+
+func extractScalaImportSelectors(
+	selectors *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	content []byte,
+) []scalaImportSelector {
+	out := make([]scalaImportSelector, 0, selectors.NamedChildCount())
+	for i := 0; i < selectors.NamedChildCount(); i++ {
+		child := selectors.NamedChild(i)
+		switch child.Type(lang) {
+		case "identifier":
+			out = append(out, scalaImportSelector{original: child.Text(content)})
+		case "arrow_renamed_identifier":
+			original := ""
+			for j := 0; j < child.NamedChildCount(); j++ {
+				id := child.NamedChild(j)
+				if id.Type(lang) != "identifier" {
+					continue
+				}
+				if original == "" {
+					original = id.Text(content)
+				}
+			}
+			out = append(out, scalaImportSelector{original: original})
+		}
+	}
+	return out
+}
+
+func extractScalaPostfixLikeDecl(
+	node *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	content []byte,
+) (kind string, name string, isPrivate bool) {
+	idents := make([]string, 0, 3)
+	for i := 0; i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child.Type(lang) == "identifier" {
+			idents = append(idents, child.Text(content))
+		}
+	}
+	if len(idents) < 2 {
+		return "", "", false
+	}
+	if len(idents) == 2 {
+		switch idents[0] {
+		case "object", "trait":
+			return idents[0], idents[1], false
+		}
+	}
+	if len(idents) >= 3 && idents[0] == "private" {
+		switch idents[1] {
+		case "object", "trait":
+			return idents[1], idents[2], true
+		}
+	}
+	return "", "", false
+}
+
+func hasPrivateOrProtectedModifier(
+	node *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	content []byte,
+) bool {
+	modifiers := findFirstNamedChild(node, lang, "modifiers")
+	if modifiers == nil {
+		return false
+	}
+	text := modifiers.Text(content)
+	return strings.Contains(text, "private") || strings.Contains(text, "protected")
+}
+
+func findFirstNamedChild(
+	node *gotreesitter.Node,
+	lang *gotreesitter.Language,
+	typ string,
+) *gotreesitter.Node {
+	for i := 0; i < node.NamedChildCount(); i++ {
+		child := node.NamedChild(i)
+		if child.Type(lang) == typ {
+			return child
+		}
+	}
+	return nil
+}
+
+func findFirstNamedChildText(
+	node *gotreesitter.Node,
+	content []byte,
+	lang *gotreesitter.Language,
+	typ string,
+) string {
+	child := findFirstNamedChild(node, lang, typ)
+	if child == nil {
+		return ""
+	}
+	return child.Text(content)
+}
+
+func isLikelyTypeName(name string) bool {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return false
+	}
+	r, _ := utf8.DecodeRuneInString(name)
+	return unicode.IsUpper(r)
+}
+
+func pathWithoutLastSegment(path string) string {
+	lastDot := strings.LastIndex(path, ".")
+	if lastDot == -1 {
+		return ""
+	}
+	return path[:lastDot]
+}
+
+func normalizeQualified(path string) string {
+	return strings.TrimPrefix(strings.TrimSpace(path), "_root_.")
+}
+
+func sortedKeys(set map[string]struct{}) []string {
+	out := make([]string, 0, len(set))
+	for k := range set {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}

--- a/src/gazelle/private/scalaparser/parser_test.go
+++ b/src/gazelle/private/scalaparser/parser_test.go
@@ -1,0 +1,128 @@
+package scalaparser
+
+import (
+	"fmt"
+	"reflect"
+	"sync"
+	"testing"
+)
+
+func TestParseExtractsScalaMetadata(t *testing.T) {
+	source := []byte(`
+package com.example
+
+import java.util.List
+import com.acme.tools._
+import scala.util.{Try => T, Success}
+
+class PublicClass
+trait PublicTrait
+object PublicObj
+private class PrivateImpl
+private object PrivateObj
+`)
+
+	metadata, err := Parse(source)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	if metadata.Package != "com.example" {
+		t.Fatalf("Package = %q, want %q", metadata.Package, "com.example")
+	}
+
+	wantClasses := []string{
+		"java.util.List",
+		"scala.util.Success",
+		"scala.util.Try",
+	}
+	if !reflect.DeepEqual(metadata.ImportedClasses, wantClasses) {
+		t.Fatalf("ImportedClasses = %v, want %v", metadata.ImportedClasses, wantClasses)
+	}
+
+	wantPackages := []string{"com.acme.tools"}
+	if !reflect.DeepEqual(metadata.ImportedPackages, wantPackages) {
+		t.Fatalf("ImportedPackages = %v, want %v", metadata.ImportedPackages, wantPackages)
+	}
+
+	wantExported := []string{
+		"com.example.PublicClass",
+		"com.example.PublicObj",
+		"com.example.PublicTrait",
+	}
+	if !reflect.DeepEqual(metadata.ExportedSymbols, wantExported) {
+		t.Fatalf("ExportedSymbols = %v, want %v", metadata.ExportedSymbols, wantExported)
+	}
+}
+
+func TestParseConcatenatesNestedPackageClauses(t *testing.T) {
+	source := []byte(`
+package com.example
+package api
+
+import foo.bar.Baz
+
+object Endpoints
+`)
+
+	metadata, err := Parse(source)
+	if err != nil {
+		t.Fatalf("Parse() error: %v", err)
+	}
+
+	if metadata.Package != "com.example.api" {
+		t.Fatalf("Package = %q, want %q", metadata.Package, "com.example.api")
+	}
+
+	wantClasses := []string{"foo.bar.Baz"}
+	if !reflect.DeepEqual(metadata.ImportedClasses, wantClasses) {
+		t.Fatalf("ImportedClasses = %v, want %v", metadata.ImportedClasses, wantClasses)
+	}
+
+	wantExported := []string{"com.example.api.Endpoints"}
+	if !reflect.DeepEqual(metadata.ExportedSymbols, wantExported) {
+		t.Fatalf("ExportedSymbols = %v, want %v", metadata.ExportedSymbols, wantExported)
+	}
+}
+
+func TestParseConcurrent(t *testing.T) {
+	source := []byte(`
+package com.example
+import java.util.List
+class App
+`)
+
+	const workers = 12
+	const rounds = 40
+
+	var wg sync.WaitGroup
+	errCh := make(chan error, workers*rounds)
+
+	for i := 0; i < workers; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for j := 0; j < rounds; j++ {
+				metadata, err := Parse(source)
+				if err != nil {
+					errCh <- err
+					return
+				}
+				if metadata.Package != "com.example" {
+					errCh <- fmt.Errorf("package = %q, want com.example", metadata.Package)
+					return
+				}
+				if len(metadata.ExportedSymbols) != 1 || metadata.ExportedSymbols[0] != "com.example.App" {
+					errCh <- fmt.Errorf("exported = %v, want [com.example.App]", metadata.ExportedSymbols)
+					return
+				}
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errCh)
+	for err := range errCh {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
## Summary
This is PR **1/5** in the Scala Gazelle parser stack.

This PR is **Phase 1** of bringing Scala parser functionality over to a **native (no-cgo)** implementation path, with the goal of preserving and extending capabilities that were previously constrained by cgo-backed approaches.

It introduces a minimal in-tree Scala parser proof package backed by `github.com/odvcencio/gotreesitter` and wired through Bazel `go_library/go_test` targets.

### What this PR adds
- new package: `src/gazelle/private/scalaparser`
- parser API that extracts:
  - package clauses (including nested package clauses)
  - imported classes and wildcard-import packages
  - exported top-level symbols (class/trait/object), excluding private/protected declarations
- concurrency test validating parser-pool safety
- `go_deps` pin for `gotreesitter` and required repo wiring in `MODULE.bazel`

### No-cgo proof
The parser test target passes with pure mode enabled:

```bash
bazel test //src/gazelle/private/scalaparser:scalaparser_test --@io_bazel_rules_go//go/config:pure
```

## Why this is split as PR1
This keeps scope intentionally small: parser substrate only, no rule-generation or resolve integration yet.

Follow-up PRs in the stack will add:
1. parser feature parity expansions based on Foursquare cases
2. Gazelle language wiring behind a flag
3. resolve integration
4. hardening + larger corpus/bench coverage
