### PR TITLE
ScalacWorker: call JarCreator.buildJar directly to keep IOException r…

### DIFF
--- a/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
+++ b/src/java/io/bazel/rulesscala/scalac/ScalacWorker.java
@@ -101,7 +101,20 @@ class ScalacWorker implements Worker.Interface {
     String[] jarCreatorArgs = {
         "-m", ops.manifestPath, "-t", ops.stampLabel, outputJarPath.toString(), classes.toString()
     };
-    JarCreator.main(jarCreatorArgs);
+    // Call buildJar directly rather than JarCreator.main: main() catches
+    // IOException and calls System.exit(1), which from inside a persistent
+    // worker tears down the JVM mid-request, bypassing
+    // Worker.persistentWorkerMain's catch (Exception e) block. The JVM dies
+    // before the WorkResponse is written; bb_worker sees EOF on the codec
+    // and reports an unhealthy_release back to Bazel as
+    // codes.Unavailable, which is retried up to --remote_retries and
+    // eventually surfaces as EXECUTION_FAILED_CATASTROPHICALLY with no
+    // actionable diagnostic. buildJar throws IOException, which work()
+    // already declares (`throws Exception`); the exception then propagates
+    // to Worker.persistentWorkerMain's catch block, which records
+    // exit_code=1 in the WorkResponse and keeps the JVM alive for the
+    // next request.
+    JarCreator.buildJar(jarCreatorArgs);
   }
 
   private static Path clearWorkDirectory(Path output, String label, String folderName) throws IOException {


### PR DESCRIPTION
…ecoverable

ScalacWorker.work invokes the jar packaging step at the tail of every Scalac action. The current call goes through JarCreator.main, which is the CLI entry point and catches IOException with `e.printStackTrace(); System.exit(1)`:

```java
  public static void main(String[] args) {
    try {
      buildJar(args);
    } catch (IOException e) {
      e.printStackTrace();
      System.exit(1);   // ← tears down the JVM
    }
  }
```

When the JarCreator runs inside a persistent worker JVM that's already serving WorkRequests, the System.exit(1) takes the JVM down before the WorkResponse for the in-flight request can be written. The worker server sees EOF on the codec and reports the request as unhealthy — on RBE that surfaces as codes.Unavailable and burns the action's --remote_retries budget, finally emerging upstream as EXECUTION_FAILED_CATASTROPHICALLY with no actionable diagnostic; on local builds it kills the persistent worker mid-build.

This was confirmed in production: a `java.nio.file.AccessDeniedException` from JarCreator.execute on an output jar took down dozens of Scalac persistent worker JVMs in succession before Bazel gave up. The AccessDenied itself is an unrelated build-directory issue, but it should have been a clean one-action failure with the stack trace attached, not a JVM-wide tear-down with no surface signal.

JarCreator.buildJar is already declared `throws IOException`, and ScalacWorker.work is already `throws Exception`, so the IOException propagates cleanly to Worker.persistentWorkerMain's `catch (Exception e)` block. That block writes WorkResponse with exit_code=1 (carrying the captured stack trace as output), keeps the JVM alive, and lets Bazel surface a normal action failure with the target label and stderr — the same behavior as the ephemeral (non-persistent) worker path.

JarCreator.main itself is unchanged: the CLI semantics of "exit 1 on IOException" are appropriate for command-line invocation. Only the in-worker call site is moved off it.

