### PR TITLE
fix: Disable ijar for `scala_macro_library` on Scala 2.x

### DIFF
--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -251,6 +251,7 @@ def _scala_macro_library_impl(ctx):
 _scala_macro_library_attrs = {
     "main_class": attr.string(),
     "exports": attr.label_list(allow_files = False),
+    "build_ijar": attr.bool(default = False),
 }
 
 _scala_macro_library_attrs.update(implicit_deps)

--- a/test/macros/BUILD
+++ b/test/macros/BUILD
@@ -46,3 +46,17 @@ scala_library(
         ":macro-with-dependencies",
     ],
 )
+
+# Issue #1819: when a scala_library exports a scala_macro_library, consumers only see
+# the ijar on the compile classpath. Ijar strips macro implementations, causing
+# ClassFormatError during macro expansion on Scala 2.x.
+scala_library(
+    name = "macro-exporter",
+    exports = [":correct-macro"],
+)
+
+scala_library(
+    name = "macro-export-user",
+    srcs = ["MacroExportUser.scala"],
+    deps = [":macro-exporter"],
+)

--- a/test/macros/MacroExportUser.scala
+++ b/test/macros/MacroExportUser.scala
@@ -1,0 +1,5 @@
+package macros
+
+object MacroExportUser {
+  def main(arguments: Array[String]): Unit = println(IdentityMacro.identityMacro("Hello via export!"))
+}

--- a/test/shell/test_macros.sh
+++ b/test/shell/test_macros.sh
@@ -21,6 +21,29 @@ macros_can_have_dependencies() {
   bazel build //test/macros:macro-with-dependencies-user
 }
 
+# Regression tests for https://github.com/bazel-contrib/rules_scala/issues/1819
+macro_export_user_builds() {
+  local scala_version="$1"
+  bazel build "--repo_env=SCALA_VERSION=${scala_version}" //test/macros:macro-export-user
+}
+
+scala_macro_library_does_not_build_ijar() {
+  local scala_version="$1"
+  local ijar_path="bazel-bin/test/macros/correct-macro-ijar.jar"
+
+  rm -f "${ijar_path}"
+  bazel build "--repo_env=SCALA_VERSION=${scala_version}" //test/macros:correct-macro
+  if [[ -f "${ijar_path}" ]]; then
+    echo "scala_macro_library should not produce an ijar on Scala ${scala_version}"
+    exit 1
+  fi
+}
+
 $runner incorrect_macro_user_does_not_build
 $runner correct_macro_user_builds
 $runner macros_can_have_dependencies
+
+for scala_version in 2.12.21 2.13.18; do
+  $runner macro_export_user_builds "$scala_version"
+  $runner scala_macro_library_does_not_build_ijar "$scala_version"
+done


### PR DESCRIPTION
## Summary
- Add `build_ijar = False` (default) to `scala_macro_library`, so macro implementations are not stripped by ijar on Scala 2.x.
- Add regression tests for [#1819](https://github.com/bazel-contrib/rules_scala/issues/1819): macro expansion via `exports`, and asserting that `scala_macro_library` does not produce an `-ijar.jar` output.

## Test plan
- [x] `RULES_SCALA_TEST_REGEX='macro_export_user|scala_macro_library_does_not_build_ijar|correct_macro|incorrect_macro|macros_can_have' bash test/shell/test_macros.sh local`
- [x] `./test_rules_scala.sh` (CI)