### PR TITLE
chore: enable immutable releases

### DIFF
--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -39,6 +39,8 @@ jobs:
       # Necessary to push to the BCR fork and open a pull request.
       publish_token: ${{ secrets.bcr_publish_token }}
   finalize:
+    permissions:
+      contents: write
     needs: publish-to-bcr
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish-to-bcr.yml
+++ b/.github/workflows/publish-to-bcr.yml
@@ -24,7 +24,7 @@ on:
 
 jobs:
   publish-to-bcr:
-    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.0.0
+    uses: bazel-contrib/publish-to-bcr/.github/workflows/publish.yaml@v1.2.0
     with:
       tag_name: ${{ inputs.tag_name }}
       # bazelbuild/bazel-central-registry fork used to open a pull request.
@@ -38,3 +38,11 @@ jobs:
     secrets:
       # Necessary to push to the BCR fork and open a pull request.
       publish_token: ${{ secrets.bcr_publish_token }}
+  finalize:
+    needs: publish-to-bcr
+    runs-on: ubuntu-latest
+    steps:
+      - run: gh release edit "$TAG" --draft=false --repo "$GITHUB_REPOSITORY"
+        env:
+          TAG: ${{ inputs.tag_name }}
+          GH_TOKEN: ${{ github.token }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,10 +27,11 @@ permissions:
 
 jobs:
   release:
-    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.2.3
+    uses: bazel-contrib/.github/.github/workflows/release_ruleset.yaml@v7.4.0
     with:
       bazel_test_command: "bazel test //src/... //test/... //third_party/..."
       prerelease: false
+      draft: true
       release_files: rules_scala-*.tar.gz
       tag_name: ${{ inputs.tag_name || github.ref_name }}
 


### PR DESCRIPTION
### Description
Allow the repo to opt-in to immutable GitHub releases. The release must be a draft until we're done editing files in it, then unset the draft bit in the finalize job.


### Motivation
Gives a guarantee that a misplaced token can't be used to attack published releases. I'd like to enforce this across bazel-contrib eventually.