### PR TITLE
Fix cross-version default dep providers

### DIFF
--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -126,7 +126,7 @@ load(
 )
 load("@rules_scala//scala:providers.bzl", "declare_deps_provider")
 load("@rules_scala//scala:scala_cross_version.bzl", "version_suffix")
-load("@rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
+load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
 
 [
     setup_scala_toolchain(
@@ -137,12 +137,19 @@ load("@rules_scala_config//:config.bzl", "SCALA_VERSION", "SCALA_VERSIONS")
     for scala_version in SCALA_VERSIONS
 ]
 
+# Default dep providers used by _default_dep_providers() in scala_toolchain.bzl.
+# Uses select() so that custom scala_toolchain() callers that don't pass
+# explicit dep_providers get the correct version's deps, including when the
+# scala_version build setting is transitioned (e.g., cross-compilation).
 [
     declare_deps_provider(
         name = deps_id + "_provider",
         deps_id = deps_id,
         visibility = ["//visibility:public"],
-        deps = default_deps(deps_id, SCALA_VERSION),
+        deps = select({{
+            "@rules_scala_config//:scala_version" + version_suffix(v): default_deps(deps_id, v)
+            for v in SCALA_VERSIONS
+        }}),
     )
     for deps_id in [
         "scala_xml",

--- a/test/shell/test_cross_build.sh
+++ b/test/shell/test_cross_build.sh
@@ -11,6 +11,22 @@ function test_cross_build() {
   bazel test //...
 }
 
+function test_cross_build_default_2x() {
+  # Verify cross-major-version compilation when the default is Scala 2.x and
+  # targets use scala_version to select Scala 3.x. Without the select-based
+  # common_toolchain_deps fix, the reporter java_library compiles Scala 3
+  # sources against Scala 2 compiler JARs (wrong toolchain resolved in exec
+  # config), failing with "symbol not found dotty.tools.dotc.*".
+  #
+  # since_3_1 is the target that exercises the fix (default 2.x -> target 3.x).
+  # scala_2_13 and scala_2_12 are sanity checks for same-major cross-minor.
+  bazel build \
+    --repo_env=SCALA_VERSION=2.13.18 \
+    //version_specific:since_3_1 \
+    //version_specific:scala_2_13 \
+    //version_specific:scala_2_12
+}
+
 function test_scalafmt() {
   bazel build //scalafmt/...
 
@@ -23,6 +39,7 @@ function test_scalafmt() {
 }
 
 $runner test_cross_build
+$runner test_cross_build_default_2x
 $runner test_scalafmt
 
 # `bazel shutdown` used to be in `test_cross_build`, after a `bazel clean`.

--- a/test_cross_build/version_specific/BUILD
+++ b/test_cross_build/version_specific/BUILD
@@ -65,3 +65,20 @@ scala_library(
     ],
     scala_version = "3.1.3",
 )
+
+# Cross-major-version targets (default 3.x -> target 2.x).
+# test_cross_build_default_2x in test_cross_build.sh builds existing 3.x
+# targets with --repo_env=SCALA_VERSION=2.13.18 to cover the reverse
+# direction (default 2.x -> target 3.x).
+
+scala_library(
+    name = "scala_2_13",
+    srcs = ["scala_2_only.scala"],
+    scala_version = "2.13.18",
+)
+
+scala_library(
+    name = "scala_2_12",
+    srcs = ["scala_2_only.scala"],
+    scala_version = "2.12.21",
+)

--- a/test_cross_build/version_specific/scala_2_only.scala
+++ b/test_cross_build/version_specific/scala_2_only.scala
@@ -1,0 +1,5 @@
+object Scala2Only {
+  implicit class StringOps(val s: String) extends AnyVal {
+    def twice: String = s + s
+  }
+}


### PR DESCRIPTION
### Description

Change the default `declare_deps_provider` targets in `@rules_scala_toolchains` to use `select()` over `SCALA_VERSIONS` instead of hardcoding `SCALA_VERSION` (the workspace default).

Custom `scala_toolchain()` callers that don't pass explicit `dep_providers` (using `_default_dep_providers()`) were always getting the default version's compiler JARs, regardless of the transitioned `scala_version`. This made cross-compilation between Scala 2.x and 3.x impossible with per-target `scala_version`.

### Motivation

When building a `scala_library` with `scala_version = "3.7.4"` while the workspace default is `"2.13.18"`, the scalac worker's reporter fails to compile. The toolchain resolves correctly (the Scala 3 toolchain is selected), but its `dep_providers` default to unprefixed provider targets that were hardcoded to `SCALA_VERSION`:

    declare_deps_provider(
        deps = default_deps(deps_id, SCALA_VERSION),  # always "2.13.18"
    )

The reporter's `select_for_scala_version` picks Scala 3 Java sources (importing `dotty.tools.dotc.*`), but `scala_compile_classpath` provides Scala 2.13 compiler JARs, causing:

    error: symbol not found dotty.tools.dotc.reporting.AbstractReporter

`setup_scala_toolchain` correctly creates per-version providers, but `_default_dep_providers()` in `scala_toolchain.bzl` returns the unprefixed (default-version) labels. Using `--repo_env=SCALA_VERSION` works around it by changing the default globally.