### PR TITLE
fix: Improve source compatibility of toolchain sources

### DIFF
--- a/scala/private/source_compat/BUILD
+++ b/scala/private/source_compat/BUILD
@@ -8,9 +8,5 @@ scala_library(
         between_2_13_and_3 = ["scala2_13/SourceCompat.scala"],
         since_3 = ["scala3/SourceCompat.scala"],
     ),
-    visibility = [
-        "//scala:__subpackages__",
-        "//src:__subpackages__",
-        "//third_party:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
 )

--- a/scala/private/source_compat/BUILD
+++ b/scala/private/source_compat/BUILD
@@ -4,7 +4,8 @@ load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
 scala_library(
     name = "source_compat",
     srcs = select_for_scala_version(
-        before_3 = ["scala2/SourceCompat.scala"],
+        before_2_13 = ["scala2_12/SourceCompat.scala"],
+        between_2_13_and_3 = ["scala2_13/SourceCompat.scala"],
         since_3 = ["scala3/SourceCompat.scala"],
     ),
     visibility = [

--- a/scala/private/source_compat/BUILD
+++ b/scala/private/source_compat/BUILD
@@ -1,0 +1,15 @@
+load("//scala:scala.bzl", "scala_library")
+load("//scala:scala_cross_version_select.bzl", "select_for_scala_version")
+
+scala_library(
+    name = "source_compat",
+    srcs = select_for_scala_version(
+        before_3 = ["scala2/SourceCompat.scala"],
+        since_3 = ["scala3/SourceCompat.scala"],
+    ),
+    visibility = [
+        "//scala:__subpackages__",
+        "//src:__subpackages__",
+        "//third_party:__subpackages__",
+    ],
+)

--- a/scala/private/source_compat/scala2/SourceCompat.scala
+++ b/scala/private/source_compat/scala2/SourceCompat.scala
@@ -1,6 +1,0 @@
-package io.bazel.rulesscala.sourcecompat
-
-object SourceCompat {
-  type Class = java.lang.Class[_]
-  type ClassOf[+Upper] = java.lang.Class[_ <: Upper]
-}

--- a/scala/private/source_compat/scala2/SourceCompat.scala
+++ b/scala/private/source_compat/scala2/SourceCompat.scala
@@ -1,0 +1,6 @@
+package io.bazel.rulesscala.sourcecompat
+
+object SourceCompat {
+  type Class = java.lang.Class[_]
+  type ClassOf[+Upper] = java.lang.Class[_ <: Upper]
+}

--- a/scala/private/source_compat/scala2_12/SourceCompat.scala
+++ b/scala/private/source_compat/scala2_12/SourceCompat.scala
@@ -1,0 +1,13 @@
+package io.bazel.rulesscala.sourcecompat
+
+object SourceCompat {
+  type Class = java.lang.Class[_]
+  type ClassOf[+Upper] = java.lang.Class[_ <: Upper]
+
+  type Stream[+T] = scala.Stream[T]
+  val Stream: scala.Stream.type = scala.Stream
+
+  def toStream[A](it: Iterable[A]): Stream[A] = it.toStream
+
+  val JavaConversions = scala.collection.JavaConverters
+}

--- a/scala/private/source_compat/scala2_13/SourceCompat.scala
+++ b/scala/private/source_compat/scala2_13/SourceCompat.scala
@@ -1,8 +1,8 @@
 package io.bazel.rulesscala.sourcecompat
 
 object SourceCompat {
-  type Class = java.lang.Class[?]
-  type ClassOf[+Upper] = java.lang.Class[? <: Upper]
+  type Class = java.lang.Class[_]
+  type ClassOf[+Upper] = java.lang.Class[_ <: Upper]
 
   type Stream[+T] = scala.LazyList[T]
   val Stream: scala.LazyList.type = scala.LazyList

--- a/scala/private/source_compat/scala3/SourceCompat.scala
+++ b/scala/private/source_compat/scala3/SourceCompat.scala
@@ -1,0 +1,6 @@
+package io.bazel.rulesscala.sourcecompat
+
+object SourceCompat {
+  type Class = java.lang.Class[?]
+  type ClassOf[+Upper] = java.lang.Class[? <: Upper]
+}

--- a/scala/scalafmt/scalafmt/ScalafmtAdapter.scala
+++ b/scala/scalafmt/scalafmt/ScalafmtAdapter.scala
@@ -6,7 +6,7 @@ import org.scalafmt.sysops.PlatformFileOps
 
 object ScalafmtAdapter {
     def readFile(file: File)(implicit codec: scala.io.Codec): String =
-        PlatformFileOps.readFile(file.toPath())(codec)
+        PlatformFileOps.readFile(file.toPath())
 
     def parseConfigFile(configFile: File): ScalafmtConfig =
         ScalafmtConfig.fromHoconFile(configFile.toPath()).get

--- a/scala/scalafmt/scalafmt/ScalafmtWorker.scala
+++ b/scala/scalafmt/scalafmt/ScalafmtWorker.scala
@@ -17,7 +17,8 @@ object ScalafmtWorker extends Worker.Interface {
     val namespace = argName.zip(argFile).toMap
 
     val sourceFile = namespace.getOrElse("input", new File(""))
-    val source = ScalafmtAdapter.readFile(sourceFile)(Codec.UTF8)
+    implicit val codec: Codec = Codec.UTF8
+    val source = ScalafmtAdapter.readFile(sourceFile)
 
     val configFile = namespace.getOrElse("config", new File(""))
     val config = ScalafmtAdapter.parseConfigFile(configFile)

--- a/src/java/io/bazel/rulesscala/scalac/definitions.bzl
+++ b/src/java/io/bazel/rulesscala/scalac/definitions.bzl
@@ -18,14 +18,21 @@ DEFAULT_SRCS = [
     Label("//src/java/io/bazel/rulesscala/scalac:scalac_files"),
 ]
 
+# Keep -source/-target 1.8 for JDK 8 toolchains; -Xlint:-options silences the
+# "source/target value 8 is obsolete" warning on newer JDKs.
+_SCALAC_JAVACOPTS = [
+    "-source",
+    "1.8",
+    "-target",
+    "1.8",
+    "-Xlint:-options",
+]
+
 def define_scalac(name = "scalac", srcs = DEFAULT_SRCS, deps = DEFAULT_SCALAC_DEPS):
     java_binary(
         name = name,
         srcs = srcs,
-        javacopts = [
-            "-source 1.8",
-            "-target 1.8",
-        ],
+        javacopts = _SCALAC_JAVACOPTS,
         main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
         visibility = ["//visibility:public"],
         deps = ([
@@ -37,10 +44,7 @@ def define_scalac_bootstrap(name = "scalac_bootstrap", srcs = DEFAULT_SRCS, deps
     java_binary(
         name = name,
         srcs = srcs,
-        javacopts = [
-            "-source 1.8",
-            "-target 1.8",
-        ],
+        javacopts = _SCALAC_JAVACOPTS,
         main_class = "io.bazel.rulesscala.scalac.ScalacWorker",
         visibility = ["//visibility:public"],
         deps = deps,

--- a/src/java/io/bazel/rulesscala/specs2/BUILD
+++ b/src/java/io/bazel/rulesscala/specs2/BUILD
@@ -12,6 +12,7 @@ scala_library(
     visibility = ["//visibility:public"],
     deps = [
         "//scala/private/toolchain_deps:scala_xml",
+        "//scala/private/source_compat",
         "//src/java/io/bazel/rulesscala/test_discovery",
         "//testing/toolchain:junit_classpath",
         "//testing/toolchain:specs2_classpath",

--- a/src/java/io/bazel/rulesscala/specs2/BUILD
+++ b/src/java/io/bazel/rulesscala/specs2/BUILD
@@ -10,6 +10,7 @@ scala_library(
         "//scala/private/toolchain_deps:scala_xml",
     ],
     visibility = ["//visibility:public"],
+    exports = ["//scala/private/source_compat"],
     deps = [
         "//scala/private/toolchain_deps:scala_xml",
         "//scala/private/source_compat",

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -63,7 +63,7 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
   override def getDescription(env: Env): Description = {
     implicit def ee: ExecutionEnv = env.specs2ExecutionEnv
     try createFilteredDescription()
-    catch { case NonFatal(t) => env.shutdown; throw t; }
+    catch { case NonFatal(t) => env.shutdown(); throw t; }
   }
 
   private def createFilteredDescription()(implicit ee: ExecutionEnv): Description = {

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -31,7 +31,7 @@ object FilteringBuilder {
     Specs2FilteringRunnerBuilder.f orElse JUnitFilteringRunnerBuilder.f
 }
 
-class Specs2PrefixSuffixTestDiscoveringSuite(runnerBuilder: RunnerBuilder)
+class Specs2PrefixSuffixTestDiscoveringSuite(testClass: SourceCompat.Class, runnerBuilder: RunnerBuilder)
   extends Suite(
     new FilteredRunnerBuilder(runnerBuilder, FilteringBuilder()),
     PrefixSuffixTestDiscoveringSuite.discoverClasses()) {

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -17,7 +17,7 @@ import org.specs2.specification.process.Stats
 
 import java.util
 import java.util.regex.Pattern
-import scala.collection.JavaConverters._
+import io.bazel.rulesscala.sourcecompat.SourceCompat.JavaConversions._
 import scala.collection.immutable.Iterable
 import scala.language.reflectiveCalls
 import scala.util.Try
@@ -105,11 +105,11 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
   private def allFragmentDescriptions(implicit ee: ExecutionEnv): Map[Fragment, Description] =
     flattenLeft(createDescriptionTree.toTree).toMap
 
-  private def flattenLeft(tree: Tree[(Fragment, Description)]): Stream[(Fragment, Description)] =
-    squishLeft(tree, Stream.Empty)
+  private def flattenLeft(tree: Tree[(Fragment, Description)]): SourceCompat.Stream[(Fragment, Description)] =
+    squishLeft(tree, SourceCompat.Stream.empty)
 
-  private def squishLeft(tree: Tree[(Fragment, Description)], xs: Stream[(Fragment, Description)]): Stream[(Fragment, Description)] =
-    Stream.cons(tree.rootLabel, tree.subForest.reverse.foldLeft(xs)((s, t) => squishLeft(t, s)))
+  private def squishLeft(tree: Tree[(Fragment, Description)], xs: SourceCompat.Stream[(Fragment, Description)]): SourceCompat.Stream[(Fragment, Description)] =
+    SourceCompat.Stream.cons(tree.rootLabel, tree.subForest.reverse.foldLeft(xs)((s, t) => squishLeft(t, s)))
 
   /**
    * Creates a mapping from sanitized example fragment name to original (un-sanitized) text.

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -11,7 +11,7 @@ import org.specs2.control.Action
 import org.specs2.fp.Tree.Node
 import org.specs2.fp.{Tree, TreeLoc}
 import org.specs2.main.{Arguments, CommandLine, Select}
-import org.specs2.specification.core.{Env, Fragment, SpecStructure, SpecificationStructure}
+import org.specs2.specification.core.{Env, Fragment, SpecificationStructure}
 import org.specs2.specification.process.Stats
 
 import java.util
@@ -30,7 +30,7 @@ object FilteringBuilder {
     Specs2FilteringRunnerBuilder.f orElse JUnitFilteringRunnerBuilder.f
 }
 
-class Specs2PrefixSuffixTestDiscoveringSuite(suite: Class[Any], runnerBuilder: RunnerBuilder)
+class Specs2PrefixSuffixTestDiscoveringSuite(runnerBuilder: RunnerBuilder)
   extends Suite(
     new FilteredRunnerBuilder(runnerBuilder, FilteringBuilder()),
     PrefixSuffixTestDiscoveringSuite.discoverClasses()) {
@@ -60,12 +60,13 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
   override lazy val specification: SpecificationStructure = parentRunner.specification
 
   override def getDescription(env: Env): Description = {
-    try createFilteredDescription(specStructure, env.specs2ExecutionEnv)
+    implicit def ee: ExecutionEnv = env.specs2ExecutionEnv
+    try createFilteredDescription()
     catch { case NonFatal(t) => env.shutdown; throw t; }
   }
 
-  private def createFilteredDescription(specStructure: SpecStructure, ee: ExecutionEnv): Description = {
-    val descTree = createDescriptionTree(ee).map(_._2)
+  private def createFilteredDescription()(implicit ee: ExecutionEnv): Description = {
+    val descTree = createDescriptionTree.map(_._2)
 
     def bottomUp[A, B](t: Tree[A], f: ((A, Iterable[B]) => B)): Tree[B] = {
       val tbs = t.subForest.map(t => bottomUp(t, f))
@@ -101,7 +102,7 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
       .getOrElse(allDescriptions[specs2_v3].createDescriptionTree(specStructure))
 
   private def allFragmentDescriptions(implicit ee: ExecutionEnv): Map[Fragment, Description] =
-    flattenLeft(createDescriptionTree(ee).toTree).toMap
+    flattenLeft(createDescriptionTree.toTree).toMap
 
   private def flattenLeft(tree: Tree[(Fragment, Description)]): Stream[(Fragment, Description)] =
     squishLeft(tree, Stream.Empty)

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -1,5 +1,6 @@
 package io.bazel.rulesscala.specs2
 
+import io.bazel.rulesscala.sourcecompat.SourceCompat
 import io.bazel.rulesscala.test_discovery.FilteredRunnerBuilder.FilteringRunnerBuilder
 import io.bazel.rulesscala.test_discovery._
 import org.junit.runner.notification.RunNotifier
@@ -48,12 +49,12 @@ class Specs2PrefixSuffixTestDiscoveringSuite(runnerBuilder: RunnerBuilder)
 
 object Specs2FilteringRunnerBuilder {
   val f: FilteringRunnerBuilder = {
-    case (parentRunner: org.specs2.runner.JUnitRunner, testClass: Class[_], pattern: Pattern) =>
+    case (parentRunner: org.specs2.runner.JUnitRunner, testClass: SourceCompat.Class, pattern: Pattern) =>
       new FilteredSpecs2ClassRunner(parentRunner, testClass, pattern)
   }
 }
 
-class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, testClass: Class[_], testFilter: Pattern)
+class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, testClass: SourceCompat.Class, testFilter: Pattern)
   extends org.specs2.runner.JUnitRunner(testClass) {
 
   //taking it from parent so not to initialize test classes multiple times

--- a/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/specs2/Specs2RunnerBuilder.scala
@@ -12,7 +12,7 @@ import org.specs2.control.Action
 import org.specs2.fp.Tree.Node
 import org.specs2.fp.{Tree, TreeLoc}
 import org.specs2.main.{Arguments, CommandLine, Select}
-import org.specs2.specification.core.{Env, Fragment, SpecificationStructure}
+import org.specs2.specification.core.{Env, Fragment, SpecStructure, SpecificationStructure}
 import org.specs2.specification.process.Stats
 
 import java.util
@@ -61,13 +61,12 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
   override lazy val specification: SpecificationStructure = parentRunner.specification
 
   override def getDescription(env: Env): Description = {
-    implicit def ee: ExecutionEnv = env.specs2ExecutionEnv
-    try createFilteredDescription()
-    catch { case NonFatal(t) => env.shutdown(); throw t; }
+    try createFilteredDescription(specStructure, env.specs2ExecutionEnv)
+    catch { case NonFatal(t) => env.shutdown; throw t; }
   }
 
-  private def createFilteredDescription()(implicit ee: ExecutionEnv): Description = {
-    val descTree = createDescriptionTree.map(_._2)
+  private def createFilteredDescription(specStructure: SpecStructure, ee: ExecutionEnv): Description = {
+    val descTree = createDescriptionTree(ee).map(_._2)
 
     def bottomUp[A, B](t: Tree[A], f: ((A, Iterable[B]) => B)): Tree[B] = {
       val tbs = t.subForest.map(t => bottomUp(t, f))
@@ -98,12 +97,12 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
     else sanitized
   }
 
-  private def createDescriptionTree(implicit ee: ExecutionEnv): TreeLoc[(Fragment, Description)] =
+  private def createDescriptionTree(ee: ExecutionEnv): TreeLoc[(Fragment, Description)] =
     Try(allDescriptions[specs2_v4].createDescriptionTree(specStructure)(ee))
       .getOrElse(allDescriptions[specs2_v3].createDescriptionTree(specStructure))
 
-  private def allFragmentDescriptions(implicit ee: ExecutionEnv): Map[Fragment, Description] =
-    flattenLeft(createDescriptionTree.toTree).toMap
+  private def allFragmentDescriptions(ee: ExecutionEnv): Map[Fragment, Description] =
+    flattenLeft(createDescriptionTree(ee).toTree).toMap
 
   private def flattenLeft(tree: Tree[(Fragment, Description)]): SourceCompat.Stream[(Fragment, Description)] =
     squishLeft(tree, SourceCompat.Stream.empty)
@@ -115,7 +114,7 @@ class FilteredSpecs2ClassRunner(parentRunner: org.specs2.runner.JUnitRunner, tes
    * Creates a mapping from sanitized example fragment name to original (un-sanitized) text.
    */
   private def specs2FragmentNamesBySanitizedName(implicit ee: ExecutionEnv): Map[String, String] =
-    allFragmentDescriptions
+    allFragmentDescriptions(ee)
       .keys
       .map(fragment => fragment.description.show)
       .map(description => sanitize(description) -> description)

--- a/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/ArchiveEntries.scala
@@ -1,11 +1,13 @@
 package io.bazel.rulesscala.test_discovery
 
+import io.bazel.rulesscala.sourcecompat.SourceCompat
+
 import java.io.{File, FileInputStream}
 import java.util.jar.{JarEntry, JarInputStream}
 
 object ArchiveEntries {
-  def listClassFiles(file: File): Stream[String] = {
-    
+  def listClassFiles(file: File): SourceCompat.Stream[String] = {
+
     val allEntries = if (file.isDirectory)
       directoryEntries(file).map(_.stripPrefix(file.toString).stripPrefix("/").stripPrefix("\\"))
     else
@@ -23,15 +25,18 @@ object ArchiveEntries {
     entry
   }
 
-  private def jarEntries(jarInputStream: JarInputStream): Stream[String] =
-    Stream.continually(getJarEntryOrCloseStream(jarInputStream))
+  private def jarEntries(jarInputStream: JarInputStream): SourceCompat.Stream[String] =
+    SourceCompat.Stream.continually(getJarEntryOrCloseStream(jarInputStream))
       .takeWhile(_.nonEmpty)
       .flatten
       .map(_.getName)
 
-  private def directoryEntries(file: File): Stream[String] =
-    file.toString #:: (file.listFiles match {
-      case null => Stream.empty
-      case files => files.toStream.flatMap(directoryEntries)
-    })
+  private def directoryEntries(file: File): SourceCompat.Stream[String] =
+    SourceCompat.Stream.cons(
+      file.toString,
+      file.listFiles match {
+        case null => SourceCompat.Stream.empty
+        case files => SourceCompat.toStream(files).flatMap(directoryEntries)
+      }
+    )
 }

--- a/src/java/io/bazel/rulesscala/test_discovery/BUILD
+++ b/src/java/io/bazel/rulesscala/test_discovery/BUILD
@@ -8,6 +8,7 @@ scala_library(
         "FilteredRunnerBuilder.scala",
     ],
     visibility = ["//visibility:public"],
+    exports = ["//scala/private/source_compat"],
     deps = [
         "//scala/private/source_compat",
         "//testing/toolchain:junit_classpath",

--- a/src/java/io/bazel/rulesscala/test_discovery/BUILD
+++ b/src/java/io/bazel/rulesscala/test_discovery/BUILD
@@ -8,5 +8,8 @@ scala_library(
         "FilteredRunnerBuilder.scala",
     ],
     visibility = ["//visibility:public"],
-    deps = ["//testing/toolchain:junit_classpath"],
+    deps = [
+        "//scala/private/source_compat",
+        "//testing/toolchain:junit_classpath",
+    ],
 )

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -1,5 +1,6 @@
 package io.bazel.rulesscala.test_discovery
 
+import io.bazel.rulesscala.sourcecompat.SourceCompat
 import io.bazel.rulesscala.test_discovery.ArchiveEntries.listClassFiles
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -46,7 +47,7 @@ object PrefixSuffixTestDiscoveringSuite {
   private val runWithAnnotation = classOf[RunWith]
   private val testAnnotation = classOf[Test]
 
-  private[rulesscala] def discoverClasses(): Array[Class[_]] = {
+  private[rulesscala] def discoverClasses(): Array[SourceCompat.Class] = {
     val archives = archivesPath.split(',').filter(_.nonEmpty)
     val classes = archives.map(new File(_)).flatMap(discoverClassesIn).distinct
     if (classes.isEmpty)
@@ -59,7 +60,7 @@ object PrefixSuffixTestDiscoveringSuite {
     classes
   }
 
-  private def discoverClassesIn(file: File): Stream[Class[_]] = {
+  private def discoverClassesIn(file: File): Stream[SourceCompat.Class] = {
     val classes = discoverClasses(listClassFiles(file), prefixes, suffixesWithClassSuffix)
 
     if (printDiscoveredClasses) {
@@ -71,7 +72,7 @@ object PrefixSuffixTestDiscoveringSuite {
 
   private def discoverClasses(entries: Stream[String],
                               prefixes: Set[String],
-                              suffixes: Set[String]): Stream[Class[_]] =
+                              suffixes: Set[String]): Stream[SourceCompat.Class] =
     matchingEntries(entries, prefixes, suffixes)
       .map(dropFileSuffix)
       .map(fileToClassFormat)
@@ -126,27 +127,27 @@ object PrefixSuffixTestDiscoveringSuite {
   private def printDiscoveredClasses: Boolean =
     System.getProperty("bazel.discover.classes.print.discovered").toBoolean
 
-  private def concreteClasses(testClass: Class[_]): Boolean =
+  private def concreteClasses(testClass: SourceCompat.Class): Boolean =
     !Modifier.isAbstract(testClass.getModifiers)
 
   private def innerClasses(testClassName: String): Boolean =
     testClassName.contains('$')
 
-  private def containsTests(testClass: Class[_]): Boolean =
+  private def containsTests(testClass: SourceCompat.Class): Boolean =
     annotatedWithRunWith(testClass) || hasTestAnnotatedMethodsInClassHierarchy(testClass)
 
-  private def annotatedWithRunWith(testClass: Class[_]) =
+  private def annotatedWithRunWith(testClass: SourceCompat.Class) =
     testClass.getAnnotation(runWithAnnotation) != null
 
   @tailrec
-  private def hasTestAnnotatedMethodsInClassHierarchy(testClass: Class[_]): Boolean =
+  private def hasTestAnnotatedMethodsInClassHierarchy(testClass: SourceCompat.Class): Boolean =
     Option(testClass) match {
       case None => false
       case Some(currentTestClass) if hasTestAnnotatedMethodsInCurrentClass(currentTestClass) => true
       case Some(currentTestClass) => hasTestAnnotatedMethodsInClassHierarchy(currentTestClass.getSuperclass)
     }
 
-  private def hasTestAnnotatedMethodsInCurrentClass(testClass: Class[_]): Boolean =
+  private def hasTestAnnotatedMethodsInCurrentClass(testClass: SourceCompat.Class): Boolean =
     testClass.getDeclaredMethods.exists { method =>
       method.getAnnotations.exists { (annotation: Annotation) =>
         testAnnotation.isAssignableFrom(annotation.annotationType)

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -60,7 +60,7 @@ object PrefixSuffixTestDiscoveringSuite {
     classes
   }
 
-  private def discoverClassesIn(file: File): Stream[SourceCompat.Class] = {
+  private def discoverClassesIn(file: File): SourceCompat.Stream[SourceCompat.Class] = {
     val classes = discoverClasses(listClassFiles(file), prefixes, suffixesWithClassSuffix)
 
     if (printDiscoveredClasses) {
@@ -70,9 +70,9 @@ object PrefixSuffixTestDiscoveringSuite {
     classes
   }
 
-  private def discoverClasses(entries: Stream[String],
+  private def discoverClasses(entries: SourceCompat.Stream[String],
                               prefixes: Set[String],
-                              suffixes: Set[String]): Stream[SourceCompat.Class] =
+                              suffixes: Set[String]): SourceCompat.Stream[SourceCompat.Class] =
     matchingEntries(entries, prefixes, suffixes)
       .map(dropFileSuffix)
       .map(fileToClassFormat)
@@ -81,9 +81,9 @@ object PrefixSuffixTestDiscoveringSuite {
       .filter(concreteClasses)
       .filter(containsTests)
 
-  private def matchingEntries(entries: Stream[String],
+  private def matchingEntries(entries: SourceCompat.Stream[String],
                               prefixes: Set[String],
-                              suffixes: Set[String]): Stream[String] =
+                              suffixes: Set[String]): SourceCompat.Stream[String] =
     entries
       .filter(entry => endsWith(suffixes)(entry) || startsWith(prefixes)(entry))
 

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -38,7 +38,7 @@ import scala.annotation.tailrec
 @RunWith(classOf[PrefixSuffixTestDiscoveringSuite])
 class DiscoveredTestSuite
 
-class PrefixSuffixTestDiscoveringSuite(testClass: Class[Any], builder: RunnerBuilder)
+class PrefixSuffixTestDiscoveringSuite(builder: RunnerBuilder)
   extends Suite(new FilteredRunnerBuilder(builder, JUnitFilteringRunnerBuilder.f), PrefixSuffixTestDiscoveringSuite.discoverClasses())
 
 object PrefixSuffixTestDiscoveringSuite {

--- a/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/DiscoveredTestSuite.scala
@@ -39,7 +39,7 @@ import scala.annotation.tailrec
 @RunWith(classOf[PrefixSuffixTestDiscoveringSuite])
 class DiscoveredTestSuite
 
-class PrefixSuffixTestDiscoveringSuite(builder: RunnerBuilder)
+class PrefixSuffixTestDiscoveringSuite(testClass: SourceCompat.Class, builder: RunnerBuilder)
   extends Suite(new FilteredRunnerBuilder(builder, JUnitFilteringRunnerBuilder.f), PrefixSuffixTestDiscoveringSuite.discoverClasses())
 
 object PrefixSuffixTestDiscoveringSuite {

--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -11,7 +11,7 @@ import org.junit.runner.Runner
 import org.junit.runners.BlockJUnit4ClassRunner
 import org.junit.runners.model.{FrameworkMethod, RunnerBuilder, TestClass}
 
-import scala.collection.JavaConverters._
+import io.bazel.rulesscala.sourcecompat.SourceCompat.JavaConversions._
 
 object FilteredRunnerBuilder {
   type FilteringRunnerBuilder = PartialFunction[(Runner, SourceCompat.Class, Pattern), Runner]

--- a/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
+++ b/src/java/io/bazel/rulesscala/test_discovery/FilteredRunnerBuilder.scala
@@ -1,6 +1,7 @@
 package io.bazel.rulesscala.test_discovery
 
 import FilteredRunnerBuilder.FilteringRunnerBuilder
+import io.bazel.rulesscala.sourcecompat.SourceCompat
 
 import java.lang.annotation.Annotation
 import java.util
@@ -13,14 +14,14 @@ import org.junit.runners.model.{FrameworkMethod, RunnerBuilder, TestClass}
 import scala.collection.JavaConverters._
 
 object FilteredRunnerBuilder {
-  type FilteringRunnerBuilder = PartialFunction[(Runner, Class[_], Pattern), Runner]
+  type FilteringRunnerBuilder = PartialFunction[(Runner, SourceCompat.Class, Pattern), Runner]
 }
 
 class FilteredRunnerBuilder(builder: RunnerBuilder, filteringRunnerBuilder: FilteringRunnerBuilder) extends RunnerBuilder {
   // Defined by --test_filter bazel flag.
   private val maybePattern = sys.env.get("TESTBRIDGE_TEST_ONLY").map(Pattern.compile)
 
-  override def runnerForClass(testClass: Class[_]): Runner = {
+  override def runnerForClass(testClass: SourceCompat.Class): Runner = {
     val runner = builder.runnerForClass(testClass)
     maybePattern.flatMap(pattern =>
       filteringRunnerBuilder.lift((runner, testClass, pattern))
@@ -28,8 +29,8 @@ class FilteredRunnerBuilder(builder: RunnerBuilder, filteringRunnerBuilder: Filt
   }
 }
 
-private[rulesscala] class FilteredTestClass(testClass: Class[_], pattern: Pattern) extends TestClass(testClass) {
-  override def getAnnotatedMethods(aClass: Class[_ <: Annotation]): util.List[FrameworkMethod] = {
+private[rulesscala] class FilteredTestClass(testClass: SourceCompat.Class, pattern: Pattern) extends TestClass(testClass) {
+  override def getAnnotatedMethods(aClass: SourceCompat.ClassOf[Annotation]): util.List[FrameworkMethod] = {
     val methods = super.getAnnotatedMethods(aClass)
     if (aClass == classOf[Test])
       methods.asScala.filter(method => methodMatchesPattern(method, pattern)).asJava
@@ -48,11 +49,11 @@ object JUnitFilteringRunnerBuilder {
   private final val TestClassField = "testClass"
 
   val f: FilteringRunnerBuilder = {
-    case (runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) =>
+    case (runner: BlockJUnit4ClassRunner, testClass: SourceCompat.Class, pattern: Pattern) =>
       replaceRunnerTestClass(runner, testClass, pattern)
   }
 
-  private def replaceRunnerTestClass(runner: BlockJUnit4ClassRunner, testClass: Class[_], pattern: Pattern) = {
+  private def replaceRunnerTestClass(runner: BlockJUnit4ClassRunner, testClass: SourceCompat.Class, pattern: Pattern) = {
     allFieldsOf(runner.getClass)
       .find(f => f.getName == TestClassField || f.getName == TestClassFieldPreJUnit4_12)
       .foreach(field => {
@@ -62,8 +63,8 @@ object JUnitFilteringRunnerBuilder {
     runner
   }
 
-  private def allFieldsOf(clazz: Class[_]) = {
-    def supers(cl: Class[_]): List[Class[_]] = {
+  private def allFieldsOf(clazz: SourceCompat.Class) = {
+    def supers(cl: SourceCompat.Class): List[SourceCompat.Class] = {
       if (cl == null) Nil else cl :: supers(cl.getSuperclass)
     }
 

--- a/src/scala/io/bazel/rules_scala/jmh_support/BUILD
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BUILD
@@ -9,6 +9,7 @@ scala_library(
     ],
     deps = [
         "//jmh:benchmark_generator",
+        "//scala/private/source_compat",
     ],
 )
 

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -1,5 +1,7 @@
 package io.bazel.rules_scala.jmh_support
 
+import io.bazel.rulesscala.sourcecompat.SourceCompat
+
 import java.net.URLClassLoader
 
 import org.openjdk.jmh.generators.core.{FileSystemDestination, GeneratorSource, BenchmarkGenerator => JMHGenerator}
@@ -181,7 +183,7 @@ object BenchmarkGenerator {
     }
   }
 
-  private def classByPath(path: Path, cl: ClassLoader): Option[Class[_]] = {
+  private def classByPath(path: Path, cl: ClassLoader): Option[SourceCompat.Class] = {
     val separator = path.getFileSystem.getSeparator
     var s = path.toString
       .stripPrefix(separator)

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -2,7 +2,6 @@ package io.bazel.rules_scala.jmh_support
 
 import java.net.URLClassLoader
 
-import scala.collection.JavaConverters._
 import org.openjdk.jmh.generators.core.{FileSystemDestination, GeneratorSource, BenchmarkGenerator => JMHGenerator}
 import org.openjdk.jmh.generators.asm.ASMGeneratorSource
 import org.openjdk.jmh.generators.reflection.RFGeneratorSource

--- a/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
+++ b/src/scala/io/bazel/rules_scala/jmh_support/BenchmarkGenerator.scala
@@ -9,7 +9,7 @@ import org.openjdk.jmh.generators.asm.ASMGeneratorSource
 import org.openjdk.jmh.generators.reflection.RFGeneratorSource
 import java.net.URI
 
-import scala.collection.JavaConverters._
+import io.bazel.rulesscala.sourcecompat.SourceCompat.JavaConversions._
 import java.nio.file.{FileSystems, Files, Path}
 
 import io.bazel.rulesscala.jar.JarCreator
@@ -132,8 +132,8 @@ object BenchmarkGenerator {
   }
 
   private def constructJar(output: Path, fileDir: Path): Unit = {
-    val creator = new JarCreator(output.toAbsolutePath.toFile.toString)
-    creator.addDirectory(fileDir.toFile)
+    val creator = new JarCreator(output.toAbsolutePath)
+    creator.addDirectory(fileDir)
     creator.execute
   }
 

--- a/src/scala/io/bazel/rules_scala/scrooge_support/FocusedZipImporter.scala
+++ b/src/scala/io/bazel/rules_scala/scrooge_support/FocusedZipImporter.scala
@@ -64,8 +64,6 @@ case class FocusedZipImporter(focus: Option[File], zips: List[File], zipFiles: L
       FileContents(importer, Source.fromInputStream(zipFile.getInputStream(entry), "UTF-8").mkString, Some(entry.getName))
     }
 
-  private[this] def canResolve(filename: String): Boolean = resolve(filename).isDefined
-
   override def getResolvedPath(filename: String): Option[String] =
     resolve(filename).map { case (_, zf, _) =>
       new File(zf.getName, toZipEntryPath(filename)).getCanonicalPath

--- a/src/scala/scripts/BUILD
+++ b/src/scala/scripts/BUILD
@@ -45,6 +45,9 @@ scala_library(
 scala_library(
     name = "scalapb_worker_lib",
     srcs = ["ScalaPBWorker.scala"],
+    scalacopts = select_for_scala_version(
+        since_3_4 = ["-source:3.3"],
+    ),
     visibility = ["//visibility:public"],
     deps = [
         "//scala_proto:scalapb_worker_deps",

--- a/src/scala/scripts/ScalaPBWorker.scala
+++ b/src/scala/scripts/ScalaPBWorker.scala
@@ -5,15 +5,21 @@ import java.net.URLClassLoader
 import java.nio.file.{Files, Paths}
 
 import io.bazel.rulesscala.worker.Worker
-import protocbridge.{ProtocBridge, ProtocCodeGenerator}
+import protocbridge.{ProtocBridge, ProtocCodeGenerator, ProtocRunner}
 
 import scala.sys.process._
 
 object ScalaPBWorker extends Worker.Interface {
 
-  private val protoc = {
-    val executable = sys.props.getOrElse("PROTOC", sys.error("PROTOC not supplied"))
-    (args: Seq[String]) => Process(executable, args).!(ProcessLogger(stderr.println(_)))
+  private val protocRunner: ProtocRunner[Int] = ProtocRunner.fromFunction {
+    case (args, extraEnv) =>
+      val executable = sys.props.getOrElse("PROTOC", sys.error("PROTOC not supplied"))
+      Process(
+        command = Seq(executable) ++ args,
+        cwd = None,
+        extraEnv = extraEnv: _*,
+      )
+      .!(ProcessLogger(stderr.println(_)))
   }
 
   private val classes = {
@@ -39,7 +45,7 @@ object ScalaPBWorker extends Worker.Interface {
   def main(args: Array[String]): Unit = Worker.workerMain(args, ScalaPBWorker)
 
   def work(args: Array[String]): Unit = {
-    val code = ProtocBridge.runWithGenerators(protoc, generators, args)
+    val code = ProtocBridge.runWithGenerators(protocRunner, generators, args.toIndexedSeq)
     if (code != 0) {
       sys.error(s"Exit with code $code")
     }

--- a/src/scala/scripts/ScroogeWorker.scala
+++ b/src/scala/scripts/ScroogeWorker.scala
@@ -18,7 +18,7 @@ object ScroogeWorker extends Worker.Interface {
   def deleteDir(path: Path): Unit =
     try DeleteRecursively.run(path)
     catch {
-      case e: Exception => ()
+      case _: Exception => ()
     }
 
   def work(args: Array[String]): Unit = {

--- a/test/src/main/scala/scalarules/test/resource_jars/BUILD
+++ b/test/src/main/scala/scalarules/test/resource_jars/BUILD
@@ -14,6 +14,7 @@ scala_library(
 
 scala_import(
     name = "imported_jar_with_resources",
+    testonly = True,
     jars = [
         ":jar_with_resources.jar",
     ],

--- a/test/src/main/scala/scalarules/test/scala_import/BUILD
+++ b/test/src/main/scala/scalarules/test/scala_import/BUILD
@@ -29,6 +29,7 @@ scala_library(
 
 scala_import(
     name = "imported_genericlib_jar",
+    testonly = True,
     jars = [
         ":generic_scalalib.jar",
     ],

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer/compiler/BUILD
@@ -10,6 +10,7 @@ scala_library_for_plugin_bootstrapping(
             # Silence migration warnings when using Scala 3.4+
             "-Wconf:msg=Alphanumeric method .* is not declared infix:s",
             "-Wconf:cat=deprecation:s",
+            "-Wconf:msg=unused:s"
         ],
     ),
     visibility = ["//visibility:public"],

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/DependencyAnalyzer.scala
@@ -13,6 +13,7 @@ import io.bazel.rulesscala.scalac.reporter.DepsTrackingReporter
 
 import java.util.Locale
 import scala.jdk.CollectionConverters.*
+import scala.annotation.nowarn
 
 class DependencyAnalyzer extends StandardPlugin:
   override val name: String = "dependency-analyzer"
@@ -22,6 +23,7 @@ class DependencyAnalyzer extends StandardPlugin:
       "dependencies which are directly included in the code, or " +
       "including unused dependencies."
 
+  @nowarn("cat=deprecation")
   override def init(options: List[String]): List[PluginPhase] = {
     given DependencyAnalyzerSettings = DependencyAnalyzerSettings.parseSettings(options, error = msg => println(msg))
     // We want to perform analysis after inlining and splicing (macro interpretation) is finished

--- a/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/ScalaVersion.scala
+++ b/third_party/dependency_analyzer/src/main/io/bazel/rulesscala/dependencyanalyzer3/ScalaVersion.scala
@@ -1,7 +1,5 @@
 package io.bazel.rulesscala.dependencyanalyzer
 
-import scala.annotation.tailrec
-import scala.util.Using
 import dotty.tools.dotc
 
 object ScalaVersion {

--- a/third_party/utils/src/test/BUILD
+++ b/third_party/utils/src/test/BUILD
@@ -24,6 +24,7 @@ scala_library(
     ),
     visibility = ["//visibility:public"],
     deps = [
+        "//scala/private/source_compat",
         "//scala/private/toolchain_deps:scala_compile_classpath",
         "//third_party/dependency_analyzer/src/main:dependency_analyzer",
     ],

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/JavaCompileUtil.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/JavaCompileUtil.scala
@@ -36,7 +36,7 @@ object JavaCompileUtil {
     fileManager.close()
     // If there's a compilation error, display error messages and fail the test
     if (!success) {
-      import scala.collection.JavaConverters._
+      import io.bazel.rulesscala.sourcecompat.SourceCompat.JavaConversions._
       for (diagnostic <- diagnostics.getDiagnostics.asScala) {
         println("Code: " + diagnostic.getCode)
         println("Kind: " + diagnostic.getKind)

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil.scala
@@ -47,8 +47,8 @@ object TestUtil extends TestUtilCommon {
   ): List[Diagnostic] = {
     // TODO: Optimize and cache global.
     val options = CommandLineParserAdapter.tokenize(compileOptions)
-    val reporter = new StoreReporter()
     val settings = new Settings(println)
+    val reporter = new StoreReporter(settings)
     val _ = new CompilerCommand(options, settings)
     settings.outputDirs.setSingleOutput(output)
 

--- a/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil3.scala
+++ b/third_party/utils/src/test/io/bazel/rulesscala/utils/TestUtil3.scala
@@ -1,16 +1,16 @@
 package io.bazel.rulesscala.utils
 
 import dotty.tools.dotc.config.CommandLineParser
-import dotty.tools.dotc.{Compiler, Driver}
+import dotty.tools.dotc.Compiler
 import dotty.tools.dotc.core.Contexts.*
 import dotty.tools.dotc.reporting.{StoreReporter, Diagnostic as CompilerDiagnostic}
 import dotty.tools.dotc.util.{NoSourcePosition, SourceFile, SourcePosition as CompilerSourcePosition}
 import dotty.tools.io.{Directory, PlainDirectory, VirtualDirectory}
 
-import java.nio.file.{Path, Paths}
+import java.nio.file.Path
 
 object TestUtil extends TestUtilCommon {
-  class CompatSourcePosition(underlying: CompilerSourcePosition)(using Context)
+  class CompatSourcePosition(underlying: CompilerSourcePosition)
       extends SourcePosition {
     override def isDefined = underlying.exists
     export underlying.{line, column}


### PR DESCRIPTION
Improve source compatibity of sources to limit amount of warnings that users would see when using rules_scala and limit the chances our deprecations would result in build issues under -Werror or when combinaied with additional flags, fixes #1832 

- removal of unused variables/imports 
- Standard library compat layer - for wildcard types and used collections 
- fixes to usages of deprecated API, eg. in ProtocWorker
