### PR TITLE
fix: Expose SemanticdbInfo.target_root when semanticdb is bundled in jar

### DIFF
--- a/scala/private/phases/phase_semanticdb.bzl
+++ b/scala/private/phases/phase_semanticdb.bzl
@@ -60,7 +60,7 @@ def phase_semanticdb(ctx, p):
 
         semanticdb_provider = SemanticdbInfo(
             semanticdb_enabled = True,
-            target_root = None if toolchain.semanticdb_bundle_in_jar else semanticdb_target_root,
+            target_root = semanticdb_target_root,
             is_bundled_in_jar = toolchain.semanticdb_bundle_in_jar,
             plugin_jar = plugin_jar,
         )

--- a/test/shell/test_semanticdb.sh
+++ b/test/shell/test_semanticdb.sh
@@ -53,16 +53,9 @@ test_produces_semanticdb(){
     exit 1
   fi
 
-  if [ $is_bundle -eq 0 ]; then
-    if [[ $semanticdb_target_root == "" ]]; then
-      echo "Error: SemanticdbInfo.target_root expected to have a value"
-      exit 1
-    fi
-  else
-    if [[ $semanticdb_target_root != "" ]]; then
-      echo "Error: SemanticdbInfo.target_root expected to be empty string"
-      exit 1
-    fi
+  if [[ $semanticdb_target_root == "" ]]; then
+    echo "Error: SemanticdbInfo.target_root expected to have a value"
+    exit 1
   fi
 
   if [[ $scala_majver == 3 ]] && [[ $semanticdb_pluginjarpath != "" ]]; then
@@ -74,19 +67,16 @@ test_produces_semanticdb(){
     exit 1
   fi
 
-  if [ $is_bundle -eq 0 ]; then
+  semanticdb_path="$(bazel info execution_root)/${semanticdb_target_root}/META-INF/semanticdb/test/semanticdb/"
 
-    semanticdb_path="$(bazel info execution_root)/${semanticdb_target_root}/META-INF/semanticdb/test/semanticdb/"
+  for arg in $FILES
+    do
+      if ! [ -f "${semanticdb_path}${arg}" ]; then
+        echo "Error: Expected Semanticdb file not found: ${semanticdb_path}${arg}"
+        exit 1;
 
-    for arg in $FILES
-      do
-        if ! [ -f "${semanticdb_path}${arg}" ]; then
-          echo "Error: Expected Semanticdb file not found: ${semanticdb_path}${arg}"
-          exit 1;
-
-        fi
-      done
-  fi
+      fi
+    done
 
   local JAR="$(bazel info bazel-bin)/test/semanticdb/all_lib.jar"
 


### PR DESCRIPTION
When semanticdb_bundle_in_jar is enabled, semanticdb files are still written under _scalac/<target>/classes/META-INF/semanticdb/ on disk and also packed into the output jar. 

Always populate target_root with the on-disk path and keep is_bundled_in_jar to indicate jar bundling. 
Update semanticdb tests to assert target_root and on-disk files in bundled mode.

Fixes #1831
