### PR TITLE
Fix ast-plus errors not failing the build

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_12_13_and_before_2_13_12/DepsTrackingReporter.java
@@ -176,8 +176,11 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
     writeSdepsFile(usedDeps, unusedDeps);
 
-    Reporter reporter = this.delegateReporter != null ? this.delegateReporter : this;
-    reportDeps(usedDeps, unusedDeps, reporter);
+    // Report through `this` so the synthesized strict-deps / unused-deps
+    // errors increment the wrapper's error count that ScalacInvoker checks
+    // via `hasErrors()`. Our `doReport` override still forwards each
+    // diagnostic to `delegateReporter` for display.
+    reportDeps(usedDeps, unusedDeps, this);
   }
 
   private Dependency buildDependency(String jar, String target, Kind kind, boolean ignored) {

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_13_12/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/after_2_13_12/DepsTrackingReporter.java
@@ -167,8 +167,11 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
     writeSdepsFile(usedDeps, unusedDeps);
 
-    Reporter reporter = this.delegateReporter != null ? this.delegateReporter : this;
-    reportDeps(usedDeps, unusedDeps, reporter);
+    // Report through `this` so the synthesized strict-deps / unused-deps
+    // errors increment the wrapper's error count that ScalacInvoker checks
+    // via `hasErrors()`. Our `doReport` override still forwards each
+    // diagnostic to `delegateReporter` for display.
+    reportDeps(usedDeps, unusedDeps, this);
   }
 
   private Dependency buildDependency(String jar, String target, Kind kind, boolean ignored) {

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/before_2_12_13/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/before_2_12_13/DepsTrackingReporter.java
@@ -163,8 +163,11 @@ public class DepsTrackingReporter extends ConsoleReporter {
 
     writeSdepsFile(usedDeps, unusedDeps);
 
-    Reporter reporter = this.delegateReporter != null ? this.delegateReporter : this;
-    reportDeps(usedDeps, unusedDeps, reporter);
+    // Report through `this` so the synthesized strict-deps / unused-deps
+    // errors increment the wrapper's error count that ScalacInvoker checks
+    // via `hasErrors()`. Our `info0` override still forwards each
+    // diagnostic to `delegateReporter` for display.
+    reportDeps(usedDeps, unusedDeps, this);
   }
 
   private Dependency buildDependency(String jar, String target, Kind kind, boolean ignored) {

--- a/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/scala_3/DepsTrackingReporter.java
+++ b/src/java/io/bazel/rulesscala/scalac/deps_tracking_reporter/scala_3/DepsTrackingReporter.java
@@ -160,8 +160,11 @@ public class DepsTrackingReporter extends BazelConsoleReporter {
 
     writeSdepsFile(usedDeps, unusedDeps);
 
-    Reporter reporter = this.delegateReporter != null ? this.delegateReporter : this;
-    reportDeps(usedDeps, unusedDeps, reporter, ctx);
+    // Report through `this` so the synthesized strict-deps / unused-deps
+    // errors increment the wrapper's error count that ScalacInvoker checks
+    // via `hasErrors()`. Our `doReport` override still forwards each
+    // diagnostic to `delegateReporter` for display.
+    reportDeps(usedDeps, unusedDeps, this, ctx);
   }
 
   private Dependency buildDependency(String jar, String target, Kind kind, boolean ignored) {

--- a/test/shell/test_compiler_dependency_tracking.sh
+++ b/test/shell/test_compiler_dependency_tracking.sh
@@ -12,6 +12,16 @@ test_fails_for_unused_dep() {
     build --extra_toolchains="//test_expect_failure/compiler_dependency_tracker:ast_plus_error" //test_expect_failure/compiler_dependency_tracker:unused_dep
 }
 
+# Scala 3 variant of test_fails_for_unused_dep. Catches the bug where the
+# Scala 3 DepsTrackingReporter routed synthesized errors to its delegate
+# only, so `hasErrors()` stayed false and the build succeeded despite
+# printing the error.
+test_scala_3_fails_for_unused_dep() {
+  action_should_fail_with_message \
+    "buildozer 'remove deps //test_expect_failure/compiler_dependency_tracker:E' //test_expect_failure/compiler_dependency_tracker:unused_dep" \
+    build --repo_env=SCALA_VERSION=3.8.3 --extra_toolchains="//test_expect_failure/compiler_dependency_tracker:ast_plus_error" //test_expect_failure/compiler_dependency_tracker:unused_dep
+}
+
 test_fails_for_missing_compile_dep() {
   action_should_fail_with_message \
     "buildozer 'add deps //test_expect_failure/compiler_dependency_tracker:E' //test_expect_failure/compiler_dependency_tracker:missing_compile_dep" \
@@ -77,6 +87,7 @@ test_scala_3_given_import_breaks_when_dep_removed() {
 
 
 $runner test_fails_for_unused_dep
+$runner test_scala_3_fails_for_unused_dep
 $runner test_fails_for_missing_compile_dep
 $runner test_fails_for_strict_dep
 $runner test_sdeps


### PR DESCRIPTION
### Description

Fix `DepsTrackingReporter` so synthesized strict-deps / unused-deps errors actually fail the build in `ast-plus` mode. They were being reported through the delegate reporter, so the wrapper's `hasErrors()` (which `ScalacInvoker` checks) stayed false and the build exited 0 despite the printed `error:` line. Reporting through `this` increments the wrapper's error count; the overridden `doReport`/`info0` still forwards each diagnostic to the delegate, so messages are shown once.

**Behavior change:** Scala 3 builds using `ast-plus` with `unused_dependency_checker_mode = "error"` (or `strict_deps_mode = "error"`) that were silently passing while emitting these messages will now fail. This is the documented intent of `mode = "error"`.

**This should be merged after #1828, as this turns the given-import false positives that #1828 fixes into actual build failures for Scala 3 users.**

### Motivation

In Scala 3 the wrapper's delegate is always non-null (`ictx.reporter()` returns a default reporter), so the issue triggers on every Scala 3 build. In Scala 2 it is latent: it only triggers when `enableDiagnosticsReport=true` (delegate is non-null), which is why it went unnoticed there. `high-level` mode is unaffected, since the dependency analyzer plugin emits errors through scalac's normal error pipeline rather than this synthesized path.