### PR TITLE
Mark testing toolchain dependencies as testonly

### DIFF
--- a/specs2/BUILD
+++ b/specs2/BUILD
@@ -7,6 +7,7 @@ java_import(
     name = "specs2",
     # `rules_java` 8.12.0 requires that `jars` not be empty. See #1741.
     jars = [":libempty.jar"],
+    testonly = True,
     exports = [
         "//testing/toolchain:specs2_classpath",
     ],

--- a/src/java/io/bazel/rulesscala/specs2/BUILD
+++ b/src/java/io/bazel/rulesscala/specs2/BUILD
@@ -2,6 +2,7 @@ load("//scala:scala.bzl", "scala_library")
 
 scala_library(
     name = "specs2_test_discovery",
+    testonly = True,
     srcs = [
         "Specs2RunnerBuilder.scala",
         "package.scala",

--- a/src/java/io/bazel/rulesscala/test_discovery/BUILD
+++ b/src/java/io/bazel/rulesscala/test_discovery/BUILD
@@ -8,5 +8,6 @@ scala_library(
         "FilteredRunnerBuilder.scala",
     ],
     visibility = ["//visibility:public"],
+    testonly = True,
     deps = ["//testing/toolchain:junit_classpath"],
 )

--- a/testing/testing.bzl
+++ b/testing/testing.bzl
@@ -31,6 +31,7 @@ def _declare_deps_provider(macro_name, deps_id, deps, visibility):
         name = label,
         deps_id = deps_id,
         visibility = visibility,
+        testonly = True,
         deps = deps,
     )
     return ":%s" % label
@@ -89,6 +90,7 @@ def setup_scala_testing_toolchain(
         name = name + "_impl",
         dep_providers = dep_providers,
         visibility = visibility,
+        testonly = True,
     )
 
     native.toolchain(
@@ -99,5 +101,6 @@ def setup_scala_testing_toolchain(
             "@rules_scala_config//:scala_version" +
             version_suffix(scala_version),
         ],
+        testonly = True,
         visibility = visibility,
     )

--- a/testing/toolchain/BUILD
+++ b/testing/toolchain/BUILD
@@ -10,6 +10,7 @@ toolchain_type(
     testing_toolchain_deps(
         name = dep,
         deps_id = dep,
+        testonly = True,
         visibility = ["//visibility:public"],
     )
     for dep in DEP_PROVIDERS


### PR DESCRIPTION
### Description

This PR adds `testonly = True` attributes to targets created by the `setup_scala_testing_toolchain` macro and its constituent dependencies.

Fixes #1824.

### Motivation

The motivation is to allow the inclusion of `testonly` targets in the test toolchain classpath. For example, a custom toolchain configured with dependencies via `rules_jvm_external` where `testonly` has been added via `maven.amend_artifact`.