### PR TITLE
worker: flush captured stderr on abnormal exit, gate trace markers behind env var

### DIFF
--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -10,6 +10,8 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * A base for JVM workers.
@@ -19,6 +21,15 @@ import java.util.List;
  *
  * <p>Worker implementations should implement the `Worker.Interface` interface and provide a main
  * method that calls `Worker.workerMain`.
+ *
+ * <p>The persistent-worker loop hijacks {@link System#out} / {@link System#err} into an
+ * in-memory buffer so the bytes can ride back in {@code WorkResponse.output}. The original
+ * {@code System.err} is snapshotted into {@code realStdErr} so a JVM shutdown hook can flush
+ * the captured tail of the in-flight request onto it on an abnormal exit that still runs
+ * shutdown hooks: {@link System#exit} from inside {@code work()}, uncaught {@link Throwable}
+ * unwinding the main thread, or signal-induced shutdown (e.g. SIGTERM). It does NOT cover
+ * SIGKILL, native JVM crashes, or {@link Runtime#halt} — those terminate without running hooks
+ * and the captured tail is unavoidably lost.
  */
 public final class Worker {
 
@@ -51,11 +62,32 @@ public final class Worker {
 
   /** The main loop for persistent worker processes */
   private static void persistentWorkerMain(Interface workerInterface) {
-    InputStream stdin = System.in;
-    PrintStream stdout = System.out;
-    PrintStream stderr = System.err;
-    ByteArrayOutputStream outStream = new SmartByteArrayOutputStream();
-    PrintStream out = new PrintStream(outStream);
+    final InputStream stdin = System.in;
+    final PrintStream stdout = System.out;
+    // Snapshot the worker server's real stderr (FD 2) before any hijack so the
+    // shutdown hook can write to a stream the server is actually reading.
+    final PrintStream realStdErr = System.err;
+    final ByteArrayOutputStream outStream = new SmartByteArrayOutputStream();
+    final PrintStream out = new PrintStream(outStream);
+
+    // Published from the main loop to the shutdown-hook thread so the
+    // abnormal-exit diagnostic can name what was running when the JVM died.
+    final AtomicReference<String> inFlightArgv = new AtomicReference<>(null);
+    final AtomicLong requestsCompleted = new AtomicLong(0);
+    final String prefix = "[rules_scala-pw pid=" + ProcessHandle.current().pid() + "] ";
+    // Set RULES_SCALA_WORKER_TRACE=1 (or any non-empty/non-zero/non-false value) to emit
+    // per-request start/end markers + lifecycle banners to the worker server's real stderr.
+    // Off by default — these are debugging output, not production logging.
+    final boolean trace = isTraceEnabled();
+
+    final Thread shutdownHook =
+        installAbnormalExitHook(
+            realStdErr, outStream, out, inFlightArgv, requestsCompleted, prefix);
+
+    if (trace) {
+      realStdErr.println(prefix + "start");
+      realStdErr.flush();
+    }
 
     // We can't support stdin, so assign it to read from an empty buffer
     System.setIn(new ByteArrayInputStream(new byte[0]));
@@ -66,7 +98,8 @@ public final class Worker {
     try {
       while (true) {
         try {
-          WorkerProtocol.WorkRequest request = WorkerProtocol.WorkRequest.parseDelimitedFrom(stdin);
+          WorkerProtocol.WorkRequest request =
+              WorkerProtocol.WorkRequest.parseDelimitedFrom(stdin);
 
           // The request will be null if stdin is closed.  We're
           // not sure if this happens in TheRealWorld™ but it is
@@ -76,10 +109,19 @@ public final class Worker {
             break;
           }
 
+          List<String> argList = request.getArgumentsList();
+          String argvSnap = summarizeArgv(argList);
+          inFlightArgv.set(argvSnap);
+          long reqNum = requestsCompleted.get() + 1;
+          if (trace) {
+            realStdErr.println(prefix + "req=" + reqNum + " argv=" + argvSnap);
+            realStdErr.flush();
+          }
+
           int code = 0;
 
           try {
-            String[] workerArgs = stringListToArray(request.getArgumentsList());
+            String[] workerArgs = stringListToArray(argList);
             String[] args = expandArgsIfArgsfile(workerArgs);
             workerInterface.work(args);
           } catch (Exception e) {
@@ -94,20 +136,122 @@ public final class Worker {
               .build()
               .writeDelimitedTo(stdout);
 
+          if (trace) {
+            realStdErr.println(
+                prefix
+                    + "req="
+                    + reqNum
+                    + " done exit="
+                    + code
+                    + " out_bytes="
+                    + outStream.size());
+            realStdErr.flush();
+          }
+          requestsCompleted.incrementAndGet();
+
         } catch (IOException e) {
           // for now we swallow IOExceptions when
           // reading/writing proto
         } finally {
           out.flush();
           outStream.reset();
+          inFlightArgv.set(null);
           System.gc();
         }
       }
     } finally {
+      // Loop exited cleanly (stdin EOF). Detach the abnormal-exit hook so it
+      // doesn't fire during the JVM's normal shutdown sequence.
+      try {
+        Runtime.getRuntime().removeShutdownHook(shutdownHook);
+      } catch (IllegalStateException ignored) {
+        // JVM is already in shutdown; the hook will fire on its own.
+      }
       System.setIn(stdin);
       System.setOut(stdout);
-      System.setErr(stderr);
+      System.setErr(realStdErr);
+      if (trace) {
+        realStdErr.println(prefix + "stop requests=" + requestsCompleted.get());
+        realStdErr.flush();
+      }
     }
+  }
+
+  private static boolean isTraceEnabled() {
+    String v = System.getenv("RULES_SCALA_WORKER_TRACE");
+    if (v == null || v.isEmpty()) return false;
+    return !v.equals("0") && !v.equalsIgnoreCase("false");
+  }
+
+  /**
+   * Installs a JVM shutdown hook that, on abnormal exit, flushes the persistent worker's captured
+   * stdout/stderr tail onto the worker server's real stderr — so a {@link System#exit} from
+   * inside {@code work()} or an uncaught {@link Throwable} surfaces with enough context for an
+   * operator to identify the failing action instead of just an EOF on the worker protocol pipe.
+   *
+   * <p>Concurrency note: when {@link System#exit} fires from inside {@code work()} the main
+   * thread is still writing to {@code outStream} while the hook reads from it. Both sides go
+   * through {@link ByteArrayOutputStream}'s synchronized methods, so the worst case is a
+   * partial-buffer read — still better than no diagnostic at all.
+   */
+  private static Thread installAbnormalExitHook(
+      PrintStream realStdErr,
+      ByteArrayOutputStream outStream,
+      PrintStream out,
+      AtomicReference<String> inFlightArgv,
+      AtomicLong requestsCompleted,
+      String prefix) {
+    final int maxTailBytes = 64 * 1024;
+    Thread hook =
+        new Thread(
+            () -> {
+              try {
+                out.flush();
+                byte[] buf = outStream.toByteArray();
+                int total = buf.length;
+                int start = total > maxTailBytes ? total - maxTailBytes : 0;
+                int len = total - start;
+                String inFlight = inFlightArgv.get();
+
+                realStdErr.println();
+                realStdErr.println(prefix + "abnormal-exit diagnostic");
+                realStdErr.println(prefix + "  requests_completed=" + requestsCompleted.get());
+                realStdErr.println(
+                    prefix + "  in_flight_argv=" + (inFlight == null ? "(idle)" : inFlight));
+                if (start > 0) {
+                  realStdErr.println(
+                      prefix
+                          + "  captured_buffer_bytes="
+                          + total
+                          + " (showing last "
+                          + maxTailBytes
+                          + ")");
+                } else {
+                  realStdErr.println(prefix + "  captured_buffer_bytes=" + total);
+                }
+                if (len > 0) {
+                  realStdErr.println(prefix + "---- captured tail begin ----");
+                  realStdErr.write(buf, start, len);
+                  if (buf[total - 1] != '\n') {
+                    realStdErr.println();
+                  }
+                  realStdErr.println(prefix + "---- captured tail end ----");
+                }
+                realStdErr.flush();
+              } catch (Throwable t) {
+                // Hooks must not propagate. Best-effort surface so a bug here isn't silent.
+                try {
+                  realStdErr.println(prefix + "abnormal-exit hook itself failed: " + t);
+                  t.printStackTrace(realStdErr);
+                  realStdErr.flush();
+                } catch (Throwable ignored) {
+                  // Give up.
+                }
+              }
+            },
+            "rules_scala-worker-abnormal-exit");
+    Runtime.getRuntime().addShutdownHook(hook);
+    return hook;
   }
 
   /** The single pass runner for ephemeral (non-persistent) worker processes */
@@ -124,10 +268,42 @@ public final class Worker {
                   Paths.get(allArgs[0].substring(1)),
                   StandardCharsets.UTF_8)
                 );
-      
+
     } else {
       return allArgs;
     }
+  }
+
+  /**
+   * Produces a printable argv summary up to ~256 characters. Used in start/end markers and the
+   * shutdown-hook diagnostic; the goal is enough context for an operator to identify the action
+   * by eyeball, not a complete record.
+   */
+  static String summarizeArgv(List<String> args) {
+    if (args.isEmpty()) {
+      return "(empty)";
+    }
+    StringBuilder sb = new StringBuilder();
+    int budget = 256;
+    int consumed = 0;
+    for (String a : args) {
+      if (budget <= 0) break;
+      if (consumed > 0) {
+        sb.append(' ');
+      }
+      if (a.length() > budget) {
+        sb.append(a, 0, budget).append("...");
+        budget = 0;
+      } else {
+        sb.append(a);
+        budget -= a.length() + 1;
+      }
+      consumed++;
+    }
+    if (consumed < args.size()) {
+      sb.append(" ...(+").append(args.size() - consumed).append(" more)");
+    }
+    return sb.toString();
   }
 
   /**

--- a/src/java/io/bazel/rulesscala/worker/WorkerTest.java
+++ b/src/java/io/bazel/rulesscala/worker/WorkerTest.java
@@ -2,14 +2,20 @@ package io.bazel.rulesscala.worker;
 
 import com.google.devtools.build.lib.worker.WorkerProtocol;
 import java.io.ByteArrayOutputStream;
+import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
 import java.io.PrintStream;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.junit.AfterClass;
 import org.junit.Test;
@@ -17,6 +23,8 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(JUnit4.class)
 public class WorkerTest {
@@ -160,6 +168,237 @@ public class WorkerTest {
     out.print("goodbye, world");
     assert (baos.toString("UTF-8").equals("goodbye, world"));
     assert (!baos.isOversized());
+  }
+
+  // ---- summarizeArgv unit tests ----
+
+  @Test
+  public void testSummarizeArgvEmpty() {
+    assertEquals("(empty)", Worker.summarizeArgv(Collections.emptyList()));
+  }
+
+  @Test
+  public void testSummarizeArgvShortArgs() {
+    assertEquals("foo bar baz", Worker.summarizeArgv(Arrays.asList("foo", "bar", "baz")));
+  }
+
+  @Test
+  public void testSummarizeArgvSingleOversizeArg() {
+    // A single arg longer than the 256-char budget gets truncated with a trailing "...".
+    StringBuilder sb = new StringBuilder();
+    for (int i = 0; i < 300; i++) sb.append('x');
+    String result = Worker.summarizeArgv(Collections.singletonList(sb.toString()));
+    assertTrue("expected truncation marker, got: " + result, result.endsWith("..."));
+    // 256 chars of payload + "..." == 259 chars total.
+    assertEquals(259, result.length());
+  }
+
+  @Test
+  public void testSummarizeArgvOverflowsBudget() {
+    // Many short args; budget is 256 chars, each "arg" entry is ~4 chars including separator,
+    // so we should consume roughly 60-70 entries before overflow and see "...(+N more)".
+    int total = 200;
+    String[] args = new String[total];
+    Arrays.fill(args, "arg");
+    String result = Worker.summarizeArgv(Arrays.asList(args));
+    assertTrue("expected overflow marker, got: " + result, result.contains("...(+"));
+    assertTrue("expected 'more' suffix, got: " + result, result.endsWith(" more)"));
+  }
+
+  // ---- abnormal-exit subprocess test ----
+
+  /**
+   * Forks a JVM that runs the persistent worker with a {@code work()} body that prints markers
+   * then calls {@link System#exit}, and asserts the shutdown-hook diagnostic appears on the
+   * subprocess's real stderr alongside the captured tail.
+   */
+  @Test
+  public void testAbnormalExitHookFlushesCapturedTail() throws Exception {
+    SubprocessResult result =
+        runHelperSubprocess(
+            "abnormal-exit-helper",
+            Collections.emptyMap(),
+            requestStream("--my-action=//some:target"));
+
+    assertEquals("subprocess should exit with helper-supplied code", 42, result.exitCode);
+    assertTrue(
+        "stderr should contain abnormal-exit header. stderr was:\n" + result.stderr,
+        result.stderr.contains("abnormal-exit diagnostic"));
+    assertTrue(
+        "stderr should name the in-flight argv. stderr was:\n" + result.stderr,
+        result.stderr.contains("in_flight_argv=--my-action=//some:target"));
+    assertTrue(
+        "stderr should report requests_completed=0. stderr was:\n" + result.stderr,
+        result.stderr.contains("requests_completed=0"));
+    assertTrue(
+        "stderr should contain captured stdout marker. stderr was:\n" + result.stderr,
+        result.stderr.contains("HELPER_STDOUT_MARKER_HELLO"));
+    assertTrue(
+        "stderr should contain captured stderr marker. stderr was:\n" + result.stderr,
+        result.stderr.contains("HELPER_STDERR_MARKER_BYE"));
+    assertTrue(
+        "stderr should bracket the captured tail. stderr was:\n" + result.stderr,
+        result.stderr.contains("---- captured tail begin ----")
+            && result.stderr.contains("---- captured tail end ----"));
+  }
+
+  /** Helper-mode {@code main}: runs as the persistent worker payload in a subprocess. */
+  static void abnormalExitHelperMain() throws Exception {
+    Worker.Interface worker =
+        new Worker.Interface() {
+          @Override
+          public void work(String[] args) {
+            System.out.println("HELPER_STDOUT_MARKER_HELLO");
+            System.err.println("HELPER_STDERR_MARKER_BYE");
+            System.out.flush();
+            System.err.flush();
+            System.exit(42);
+          }
+        };
+    Worker.workerMain(new String[] {"--persistent_worker"}, worker);
+  }
+
+  // ---- trace env-var subprocess test ----
+
+  /**
+   * Asserts that {@code RULES_SCALA_WORKER_TRACE=1} turns on per-request markers and lifecycle
+   * banners on the worker server's real stderr; absent the env var, those lines are silent.
+   */
+  @Test
+  public void testTraceModeEnabledByEnvVar() throws Exception {
+    java.util.Map<String, String> env = new java.util.HashMap<>();
+    env.put("RULES_SCALA_WORKER_TRACE", "1");
+    SubprocessResult on =
+        runHelperSubprocess("trace-helper", env, requestStream("--target=//some:label"));
+    assertEquals(0, on.exitCode);
+    assertTrue(
+        "trace=on stderr should contain 'start'. stderr was:\n" + on.stderr,
+        on.stderr.contains("] start"));
+    assertTrue(
+        "trace=on stderr should contain per-request argv. stderr was:\n" + on.stderr,
+        on.stderr.contains("argv=--target=//some:label"));
+    assertTrue(
+        "trace=on stderr should contain per-request done. stderr was:\n" + on.stderr,
+        on.stderr.contains("done exit=0"));
+    assertTrue(
+        "trace=on stderr should contain 'stop'. stderr was:\n" + on.stderr,
+        on.stderr.contains("] stop requests=1"));
+
+    SubprocessResult off =
+        runHelperSubprocess(
+            "trace-helper", Collections.emptyMap(), requestStream("--target=//some:label"));
+    assertEquals(0, off.exitCode);
+    assertFalse(
+        "trace=off stderr should NOT contain '] start'. stderr was:\n" + off.stderr,
+        off.stderr.contains("] start"));
+    assertFalse(
+        "trace=off stderr should NOT contain per-request markers. stderr was:\n" + off.stderr,
+        off.stderr.contains("argv=--target=//some:label"));
+  }
+
+  /** Helper-mode {@code main}: handles one request, returns success, then exits cleanly. */
+  static void traceHelperMain() throws Exception {
+    Worker.Interface worker =
+        new Worker.Interface() {
+          @Override
+          public void work(String[] args) {
+            // No-op: we just want a successful request to drive the trace markers.
+          }
+        };
+    Worker.workerMain(new String[] {"--persistent_worker"}, worker);
+  }
+
+  // ---- subprocess plumbing ----
+
+  /** {@code main} entry that dispatches to the helper modes used by the subprocess tests. */
+  public static void main(String[] args) throws Exception {
+    if (args.length >= 1 && args[0].equals("abnormal-exit-helper")) {
+      abnormalExitHelperMain();
+      return;
+    }
+    if (args.length >= 1 && args[0].equals("trace-helper")) {
+      traceHelperMain();
+      return;
+    }
+    System.err.println("WorkerTest.main invoked with unrecognized args: " + Arrays.toString(args));
+    System.exit(2);
+  }
+
+  private static byte[] requestStream(String... argv) throws IOException {
+    WorkerProtocol.WorkRequest.Builder b = WorkerProtocol.WorkRequest.newBuilder();
+    for (String a : argv) b.addArguments(a);
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    b.build().writeDelimitedTo(baos);
+    return baos.toByteArray();
+  }
+
+  /** Captured outcome of running a helper-mode subprocess. */
+  private static final class SubprocessResult {
+    final int exitCode;
+    final String stdout;
+    final String stderr;
+
+    SubprocessResult(int exitCode, String stdout, String stderr) {
+      this.exitCode = exitCode;
+      this.stdout = stdout;
+      this.stderr = stderr;
+    }
+  }
+
+  /**
+   * Forks {@code java -cp $CLASSPATH WorkerTest <mode>}, writes the given bytes to its stdin,
+   * drains stdout/stderr in parallel, waits up to 30s, and returns the captured outcome.
+   * Throws on timeout.
+   */
+  private static SubprocessResult runHelperSubprocess(
+      String mode, java.util.Map<String, String> extraEnv, byte[] stdinBytes) throws Exception {
+    String javaBin = System.getProperty("java.home") + File.separator + "bin" + File.separator + "java";
+    String cp = System.getProperty("java.class.path");
+    ProcessBuilder pb =
+        new ProcessBuilder(javaBin, "-cp", cp, "io.bazel.rulesscala.worker.WorkerTest", mode);
+    pb.environment().putAll(extraEnv);
+    Process p = pb.start();
+
+    ByteArrayOutputStream outBuf = new ByteArrayOutputStream();
+    ByteArrayOutputStream errBuf = new ByteArrayOutputStream();
+    Thread stdoutDrain = drain(p.getInputStream(), outBuf, "stdout-drain");
+    Thread stderrDrain = drain(p.getErrorStream(), errBuf, "stderr-drain");
+
+    try (OutputStream toChild = p.getOutputStream()) {
+      toChild.write(stdinBytes);
+      toChild.flush();
+      // For trace-helper we close stdin so the worker loop exits cleanly after one request.
+      // For abnormal-exit-helper the subprocess calls System.exit before reading further,
+      // so closing is a no-op (the OS pipe is torn down on exit).
+    }
+
+    if (!p.waitFor(30, TimeUnit.SECONDS)) {
+      p.destroyForcibly();
+      throw new AssertionError("subprocess did not exit within 30s; mode=" + mode);
+    }
+    stdoutDrain.join(5000);
+    stderrDrain.join(5000);
+
+    return new SubprocessResult(
+        p.exitValue(),
+        outBuf.toString(StandardCharsets.UTF_8),
+        errBuf.toString(StandardCharsets.UTF_8));
+  }
+
+  private static Thread drain(InputStream in, ByteArrayOutputStream into, String name) {
+    Thread t =
+        new Thread(
+            () -> {
+              try {
+                in.transferTo(into);
+              } catch (IOException ignored) {
+                // Stream closed when the subprocess exits; nothing to do.
+              }
+            },
+            name);
+    t.setDaemon(true);
+    t.start();
+    return t;
   }
 
   @AfterClass


### PR DESCRIPTION
The persistent-worker loop redirects System.out / System.err into an in-memory buffer (outStream) so the bytes ride back in WorkResponse.output. When the JVM exits before the next WorkResponse is written — direct System.exit(N) from inside work() (scalac's reporter, a compiler plugin, any wrapper that bails via Runtime.exit), uncaught Throwable unwinding the main thread, signal-induced shutdown that still runs hooks — the captured buffer dies in memory and the worker server receives nothing but an EOF on the codec. SIGKILL, native JVM crashes, and Runtime.halt are unavoidably uncovered.

Snapshot System.err into a `realStdErr` local before any setErr() call and install a JVM shutdown hook that, on every termination path that runs hooks, flushes the in-flight outStream onto realStdErr (still wired to the worker server's pipe). The normal-completion path resets outStream after every request, so a clean stdin-EOF shutdown leaves the buffer empty; the hook is removed from the runtime in the outer finally on normal exit. Track in-flight argv and a completed-request counter so the abnormal-exit diagnostic can name the action that was running. Captured tail is bounded to 64 KB (last bytes wins; the failure-causing output is typically at the end), preventing a runaway scalac from flooding the worker server's stderr ring buffer.

Per-request start/end markers and lifecycle banners are gated behind the RULES_SCALA_WORKER_TRACE env var — off by default, since the shutdown-hook diagnostic already names the in-flight argv. Set to a truthy value (e.g. RULES_SCALA_WORKER_TRACE=1) when debugging worker behavior.

Tests cover the summarizeArgv helper and exercise the shutdown-hook / trace-mode paths via a forked JVM subprocess (testing them in-process would require taking the test JVM down).

The ephemeral (non-persistent) path is unchanged; it never hijacks the streams and so never needed the recovery path.

### Motivation

Used to debug #1840.
