### PR TITLE
fix: Provide portable scala reflect to specs2 - required for Scala 3 

### DIFF
--- a/examples/testing/multi_frameworks_toolchain/example/Specs2ExampleTest.scala
+++ b/examples/testing/multi_frameworks_toolchain/example/Specs2ExampleTest.scala
@@ -1,8 +1,8 @@
 package example
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class Specs2ExampleTest extends SpecWithJUnit {
+class Specs2ExampleTest extends SpecificationWithJUnit {
 
   "Example" in {
     1 mustEqual 1

--- a/examples/testing/specs2_junit_repositories/example/Specs2ExampleTest.scala
+++ b/examples/testing/specs2_junit_repositories/example/Specs2ExampleTest.scala
@@ -1,8 +1,8 @@
 package example
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class Specs2ExampleTest extends SpecWithJUnit {
+class Specs2ExampleTest extends SpecificationWithJUnit {
   "works" in {
     1 mustEqual 1
   }

--- a/scala/toolchains.bzl
+++ b/scala/toolchains.bzl
@@ -174,11 +174,6 @@ def scala_toolchains(
             id: True
             for id in junit_artifact_ids()
         })
-    if specs2:
-        artifact_ids_to_fetch_sources.update({
-            id: True
-            for id in specs2_artifact_ids() + specs2_junit_artifact_ids()
-        })
     if jmh:
         artifact_ids_to_fetch_sources.update({
             id: False
@@ -208,6 +203,11 @@ def scala_toolchains(
             version_specific_artifact_ids.update({
                 id: fetch_sources
                 for id in scalafmt_artifact_ids(scala_version)
+            })
+        if specs2:
+            version_specific_artifact_ids.update({
+                id: True
+                for id in specs2_artifact_ids(scala_version) + specs2_junit_artifact_ids()
             })
 
         all_artifacts = (

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -187,7 +187,9 @@ load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
         junit_classpath = repositories(scala_version, {junit}),
         specs2_classpath = repositories(
             scala_version,
-            ["@" + id for id in specs2_artifact_ids(scala_version)],
+            ["@" + id for id in specs2_artifact_ids(scala_version)]
+            if {specs2}
+            else None,
         ),
         specs2_junit_classpath = repositories(scala_version, {specs2_junit}),
     )

--- a/scala/toolchains_repo.bzl
+++ b/scala/toolchains_repo.bzl
@@ -169,6 +169,10 @@ load(
     "version_suffix",
 )
 load(
+    "@rules_scala//specs2:specs2.bzl",
+    "specs2_artifact_ids",
+)
+load(
     "@rules_scala//testing:testing.bzl",
     "{deps_symbols}",
     "setup_scala_testing_toolchain",
@@ -181,7 +185,10 @@ load("@rules_scala_config//:config.bzl", "SCALA_VERSIONS")
         scala_version = scala_version,
         scalatest_classpath = repositories(scala_version, {scalatest}),
         junit_classpath = repositories(scala_version, {junit}),
-        specs2_classpath = repositories(scala_version, {specs2}),
+        specs2_classpath = repositories(
+            scala_version,
+            ["@" + id for id in specs2_artifact_ids(scala_version)],
+        ),
         specs2_junit_classpath = repositories(scala_version, {specs2_junit}),
     )
     for scala_version in SCALA_VERSIONS

--- a/specs2/specs2.bzl
+++ b/specs2/specs2.bzl
@@ -1,10 +1,13 @@
-def specs2_artifact_ids():
-    return [
+def specs2_artifact_ids(scala_version = None):
+    ids = [
         "io_bazel_rules_scala_org_specs2_specs2_common",
         "io_bazel_rules_scala_org_specs2_specs2_core",
         "io_bazel_rules_scala_org_specs2_specs2_fp",
         "io_bazel_rules_scala_org_specs2_specs2_matcher",
     ]
+    if scala_version != None and scala_version.startswith("3."):
+        ids.append("io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13")
+    return ids
 
 def specs2_dependencies():
     return [Label("//specs2:specs2")]

--- a/test/coverage_filename_encoding/Test.scala
+++ b/test/coverage_filename_encoding/Test.scala
@@ -1,8 +1,8 @@
 package coverage_filename_encoding
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class Test extends SpecWithJUnit {
+class Test extends SpecificationWithJUnit {
   "testA1" in {
     A1.a1(true) must be_!=(1)
   }

--- a/test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala
+++ b/test/coverage_specs2_with_junit/TestWithSpecs2WithJUnit.scala
@@ -1,8 +1,8 @@
 package coverage_specs2_with_junit
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class TestWithSpecs2WithJUnit extends SpecWithJUnit {
+class TestWithSpecs2WithJUnit extends SpecificationWithJUnit {
   "testA1" in {
     A1.a1(true) must be_==(B1)
   }

--- a/test/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
+++ b/test/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
@@ -1,9 +1,9 @@
 package scalarules.test.junit.specs2
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 import scalarules.test.junit.support.JUnitCompileTimeDep
 
-class JunitSpecs2Test extends SpecWithJUnit {
+class JunitSpecs2Test extends SpecificationWithJUnit {
 
   "specs2 tests" >> {
     "run smoothly in bazel" in {
@@ -17,7 +17,7 @@ class JunitSpecs2Test extends SpecWithJUnit {
   }
 }
 
-class JunitSpecs2AnotherTest extends SpecWithJUnit {
+class JunitSpecs2AnotherTest extends SpecificationWithJUnit {
 
   "other specs2 tests" >> {
     "run from another test" >> {
@@ -37,7 +37,7 @@ class JunitSpecs2AnotherTest extends SpecWithJUnit {
   }
 }
 
-class JunitSpec2RegexTest extends SpecWithJUnit {
+class JunitSpec2RegexTest extends SpecificationWithJUnit {
 
   "tests with unsafe characters" >> {
     "2 + 2 != 5" in {
@@ -50,7 +50,7 @@ class JunitSpec2RegexTest extends SpecWithJUnit {
   }
 }
 
-class JunitSpecs2ManyFragmentsTest extends SpecWithJUnit {
+class JunitSpecs2ManyFragmentsTest extends SpecificationWithJUnit {
 
   (1 to 200) foreach { i =>
     s"fragment no $i" in success

--- a/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
+++ b/test/src/main/scala/scalarules/test/junit/test_discovery/ArchiveEntriesTest.scala
@@ -1,12 +1,12 @@
 package io.bazel.rulesscala.test_discovery
 
 import io.bazel.rulesscala.test_discovery.ArchiveEntries.listClassFiles
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
 import java.io.File
 import java.nio.file.Files
 
-class ArchiveEntriesTest extends SpecWithJUnit {
+class ArchiveEntriesTest extends SpecificationWithJUnit {
   "List only class files from a directory" in {
     val dir = Files.createTempDirectory("temp")
     Files.createFile(dir.resolve("SomeFile"))

--- a/test/src/main/scala/scalarules/test/location_expansion/LocationExpansionTest.scala
+++ b/test/src/main/scala/scalarules/test/location_expansion/LocationExpansionTest.scala
@@ -1,7 +1,7 @@
 package scalarules.test.location_expansion
 
-import org.specs2.mutable.SpecWithJUnit
-class LocationExpansionTest extends SpecWithJUnit {
+import org.specs2.mutable.SpecificationWithJUnit
+class LocationExpansionTest extends SpecificationWithJUnit {
 
   "tests" >> {
     "support location expansion" >> {

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesFilegroupTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesFilegroupTest.scala
@@ -1,8 +1,8 @@
 package scalarules.test.resources
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class ScalaLibOnlyResourcesFilegroupTest extends SpecWithJUnit {
+class ScalaLibOnlyResourcesFilegroupTest extends SpecificationWithJUnit {
 
   "Scala library with no srcs and only filegroup resources" >> {
     "allow to load resources" >> {

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibOnlyResourcesTest.scala
@@ -1,8 +1,8 @@
 package scalarules.test.resources
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class ScalaLibOnlyResourcesTest extends SpecWithJUnit {
+class ScalaLibOnlyResourcesTest extends SpecificationWithJUnit {
 
   "Scala library with no srcs and only resources" >> {
     "allow to load resources" >> {

--- a/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
+++ b/test/src/main/scala/scalarules/test/resources/ScalaLibResourcesFromExternalDepTest.scala
@@ -1,8 +1,8 @@
 package scalarules.test.resources
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class ScalaLibResourcesFromExternalDepTest extends SpecWithJUnit {
+class ScalaLibResourcesFromExternalDepTest extends SpecificationWithJUnit {
 
   "Scala library depending on resources from external resource-only jar" >> {
     "allow to load resources" >> {

--- a/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
+++ b/test/src/main/scala/scalarules/test/scala_import/ScalaImportExposesJarsTest.scala
@@ -2,9 +2,9 @@ package scalarules.test.scala_import
 
 import com.google.common.cache.Cache
 import org.apache.commons.lang3.ArrayUtils
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class ScalaImportExposesJarsTest extends SpecWithJUnit {
+class ScalaImportExposesJarsTest extends SpecificationWithJUnit {
   "scala_import" >> {
     "enable using the jars it exposes" in {
       println(classOf[Cache[String, String]])

--- a/test_expect_failure/compiler_dependency_tracker/sdeps/SdepsTest.scala
+++ b/test_expect_failure/compiler_dependency_tracker/sdeps/SdepsTest.scala
@@ -1,13 +1,13 @@
 package sdeps
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 import io.bazel.rulesscala.deps.proto.ScalaDeps
 import io.bazel.rulesscala.deps.proto.ScalaDeps.Dependency.Kind._
 import org.specs2.matcher.Matcher
 
 import java.util
 
-class SdepsTest extends SpecWithJUnit {
+class SdepsTest extends SpecificationWithJUnit {
 
   "Mixed Scala/Java source targets" should {
     val deps = loadSdeps("mixed_sources.sdeps")

--- a/test_expect_failure/scala_junit_test/specs2/FailingTest.scala
+++ b/test_expect_failure/scala_junit_test/specs2/FailingTest.scala
@@ -1,8 +1,8 @@
 package scalarules.test.junit.specs2
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class FailingTest extends SpecWithJUnit {
+class FailingTest extends SpecificationWithJUnit {
 
   val boom: String = { throw new Exception("Boom") }
 

--- a/test_expect_failure/scala_junit_test/specs2/SuiteWithOneFailingTest.scala
+++ b/test_expect_failure/scala_junit_test/specs2/SuiteWithOneFailingTest.scala
@@ -1,8 +1,8 @@
 package scalarules.test.junit.specs2
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 
-class SuiteWithOneFailingTest extends SpecWithJUnit {
+class SuiteWithOneFailingTest extends SpecificationWithJUnit {
 
   "specs2 tests" >> {
     "succeed" >> success

--- a/test_version.sh
+++ b/test_version.sh
@@ -2,11 +2,14 @@
 
 set -e
 
-scala_2_12_version="2.12.21"
-scala_2_13_version="2.13.18"
-scala_3_version="3.3.7"
+scala_versions=(
+  "2.12.21"
+  "2.13.18"
+  "3.3.7"
+  "3.8.4"
+)
 
-SCALA_VERSION_DEFAULT=$scala_2_12_version
+SCALA_VERSION_DEFAULT="${scala_versions[0]}"
 
 diagnostics_reporter_toolchain="//:diagnostics_reporter_toolchain"
 diagnostics_reporter_and_semanticdb_toolchain="//:diagnostics_reporter_and_semanticdb_toolchain"
@@ -111,8 +114,15 @@ test_check_module_bazel_template() {
 
 test_scala_version() {
   local SCALA_VERSION="$1"
+  local test_command="bazel test //... --repo_env=SCALA_VERSION=${SCALA_VERSION}"
 
-  run_in_test_repo "bazel test //... --repo_env=SCALA_VERSION=${SCALA_VERSION}" "scala_version" "version_specific_tests_dir/"
+  # Scrooge generates Scala 2 syntax (e.g. do-while) that does not compile on Scala 3.
+  # Scrooge compatibility is covered separately by test_twitter_scrooge_versions.
+  if [[ "$SCALA_VERSION" == 3.* ]]; then
+    test_command="${test_command} -- -//src/main/scala/scalarules/test/twitter_scrooge/..."
+  fi
+
+  run_in_test_repo "${test_command}" "scala_version" "version_specific_tests_dir/"
 }
 
 test_reporter() {
@@ -160,28 +170,16 @@ runner=$(get_test_runner "${1:-local}")
 export USE_BAZEL_VERSION=${USE_BAZEL_VERSION:-$(cat $dir/.bazelversion)}
 
 TEST_TIMEOUT=15 $runner test_check_module_bazel_template
-TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_12_version}"
-TEST_TIMEOUT=15 $runner test_scala_version "${scala_2_13_version}"
+
+for scala_version in "${scala_versions[@]}"; do
+  TEST_TIMEOUT=15 $runner test_scala_version "${scala_version}"
+  TEST_TIMEOUT=15 $runner test_reporter "${scala_version}" "${no_diagnostics_reporter_toolchain}"
+  TEST_TIMEOUT=15 $runner test_reporter "${scala_version}" "${diagnostics_reporter_toolchain}"
+  TEST_TIMEOUT=15 $runner test_reporter "${scala_version}" "${diagnostics_reporter_and_semanticdb_toolchain}"
+
+  TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain
+  TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain
+done
 
 TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "18.6.0"
 TEST_TIMEOUT=15 $runner test_twitter_scrooge_versions "21.2.0"
-
-TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${no_diagnostics_reporter_toolchain}"
-TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${no_diagnostics_reporter_toolchain}"
-TEST_TIMEOUT=15 $runner test_reporter "${scala_3_version}"    "${no_diagnostics_reporter_toolchain}"
-
-TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${diagnostics_reporter_toolchain}"
-TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_toolchain}"
-TEST_TIMEOUT=15 $runner test_reporter "${scala_3_version}"    "${diagnostics_reporter_toolchain}"
-
-TEST_TIMEOUT=15 $runner test_reporter "${scala_2_12_version}" "${diagnostics_reporter_and_semanticdb_toolchain}"
-TEST_TIMEOUT=15 $runner test_reporter "${scala_2_13_version}" "${diagnostics_reporter_and_semanticdb_toolchain}"
-TEST_TIMEOUT=15 $runner test_reporter "${scala_3_version}"    "${diagnostics_reporter_and_semanticdb_toolchain}"
-
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_12_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_13_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_3_version}"    //test_expect_failure/diagnostics_reporter:diagnostics_reporter_toolchain 
-
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_12_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_2_13_version}" //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain
-TEST_TIMEOUT=15 $runner test_diagnostic_proto_files "${scala_3_version}"    //test_expect_failure/diagnostics_reporter:diagnostics_reporter_and_semanticdb_toolchain

--- a/test_version/version_specific_tests_dir/BUILD
+++ b/test_version/version_specific_tests_dir/BUILD
@@ -10,6 +10,7 @@ load(
     "scala_test",
 )
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
+load("@rules_scala//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 
 package(default_testonly = 1)
 
@@ -84,7 +85,10 @@ scala_library(
 
 scala_macro_library(
     name = "MacroTest",
-    srcs = ["MacroTest.scala"],
+    srcs = select_for_scala_version(
+        any_2 = ["MacroTest.scala"],
+        since_3 = ["MacroTest_3.scala"],
+    ),
 )
 
 scala_library(

--- a/test_version/version_specific_tests_dir/Exported.scala
+++ b/test_version/version_specific_tests_dir/Exported.scala
@@ -4,7 +4,8 @@ object Exported {
   def message: String = {
     // terrible, don't do this in real code:
     val msg = Class.forName("scalarules.test.Runtime")
-      .newInstance
+      .getDeclaredConstructor()
+      .newInstance()
       .toString
     "you all, everybody. " + msg
   }

--- a/test_version/version_specific_tests_dir/HelloLib.scala
+++ b/test_version/version_specific_tests_dir/HelloLib.scala
@@ -19,7 +19,7 @@ object HelloLib {
   // to just def dumb(x: Int) = x == 3
   def dumb(x: Int) = if (x == 3) true else false
 
-  def printMessage(arg: String) {
+  def printMessage(arg: String): Unit = {
     MacroTest.hello(arg == "yo")
     println(getOtherLibMessage(arg))
     println(getOtherJavaLibMessage(arg))

--- a/test_version/version_specific_tests_dir/MacroTest_3.scala
+++ b/test_version/version_specific_tests_dir/MacroTest_3.scala
@@ -1,0 +1,12 @@
+package scalarules.test
+
+import scala.quoted.*
+
+object MacroTest {
+  inline def hello(param: Any): Unit = ${ helloImpl('param) }
+
+  private def helloImpl(param: Expr[Any])(using Quotes): Expr[Unit] = {
+    val paramRep = param.show
+    '{ println(${ Expr(paramRep) } + " = " + $param) }
+  }
+}

--- a/test_version/version_specific_tests_dir/ScalaBinary.scala
+++ b/test_version/version_specific_tests_dir/ScalaBinary.scala
@@ -15,7 +15,7 @@
 package scalarules.test
 
 object ScalaBinary {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     println(MacroTest.hello(1 + 2))
     HelloLib.printMessage("Hello");
   }

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/MixJavaScalaLibBinary.scala
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/MixJavaScalaLibBinary.scala
@@ -15,7 +15,7 @@
 package scalarules.test
 
 object MixJavaScalaLibBinary {
-  def main(args: Array[String]) {
+  def main(args: Array[String]): Unit = {
     val bar = new Bar()
     println("created an instance of a mixed java scala code from a library")
   }

--- a/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
+++ b/test_version/version_specific_tests_dir/src/main/scala/scalarules/test/junit/specs2/Specs2Tests.scala
@@ -1,9 +1,9 @@
 package scalarules.test.junit.specs2
 
-import org.specs2.mutable.SpecWithJUnit
+import org.specs2.mutable.SpecificationWithJUnit
 import scalarules.test.junit.support.JUnitCompileTimeDep
 
-class JunitSpecs2Test extends SpecWithJUnit {
+class JunitSpecs2Test extends SpecificationWithJUnit {
 
   "specs2 tests" >> {
     "run smoothly in bazel" in {
@@ -17,7 +17,7 @@ class JunitSpecs2Test extends SpecWithJUnit {
   }
 }
 
-class JunitSpecs2AnotherTest extends SpecWithJUnit {
+class JunitSpecs2AnotherTest extends SpecificationWithJUnit {
 
   "other specs2 tests" >> {
     "run from another test" >> {
@@ -37,7 +37,7 @@ class JunitSpecs2AnotherTest extends SpecWithJUnit {
   }
 }
 
-class JunitSpec2RegexTest extends SpecWithJUnit {
+class JunitSpec2RegexTest extends SpecificationWithJUnit {
 
   "tests with unsafe characters" >> {
     "2 + 2 != 5" in {

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_4.bzl
+++ b/third_party/repositories/scala_3_4.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_5.bzl
+++ b/third_party/repositories/scala_3_5.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_6.bzl
+++ b/third_party/repositories/scala_3_6.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_7.bzl
+++ b/third_party/repositories/scala_3_7.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",

--- a/third_party/repositories/scala_3_8.bzl
+++ b/third_party/repositories/scala_3_8.bzl
@@ -152,6 +152,10 @@ artifacts = {
         "artifact": "org.ow2.asm:asm:9.0",
         "sha256": "0df97574914aee92fd349d0cb4e00f3345d45b2c239e0bb50f0a90ead47888e0",
     },
+    "io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13": {
+        "artifact": "org.portable-scala:portable-scala-reflect_2.13:1.1.1",
+        "sha256": "11f2f59d0c228912811095025b36ce58a025a8397851d773295c8ad7862d8488",
+    },
     "io_bazel_rules_scala_org_specs2_specs2_common": {
         "artifact": "org.specs2:specs2-common_3:jar:5.0.0-RC-21",
         "sha256": "bfbc91a136493483ed5d2beba7f48520e72b66a9987ebec5b8f0ca38bda02801",
@@ -170,6 +174,9 @@ artifacts = {
     "io_bazel_rules_scala_org_specs2_specs2_fp": {
         "artifact": "org.specs2:specs2-fp_3:jar:5.0.0-RC-21",
         "sha256": "60f26aa132decb52682bba7ce0355b0b749b1b5fe283ec8929b050bb794cc1b8",
+        "deps": [
+            "@io_bazel_rules_scala_org_portable_scala_portable_scala_reflect_2_13",
+        ],
     },
     "io_bazel_rules_scala_org_specs2_specs2_junit": {
         "artifact": "org.specs2:specs2-junit_3:jar:5.0.0-RC-21",


### PR DESCRIPTION
Specs2 uses portable-scala-reflect at compile time, it should have been explicitlly provided. 
Otherwise it results in a compilation failures 

```
ERROR: /Users/wmazur/projects/bazel-contrib/rules_scala/src/java/io/bazel/rulesscala/specs2/BUILD:4:14: scala @@//src/java/io/bazel/rulesscala/specs2:specs2_test_discovery failed: (Exit 1): scalac failed: error executing Scalac command (from target //src/java/io/bazel/rulesscala/specs2:specs2_test_discovery) bazel-out/darwin_arm64-opt-exec-ST-d57f47055a04/bin/src/java/io/bazel/rulesscala/scalac/scalac ... (remaining 1 argument skipped)
undefined: new org.portablescala.reflect.annotation.EnableReflectiveInstantiation # -1: TermRef(TypeRef(TermRef(TermRef(TermRef(TermRef(ThisType(TypeRef(NoPrefix,module class <root>)),object org),object portablescala),object reflect),object annotation),EnableReflectiveInstantiation),<init>) at dependency-analyzer-AstPlus
1 error found

```