### PR TITLE
Enable semanticdb phase during plugin bootstrapping

### DIFF
--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -163,7 +163,7 @@ def _scala_library_for_plugin_bootstrapping_impl(ctx):
             ("dependency", phase_dependency_library_for_plugin_bootstrapping),
             ("collect_jars", phase_collect_jars_common),
             ("scalacopts", phase_scalacopts),
-            #("semanticdb", phase_semanticdb), noneed for semanticdb in bootstrap
+            ("semanticdb", phase_semanticdb),  # enable semanticdb during bootstrap since user scalacopts may include flags for it
             ("compile", phase_compile_library_for_plugin_bootstrapping),
             ("merge_jars", phase_merge_jars),
             ("runfiles", phase_runfiles_library),

--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -163,7 +163,7 @@ def _scala_library_for_plugin_bootstrapping_impl(ctx):
             ("dependency", phase_dependency_library_for_plugin_bootstrapping),
             ("collect_jars", phase_collect_jars_common),
             ("scalacopts", phase_scalacopts),
-            ("semanticdb", phase_semanticdb),  # enable semanticdb during bootstrap since user scalacopts may include flags for it
+            ("semanticdb", phase_semanticdb),  # enable semanticdb during bootstrap since toolchain scalacopts may include flags for it
             ("compile", phase_compile_library_for_plugin_bootstrapping),
             ("merge_jars", phase_merge_jars),
             ("runfiles", phase_runfiles_library),

--- a/test/semanticdb/BUILD
+++ b/test/semanticdb/BUILD
@@ -30,6 +30,21 @@ toolchain(
     visibility = ["//visibility:public"],
 )
 
+scala_toolchain(
+    name = "semanticdb_synthetics_toolchain_impl",
+    enable_semanticdb = True,
+    scalacopts = ["-P:semanticdb:synthetics:on"],
+    semanticdb_bundle_in_jar = False,
+    visibility = ["//visibility:public"],
+)
+
+toolchain(
+    name = "semanticdb_synthetics_toolchain",
+    toolchain = ":semanticdb_synthetics_toolchain_impl",
+    toolchain_type = "//scala:toolchain_type",
+    visibility = ["//visibility:public"],
+)
+
 scala_library(
     name = "all_lib",
     srcs = glob(["*.scala"]),

--- a/test/shell/test_semanticdb.sh
+++ b/test/shell/test_semanticdb.sh
@@ -203,7 +203,7 @@ run_semanticdb_tests() {
 
   $runner test_no_semanticdb
   $runner test_semanticdb_handles_removed_sourcefiles
+  $runner test_semanticdb_synthetics_toolchain_scalaopt
 }
 
 run_semanticdb_tests
-$runner test_semanticdb_synthetics_toolchain_scalaopt

--- a/test/shell/test_semanticdb.sh
+++ b/test/shell/test_semanticdb.sh
@@ -177,6 +177,18 @@ test_semanticdb_handles_removed_sourcefiles() {
 
 }
 
+test_semanticdb_synthetics_toolchain_scalaopt() {
+  # Regression test: building with a toolchain that sets enable_semanticdb=True and
+  # includes -P:semanticdb:synthetics:on in scalacopts should succeed. Previously it
+  # failed because scala_library_for_plugin_bootstrapping (which compiles the dep
+  # analyzer plugin) skipped phase_semanticdb, so the semanticdb plugin was never
+  # loaded but the -P:semanticdb:... flag was still forwarded to scalac.
+  set -e
+  bazel build \
+    --extra_toolchains="//test/semanticdb:semanticdb_synthetics_toolchain" \
+    //test/semanticdb:all_lib
+}
+
 run_semanticdb_tests() {
   local bundle=1;   local nobundle=0
   local scala3=3;    local scala2=2
@@ -194,3 +206,4 @@ run_semanticdb_tests() {
 }
 
 run_semanticdb_tests
+$runner test_semanticdb_synthetics_toolchain_scalaopt


### PR DESCRIPTION
### Description
Add `phase_semanticdb` to the `scala_library_for_plugin_bootstrapping` phase list so the semanticdb plugin jar is loaded whenever the toolchain enables semanticdb.

Previously, `scala_library_for_plugin_bootstrapping` (used to compile the dep analyzer plugin) skipped `phase_semanticdb`. When a toolchain sets `enable_semanticdb = True` and includes a `-P:semanticdb:...` scalacopt (e.g. `-P:semanticdb:synthetics:on`), the bootstrap compilation received the flag but had no semanticdb plugin loaded — scalac failed with `error: bad option: -P:semanticdb:synthetics:on`.

A regression test that builds `//test/semanticdb:all_lib` with a synthetics-enabled semanticdb toolchain is also added to verify the bootstrap path handles these scalacopts.

### Motivation
When a toolchain sets `enable_semanticdb = True` and passes `-P:semanticdb:...` scalacopts (e.g. `-P:semanticdb:synthetics:on`), the dep analyzer plugin bootstrap compilation failed with `error: bad option: -P:semanticdb:synthetics:on` because `phase_semanticdb` was not included in the bootstrap phase list and the plugin jar was never loaded.