### PR TITLE
Fix unused-dependency false positive for given imports

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java
@@ -118,7 +118,17 @@ public class DepsTrackingReporter extends ConsoleReporter {
     Set<String> usedTargets = new HashSet<>();
     Set<Dependency> usedDeps = new HashSet<>();
 
-    for (String jar : usedJars) {
+    // Treat AST-discovered jars as used in addition to those reported
+    // by the patched SymbolLoaders.complete hook. Mirrors the Scala 3
+    // copy for consistency.
+    Set<String> allUsedJars = new HashSet<>(usedJars);
+    for (String jar : astUsedJars) {
+      if (jarToTarget.containsKey(jar) || indirectJarToTarget.containsKey(jar)) {
+        allUsedJars.add(jar);
+      }
+    }
+
+    for (String jar : allUsedJars) {
       String target = jarToTarget.get(jar);
 
       if (target == null) {
@@ -312,7 +322,11 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
   private String jarLabel(String path) throws IOException {
     try (JarFile jar = new JarFile(path)) {
-      return jar.getManifest().getMainAttributes().getValue("Target-Label");
+      // Generated jars without a MANIFEST.MF return null here; treat
+      // them the same as a manifest with no Target-Label attribute.
+      return jar.getManifest() == null
+          ? null
+          : jar.getManifest().getMainAttributes().getValue("Target-Label");
     }
   }
 

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_13_12/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_13_12/DepsTrackingReporter.java
@@ -109,7 +109,17 @@ public class DepsTrackingReporter extends ConsoleReporter {
     Set<String> usedTargets = new HashSet<>();
     Set<Dependency> usedDeps = new HashSet<>();
 
-    for (String jar : usedJars) {
+    // Treat AST-discovered jars as used in addition to those reported
+    // by the patched SymbolLoaders.complete hook. Mirrors the Scala 3
+    // copy for consistency.
+    Set<String> allUsedJars = new HashSet<>(usedJars);
+    for (String jar : astUsedJars) {
+      if (jarToTarget.containsKey(jar) || indirectJarToTarget.containsKey(jar)) {
+        allUsedJars.add(jar);
+      }
+    }
+
+    for (String jar : allUsedJars) {
       String target = jarToTarget.get(jar);
 
       if (target == null) {
@@ -303,7 +313,11 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
   private String jarLabel(String path) throws IOException {
     try (JarFile jar = new JarFile(path)) {
-      return jar.getManifest().getMainAttributes().getValue("Target-Label");
+      // Generated jars without a MANIFEST.MF return null here; treat
+      // them the same as a manifest with no Target-Label attribute.
+      return jar.getManifest() == null
+          ? null
+          : jar.getManifest().getMainAttributes().getValue("Target-Label");
     }
   }
 

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/before_2_12_13/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/before_2_12_13/DepsTrackingReporter.java
@@ -105,7 +105,17 @@ public class DepsTrackingReporter extends ConsoleReporter {
     Set<String> usedTargets = new HashSet<>();
     Set<Dependency> usedDeps = new HashSet<>();
 
-    for (String jar : usedJars) {
+    // Treat AST-discovered jars as used in addition to those reported
+    // by the patched SymbolLoaders.complete hook. Mirrors the Scala 3
+    // copy for consistency.
+    Set<String> allUsedJars = new HashSet<>(usedJars);
+    for (String jar : astUsedJars) {
+      if (jarToTarget.containsKey(jar) || indirectJarToTarget.containsKey(jar)) {
+        allUsedJars.add(jar);
+      }
+    }
+
+    for (String jar : allUsedJars) {
       String target = jarToTarget.get(jar);
 
       if (target == null) {
@@ -299,7 +309,11 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
   private String jarLabel(String path) throws IOException {
     try (JarFile jar = new JarFile(path)) {
-      return jar.getManifest().getMainAttributes().getValue("Target-Label");
+      // Generated jars without a MANIFEST.MF return null here; treat
+      // them the same as a manifest with no Target-Label attribute.
+      return jar.getManifest() == null
+          ? null
+          : jar.getManifest().getMainAttributes().getValue("Target-Label");
     }
   }
 

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/scala_3/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/scala_3/DepsTrackingReporter.java
@@ -100,7 +100,19 @@ public class DepsTrackingReporter extends BazelConsoleReporter {
     Set<String> usedTargets = new HashSet<>();
     Set<Dependency> usedDeps = new HashSet<>();
 
-    for (String jar : usedJars) {
+    // Treat AST-discovered jars as used in addition to those reported
+    // by the patched SymbolLoaders.complete hook. The hook does not
+    // fire reliably for Scala 3 `given` symbols imported via
+    // `import x.given`, so on its own it can flag a direct dep used
+    // solely to provide a given instance as unused.
+    Set<String> allUsedJars = new HashSet<>(usedJars);
+    for (String jar : astUsedJars) {
+      if (jarToTarget.containsKey(jar) || indirectJarToTarget.containsKey(jar)) {
+        allUsedJars.add(jar);
+      }
+    }
+
+    for (String jar : allUsedJars) {
       String target = jarToTarget.get(jar);
 
       if (target == null) {
@@ -297,7 +309,11 @@ public class DepsTrackingReporter extends BazelConsoleReporter {
 
   private String jarLabel(String path) throws IOException {
     try (JarFile jar = new JarFile(path)) {
-      return jar.getManifest().getMainAttributes().getValue("Target-Label");
+      // Generated jars without a MANIFEST.MF return null here; treat
+      // them the same as a manifest with no Target-Label attribute.
+      return jar.getManifest() == null
+          ? null
+          : jar.getManifest().getMainAttributes().getValue("Target-Label");
     }
   }
 

--- a/test/shell/test_compiler_dependency_tracking.sh
+++ b/test/shell/test_compiler_dependency_tracking.sh
@@ -54,9 +54,32 @@ test_no_unused_warn_when_broken() {
     build //test_expect_failure/compiler_dependency_tracker:F
 }
 
+# A Scala 3 target that uses an implicit summon resolved from a
+# `given` import builds cleanly under the ast_plus_error toolchain.
+# More targeted coverage of the underlying analyzer behavior lives in
+# the AstUsedJarFinderTest.scala unit tests.
+test_scala_3_given_import_is_not_unused() {
+  bazel build \
+    --extra_toolchains=//test_expect_failure/compiler_dependency_tracker:ast_plus_error \
+    //test_expect_failure/compiler_dependency_tracker/given_imports:user
+}
+
+# Companion negative test. The :user_missing_given_dep target has the
+# same source as :user but its deps omit the dep that provides the
+# given. Compilation must fail with a "no given instance" error,
+# anchoring the assumption that the given dep is genuinely required by
+# :user.
+test_scala_3_given_import_breaks_when_dep_removed() {
+  action_should_fail_with_message \
+    "No given instance" \
+    build --extra_toolchains=//test_expect_failure/compiler_dependency_tracker:ast_plus_error //test_expect_failure/compiler_dependency_tracker/given_imports:user_missing_given_dep
+}
+
 
 $runner test_fails_for_unused_dep
 $runner test_fails_for_missing_compile_dep
 $runner test_fails_for_strict_dep
 $runner test_sdeps
 $runner test_no_unused_warn_when_broken
+$runner test_scala_3_given_import_is_not_unused
+$runner test_scala_3_given_import_breaks_when_dep_removed

--- a/test_expect_failure/compiler_dependency_tracker/given_imports/BUILD
+++ b/test_expect_failure/compiler_dependency_tracker/given_imports/BUILD
@@ -1,0 +1,54 @@
+load("//scala:scala.bzl", "scala_library")
+
+# Targets exercising Scala 3 `given` imports under the
+# `ast_plus_error` toolchain. Driven by
+# test/shell/test_compiler_dependency_tracking.sh.
+#
+# More targeted coverage of the underlying analyzer behavior lives in
+# the unit tests at
+# third_party/dependency_analyzer/src/test/.../AstUsedJarFinderTest.scala
+# and runs against every supported Scala 3 version. These targets pin a
+# single version because the shell test needs a concrete Scala 3
+# toolchain and the behavior under test is not version-specific.
+SCALA_3_VERSION = "3.7.4"
+
+scala_library(
+    name = "tc",
+    srcs = ["TC.scala"],
+    scala_version = SCALA_3_VERSION,
+    visibility = ["//visibility:public"],
+)
+
+scala_library(
+    name = "givens",
+    srcs = ["Givens.scala"],
+    scala_version = SCALA_3_VERSION,
+    visibility = ["//visibility:public"],
+    deps = [":tc"],
+)
+
+# Builds successfully under the ast_plus_error toolchain: `:givens`
+# provides the given that `:tc` requires through implicit search.
+scala_library(
+    name = "user",
+    srcs = ["User.scala"],
+    scala_version = SCALA_3_VERSION,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":givens",
+        ":tc",
+    ],
+)
+
+# Same source as `:user` but with `:givens` removed from `deps`.
+# Building it must fail with a "no given instance" error, anchoring
+# the assumption that `:givens` is genuinely required by `:user`.
+scala_library(
+    name = "user_missing_given_dep",
+    srcs = ["UserMissingGivenDep.scala"],
+    scala_version = SCALA_3_VERSION,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":tc",
+    ],
+)

--- a/test_expect_failure/compiler_dependency_tracker/given_imports/Givens.scala
+++ b/test_expect_failure/compiler_dependency_tracker/given_imports/Givens.scala
@@ -1,0 +1,3 @@
+package given_imports.givenpkg
+
+given given_imports.tcpkg.TC[Int] = new given_imports.tcpkg.TC[Int]

--- a/test_expect_failure/compiler_dependency_tracker/given_imports/TC.scala
+++ b/test_expect_failure/compiler_dependency_tracker/given_imports/TC.scala
@@ -1,0 +1,3 @@
+package given_imports.tcpkg
+
+class TC[T]

--- a/test_expect_failure/compiler_dependency_tracker/given_imports/User.scala
+++ b/test_expect_failure/compiler_dependency_tracker/given_imports/User.scala
@@ -1,0 +1,15 @@
+// Imports a top-level `given` from a package and resolves it via
+// `summon`. The associated Bazel target depends on the jar that
+// provides the given; building it under `unused_dependency_checker_mode
+// = "error"` should succeed, since the given is genuinely required.
+//
+// This is an end-to-end smoke test. In this minimal setup both the AST
+// traversal and the SymbolLoaders.complete DT hook independently catch
+// the given's jar, so the test passes regardless of the AST-side change
+// in AstUsedJarFinder.scala. The AST path is exercised directly (with
+// the DT hook out of the picture) by the unit tests in
+// AstUsedJarFinderTest.scala.
+import given_imports.givenpkg.given
+
+object User:
+  val tc: given_imports.tcpkg.TC[Int] = summon[given_imports.tcpkg.TC[Int]]

--- a/test_expect_failure/compiler_dependency_tracker/given_imports/UserMissingGivenDep.scala
+++ b/test_expect_failure/compiler_dependency_tracker/given_imports/UserMissingGivenDep.scala
@@ -1,0 +1,8 @@
+// Same source as User.scala. The associated Bazel target intentionally
+// omits the dep that provides the given, so compilation must fail with
+// a "no given instance" error. This anchors the assumption made by the
+// `:user` target above: that the given dep really is required.
+import given_imports.givenpkg.given
+
+object UserMissingGivenDep:
+  val tc: given_imports.tcpkg.TC[Int] = summon[given_imports.tcpkg.TC[Int]]

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/AstUsedJarFinder.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/AstUsedJarFinder.scala
@@ -75,12 +75,26 @@ class AstUsedJarFinder {
             fullyExploreTree(expansion)
 
           case Import(qualifier, selectors) =>
+            // Resolve named selectors so `import foo.bar.A` records A
+            // as a direct dep even when A appears nowhere else. The
+            // qualifier itself is handled by the RefTree branch below
+            // when foreachSubTree visits it.
             val symbol = qualifier.symbol
             selectors.foreach { selector =>
               if selector.name != nme.WILDCARD && selector.rename != nme.WILDCARD then
                 val selected = symbol.info.member(selector.name).symbol
                 handleSymbol(selected, tree.sourcePos)
             }
+          // Record the file of the referenced symbol, in addition to
+          // the file of `tree.tpe` handled below. The two diverge for
+          // a Scala 3 `given` brought into scope by `import x.given`:
+          // the AST contains `Ident(given_X)` whose `tpe` narrows to
+          // the typeclass type, so `exploreType` only reaches the
+          // typeclass's jar. The given's defining jar (often a
+          // different dep) is reachable only via the symbol's
+          // `associatedFile`.
+          case _: RefTree =>
+            handleSymbol(tree.symbol, tree.sourcePos)
           case _ => // skip
         }
 

--- a/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
+++ b/third_party/dependency_analyzer/src/test/io/bazel/rulesscala/dependencyanalyzer/AstUsedJarFinderTest.scala
@@ -502,6 +502,12 @@ class AstUsedJarFinderTest extends AnyFunSuite {
     // In this case expr=foo.bar and selectors=[_], so expr does not have
     // a type which corresponds with A.
     testImport("foo.bar._", isDirect = false)
+
+    // In this case expr=foo.bar.A and selectors=[_]. The qualifier
+    // expression references A directly, and the RefTree branch in
+    // visitNode records A's defining file as part of normal subtree
+    // traversal.
+    testImport("foo.bar.A._", isDirect = true)
   }
 
   test("java interface method argument is direct") {
@@ -602,6 +608,205 @@ class AstUsedJarFinderTest extends AnyFunSuite {
           |""".stripMargin,
         expectedStrictDeps = List("UnitTests", "Category")
       )
+    }
+  }
+
+  // Asserts that an implicit val resolved from a wildcard import is
+  // recognized as a use of the providing object's jar in Scala 2.
+  // Scala 2's typer expands the resolved implicit to a fully qualified
+  // Select chain (`implicits.pkg.TCInstances.intTC` in the typed AST),
+  // so the analyzer reaches the providing object via the standard
+  // tree.tpe path. If a future typer change starts producing a bare
+  // `Ident(intTC)` instead, this test fails and the Scala 2 analyzer
+  // would need the same RefTree-based handling that
+  // dependencyanalyzer3/AstUsedJarFinder.scala has.
+  if (!isScala3) {
+    test("wildcard implicit import and implicit usage is direct (Scala 2)") {
+      withSandbox { sandbox =>
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package implicits.pkg
+            |
+            |class TC[T]
+            |
+            |object TCInstances {
+            |  implicit val intTC: TC[Int] = new TC[Int]
+            |}
+            |""".stripMargin
+        )
+
+        val bCode =
+          """
+            |import implicits.pkg.TCInstances._
+            |
+            |object B {
+            |  def needsTC[T](implicit tc: implicits.pkg.TC[T]): implicits.pkg.TC[T] = tc
+            |  val tc: implicits.pkg.TC[Int] = needsTC[Int]
+            |}
+            |""".stripMargin
+
+        sandbox.checkStrictDepsErrorsReported(
+          code = bCode,
+          expectedStrictDeps = List("implicits/pkg/TCInstances", "implicits/pkg/TC")
+        )
+      }
+    }
+  }
+
+  // Tests for Scala 3 `given` imports. See AstUsedJarFinder.scala for
+  // why these references are tracked through the symbol path rather
+  // than the type path.
+  if (isScala3) {
+    // Scala 3 puts top-level definitions in a synthetic `<source>$package`
+    // object, where `<source>` is the source file's base name. TestUtil
+    // names every compilation unit `scala_compiler_util_run_code.scala`,
+    // so top-level givens end up in `scala_compiler_util_run_code$package`.
+    val tlPackageObject = "scala_compiler_util_run_code$package"
+
+    test("package-level given import is direct (Scala 3)") {
+      // A top-level `given` brought into scope by `import pkg.given`
+      // and used through an implicit summon counts as a direct use of
+      // the package's jar. The RefTree arm in AstUsedJarFinder is what
+      // reaches that jar; the type path on its own only sees the
+      // typeclass.
+      withSandbox { sandbox =>
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.tlpkg
+            |
+            |class TC[T]
+            |""".stripMargin
+        )
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.tlinst
+            |
+            |given givens.tlpkg.TC[Int] = new givens.tlpkg.TC[Int]
+            |""".stripMargin
+        )
+
+        val bCode =
+          """
+            |import givens.tlinst.given
+            |
+            |object B:
+            |  val tc: givens.tlpkg.TC[Int] = summon[givens.tlpkg.TC[Int]]
+            |""".stripMargin
+
+        sandbox.checkStrictDepsErrorsReported(
+          code = bCode,
+          expectedStrictDeps = List(s"givens/tlinst/$tlPackageObject", "givens/tlpkg/TC")
+        )
+      }
+    }
+
+    test("object-level given import is direct (Scala 3)") {
+      // Importing givens from an object also marks the object's jar
+      // as direct. The import qualifier is a Select whose
+      // tpe.typeSymbol unwraps to the module class, so the type path
+      // alone is sufficient here.
+      withSandbox { sandbox =>
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.pkg
+            |
+            |class TC[T]
+            |
+            |object TCInstances:
+            |  given TC[Int] = new TC[Int]
+            |""".stripMargin
+        )
+
+        val bCode =
+          """
+            |import givens.pkg.TCInstances.given
+            |
+            |object B:
+            |  val tc: givens.pkg.TC[Int] = summon[givens.pkg.TC[Int]]
+            |""".stripMargin
+
+        sandbox.checkStrictDepsErrorsReported(
+          code = bCode,
+          expectedStrictDeps = List("givens/pkg/TCInstances", "givens/pkg/TC")
+        )
+      }
+    }
+
+    test("package-level given import without usage is flagged as unused (Scala 3)") {
+      // `import pkg.given` from a package with no actual implicit
+      // resolution does not count as a use of pkg's jar: removing the
+      // dep would not break compilation, since implicit search never
+      // resolves any given from it. The qualifier is a package with no
+      // associated file, and the body has no `Ident(given_X)` for the
+      // RefTree arm to record, so neither path marks the dep as used.
+      withSandbox { sandbox =>
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.tlpkg2
+            |
+            |class TC[T]
+            |""".stripMargin
+        )
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.tlinst2
+            |
+            |given givens.tlpkg2.TC[Int] = new givens.tlpkg2.TC[Int]
+            |""".stripMargin
+        )
+
+        val bCode =
+          """
+            |import givens.tlinst2.given
+            |
+            |class B
+            |""".stripMargin
+
+        sandbox.checkUnusedDepsErrorReported(
+          code = bCode,
+          expectedUnusedDeps = List(s"givens/tlinst2/$tlPackageObject")
+        )
+      }
+    }
+
+    test("by-type given import from a package is direct (Scala 3)") {
+      // `import pkg.{given TC[Int]}` is the by-type form of given
+      // import. The selector is still a GivenSelector (with a `bound`
+      // Tree), the qualifier is still a package, and the body
+      // references the given via Ident, so the same RefTree path
+      // applies as for the wildcard `.given` form.
+      withSandbox { sandbox =>
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.bytype
+            |
+            |class TC[T]
+            |""".stripMargin
+        )
+        sandbox.compileWithoutAnalyzer(
+          """
+            |package givens.bytypeinst
+            |
+            |given givens.bytype.TC[Int] = new givens.bytype.TC[Int]
+            |""".stripMargin
+        )
+
+        val bCode =
+          """
+            |import givens.bytypeinst.{given givens.bytype.TC[Int]}
+            |
+            |object B:
+            |  val tc: givens.bytype.TC[Int] = summon[givens.bytype.TC[Int]]
+            |""".stripMargin
+
+        sandbox.checkStrictDepsErrorsReported(
+          code = bCode,
+          expectedStrictDeps = List(
+            s"givens/bytypeinst/$tlPackageObject",
+            "givens/bytype/TC"
+          )
+        )
+      }
     }
   }
 


### PR DESCRIPTION
### Description

Fix an unused-dependency false positive for Scala 3 `given` imports under the `ast` and `ast-plus` dependency-tracking methods. The Scala 3 AST traversal now also records the file of the referenced *symbol* (not just the type), and `DepsTrackingReporter` now considers AST-discovered jars when computing unused deps (mirrored in the Scala 2 reporters).

### Motivation

When `unused_dependency_checker_mode = "error"` is enabled with one of the AST-based tracking methods on Scala 3, a dep that supplies a `given` brought into scope via `import x.given` is reported as unused even though removing it breaks compilation. After typer, the use site is `Ident(given_X)` whose `tpe` narrows to the typeclass, so the existing `tree.tpe.typeSymbol` path only reaches the typeclass jar, not the jar defining the given. In `ast-plus` mode, `DepsTrackingReporter` additionally ignores AST-discovered jars when computing unused deps, so even when the AST traversal catches the dep, the unused check still flags it.