### PR TITLE
ci: Exercise `bazel build //...` to catch wildcard-only breakages

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -6,6 +6,23 @@ matrix:
   bcr_bazel: [7.x, 8.x, 9.x, rolling, last_green]
 
 tasks:
+  analyze_all:
+    # Loading + analysis of the whole repo (no execution). This is the cheap
+    # tripwire for wildcard-only breakages (e.g. a visibility/alias regression)
+    # that never surface when CI only builds //test/..., since a plain
+    # `bazel build //...` is not otherwise exercised anywhere. test_expect_failure/
+    # is excluded: its targets are negative tests meant to fail (some already at
+    # analysis) and are exercised explicitly by the shell scripts instead.
+    name: "bazel build //... --nobuild"
+    platform: ubuntu2004
+    shell_commands:
+      - mv tools/bazel.rc.buildkite tools/bazel.rc
+      - echo "import %workspace%/tools/bazel.rc" > .bazelrc
+    build_flags:
+      - "--nobuild"
+    build_targets:
+      - "//..."
+      - "-//test_expect_failure/..."
   ubuntu2004:
     name: "bazel test //test/..."
     platform: ubuntu2004
@@ -13,7 +30,13 @@ tasks:
       - mv tools/bazel.rc.buildkite tools/bazel.rc
       - echo "import %workspace%/tools/bazel.rc" > .bazelrc
     build_targets:
-      - "//test/..."
+      # Build everything buildable, not just //test/.... The only wildcard
+      # exclusion is test_expect_failure/, whose targets are negative tests
+      # meant to fail compilation (exercised explicitly by the shell scripts).
+      # Other conditional targets (manual_test/*, test_statsfile empty-stats
+      # genrule) are tagged "manual" and thus already skipped by wildcards.
+      - "//..."
+      - "-//test_expect_failure/..."
     test_targets:
       - "//test/..."
   macos:
@@ -24,7 +47,8 @@ tasks:
       - mv tools/bazel.rc.buildkite tools/bazel.rc
       - echo "import %workspace%/tools/bazel.rc" > .bazelrc
     build_targets:
-      - "//test/..."
+      - "//..."
+      - "-//test_expect_failure/..."
     test_targets:
       - "//test/..."
   test_rules_scala_linux:

--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -24,7 +24,7 @@ tasks:
       - "//..."
       - "-//test_expect_failure/..."
   ubuntu2004:
-    name: "bazel test //test/..."
+    name: "bazel test //..."
     platform: ubuntu2004
     shell_commands:
       - mv tools/bazel.rc.buildkite tools/bazel.rc
@@ -38,9 +38,14 @@ tasks:
       - "//..."
       - "-//test_expect_failure/..."
     test_targets:
-      - "//test/..."
+      # Mirror build_targets: run every test except the test_expect_failure/
+      # negative tests (exercised explicitly by the shell scripts). Beyond
+      # //test/... this also covers e.g. //third_party/dependency_analyzer/...,
+      # the //src/java worker/compileoptions unit tests and //tools:lint_check.
+      - "//..."
+      - "-//test_expect_failure/..."
   macos:
-    name: "bazel test //test/..."
+    name: "bazel test //..."
     platform: macos
     shell_commands:
       # Disable local disk caching on CI.
@@ -50,7 +55,8 @@ tasks:
       - "//..."
       - "-//test_expect_failure/..."
     test_targets:
-      - "//test/..."
+      - "//..."
+      - "-//test_expect_failure/..."
   test_rules_scala_linux:
     name: "./test_rules_scala"
     platform: ubuntu2004


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1843

## Chain of upstream PRs as of 2026-07-02

* PR #1843:
  `master` ← `fix/bazel-analysis`

  * **PR #1844 (THIS ONE)**:
    `fix/bazel-analysis` ← `chore/ci-analysis-check`

<!-- end git-machete generated -->

### Description

Extend CI to actually exercise the whole repo so wildcard-only breakages are caught going forward. Changes to `.bazelci/presubmit.yml`:

- Add an `analyze_all` task running `bazel build //... --nobuild` — loading + analysis of the whole repo with no execution, a cheap tripwire for regressions like the protoc alias visibility error fixed in #1843.
- Expand the `ubuntu2004` and `macos` `build_targets` from `//test/...` to `//...`, so the full repo is actually built (not just the test tree).
- Broaden the `ubuntu2004` and `macos` `test_targets` the same way, from `//test/...` to `//...`, so tests outside `//test/...` actually run: the `//third_party/dependency_analyzer/...` suite, the `//src/java` `worker`/`compileoptions` unit tests, and `//tools:lint_check`.

All three wildcards exclude `//test_expect_failure/...`, whose targets are negative tests meant to fail (some already at analysis) and are exercised explicitly by the shell scripts. Other conditional targets (`manual_test/*`, the empty-stats-file genrule) are tagged `manual` in #1843 and are therefore already skipped by wildcard expansion.

### Motivation

The whole class of bugs fixed in #1843 slipped through because CI only ever built and tested `//test/...` — a plain `bazel build //...` / `bazel test //...` was never run anywhere, so a wildcard-only regression (e.g. a visibility/alias change) produced green CI while the wildcard build was broken, and real tests outside `//test/...` were never executed. This change closes that gap by making the full repo wildcard-clean under CI. Depends on #1843, which makes `bazel build //...` pass in the first place.