### PR TITLE
chore: Pin sources jar hashes so they are cacheable

### DIFF
--- a/scripts/create_repository.py
+++ b/scripts/create_repository.py
@@ -396,6 +396,10 @@ class ArtifactResolver:
         self._downloaded_artifacts_file = downloaded_artifacts_file
         self._artifact_cache = {}
 
+        # Populated by `resolve_artifacts`: maps `group:artifact:version` to the
+        # sha256 of that artifact's `-sources.jar` (when one is published).
+        self.srcjar_checksums = {}
+
     def resolve_artifacts(
         self, root_artifacts, current_artifacts
     ) -> List[ResolvedArtifact]:
@@ -413,6 +417,7 @@ class ArtifactResolver:
                 date versions of the `root_artifacts` and their dependencies
         """
         artifacts_data = self._fetch_artifacts_data(root_artifacts)
+        self.srcjar_checksums = self._fetch_srcjar_checksums(root_artifacts)
         current_artifacts_map = self._create_current_artifacts_map(
             current_artifacts
         )
@@ -432,13 +437,66 @@ class ArtifactResolver:
 
         return resolved
 
-    def _fetch_artifacts_data(self, root_artifacts):
+    def _fetch_srcjar_checksums(self, root_artifacts) -> Dict[str, str]:
+        """Resolves the `-sources.jar` sha256 for the artifact graph.
+
+        Runs a second `coursier fetch` restricted to the `sources` classifier.
+        This is best-effort: artifacts that publish no sources jar are simply
+        absent from the returned map (and coursier reports them only as
+        warnings, so the fetch as a whole still succeeds).
+
+        Args:
+            root_artifacts: the Maven coordinates of artifacts to resolve
+
+        Returns:
+            a map from `group:artifact:version` to the sha256 of its
+                `-sources.jar`
+        """
+        try:
+            data = self._fetch_artifacts_data(
+                root_artifacts, classifier='sources'
+            )
+        except CreateRepositoryError as err:
+            print(f'  WARNING: could not resolve sources jars: {err}')
+            return {}
+
+        checksums = {}
+
+        for artifact in data['dependencies']:
+            src_file = artifact.get('file')
+
+            if not src_file:
+                continue
+
+            coord = self._strip_classifier(artifact['coord'])
+
+            with open(src_file, 'rb') as f:
+                checksums[coord] = hashlib.sha256(f.read()).hexdigest()
+
+        return checksums
+
+    @staticmethod
+    def _strip_classifier(coord):
+        """Normalizes `group:artifact:jar:sources:version` coordinates.
+
+        Coursier reports classified artifacts with extra components (e.g.
+        `org.scala-lang:scala-library:jar:sources:2.12.21`). The groupId and
+        artifactId are always the first two components and the version the last,
+        so drop everything in between to recover the plain
+        `group:artifact:version` form used to key artifacts elsewhere.
+        """
+        parts = coord.split(':')
+        return f'{parts[0]}:{parts[1]}:{parts[-1]}'
+
+    def _fetch_artifacts_data(self, root_artifacts, classifier=None):
         try:
             artifacts_file = Path(self._downloaded_artifacts_file)
             command = (
                 f'coursier fetch {' '.join(root_artifacts)} --json-output-file ' +
                 self._downloaded_artifacts_file
             )
+            if classifier:
+                command += f' --classifier {classifier}'
             self._run_command(command, 'Fetching resolved artifacts')
 
             with open(artifacts_file, 'r', encoding='utf-8') as f:
@@ -537,6 +595,9 @@ class ArtifactUpdater:
             labeler,
         )
         self._update_artifacts(original_artifacts, resolved_artifacts)
+        self._apply_srcjar_checksums(
+            original_artifacts, self._resolver.srcjar_checksums
+        )
         self._write_to_file(original_artifacts, scala_version, file_path)
 
     def _get_original_artifacts(self, file_path, labeler):
@@ -659,7 +720,59 @@ class ArtifactUpdater:
                 del metadata['testonly']
 
     @staticmethod
+    def _apply_srcjar_checksums(artifacts, srcjar_checksums):
+        """Backfills each artifact's `srcjar_sha256` from `srcjar_checksums`.
+
+        Unlike `_update_artifacts`, this touches every entry (not just those
+        whose version changed), so it also records the sources hash for
+        artifacts already pinned at their latest version. Recording the hash
+        lets Bazel serve the `-sources.jar` from the repository cache instead of
+        re-downloading it. Entries whose coordinates have no published sources
+        jar (hence are absent from `srcjar_checksums`) get any stale
+        `srcjar_sha256` removed.
+
+        Args:
+            artifacts: the artifact repository dictionary to update in place
+            srcjar_checksums: a map from `group:artifact:version` to the sha256
+                of that artifact's `-sources.jar`
+        """
+        for metadata in artifacts.values():
+            srcjar_sha256 = srcjar_checksums.get(metadata.get('artifact'))
+
+            if srcjar_sha256:
+                metadata['srcjar_sha256'] = srcjar_sha256
+            elif 'srcjar_sha256' in metadata:
+                del metadata['srcjar_sha256']
+
+    # Canonical order of keys within a single artifact's metadata block. Any
+    # keys not listed here are appended afterwards in their existing order.
+    _METADATA_KEY_ORDER = [
+        'testonly',
+        'artifact',
+        'sha256',
+        'srcjar_sha256',
+        'deps',
+        'runtime_deps',
+    ]
+
+    @staticmethod
+    def _order_metadata_keys(metadata):
+        ordered = {
+            key: metadata[key]
+            for key in ArtifactUpdater._METADATA_KEY_ORDER
+            if key in metadata
+        }
+        for key, value in metadata.items():
+            if key not in ordered:
+                ordered[key] = value
+        return ordered
+
+    @staticmethod
     def _write_to_file(artifact_dict, scala_version, file):
+        artifact_dict = {
+            label: ArtifactUpdater._order_metadata_keys(metadata)
+            for label, metadata in artifact_dict.items()
+        }
         artifacts = (
             json.dumps(dict(sorted(artifact_dict.items())), indent=4)
                 .replace('true', 'True')

--- a/third_party/repositories/repositories.bzl
+++ b/third_party/repositories/repositories.bzl
@@ -135,6 +135,10 @@ def repositories(
             name = artifact_repo_name,
             artifact = artifacts[id]["artifact"],
             artifact_sha256 = artifacts[id]["sha256"],
+            # Pinning the sources jar hash lets Bazel serve it from the
+            # repository cache instead of re-downloading it. Empty when unknown
+            # or when the artifact publishes no sources jar.
+            srcjar_sha256 = artifacts[id].get("srcjar_sha256", ""),
             licenses = ["notice"],
             server_urls = maven_servers,
             deps = [dep + suffix for dep in artifacts[id].get("deps", [])],

--- a/third_party/repositories/scala_2_11.bzl
+++ b/third_party/repositories/scala_2_11.bzl
@@ -9,6 +9,7 @@ artifacts = {
     "com_geirsson_metaconfig_core": {
         "artifact": "com.geirsson:metaconfig-core_2.11:0.9.10",
         "sha256": "c8b8f64e42d52a0bd7af1094c46c1fc15773f3bc62d014b833509679e857035b",
+        "srcjar_sha256": "5deb9cb0107f20d1fad88d86673cc6b9f8eedca6ec0ebac520092c9529aca322",
         "deps": [
             "@com_lihaoyi_pprint",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -19,6 +20,7 @@ artifacts = {
     "com_geirsson_metaconfig_typesafe_config": {
         "artifact": "com.geirsson:metaconfig-typesafe-config_2.11:0.9.10",
         "sha256": "6260f0994d06d666b931d739635fe94b29dbcb758c421553bc4fab8822d650aa",
+        "srcjar_sha256": "6c01f81b6cdf87a5c85eff09e664d01db7778c827dea740eb5346a833ffd9907",
         "deps": [
             "@com_geirsson_metaconfig_core",
             "@com_typesafe_config",
@@ -33,14 +35,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -48,6 +53,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -65,14 +71,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.11:0.2.6",
         "sha256": "63878260e23a1e28ecd8d6987d5feda9d72507b476137b9f642ac2c75035a9c8",
+        "srcjar_sha256": "2bc66745304cb81dce5ffcb2b86afd3e35485bd60c4460d5965049dcf9d0f065",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -81,6 +90,7 @@ artifacts = {
     "com_lihaoyi_fastparse": {
         "artifact": "com.lihaoyi:fastparse_2.11:2.1.2",
         "sha256": "5c5d81f90ada03ac5b21b161864a52558133951031ee5f6bf4d979e8baa03628",
+        "srcjar_sha256": "1f4509b44b9de440400b949993277d22440033bf42425f93f5b13b94dc41f63b",
         "deps": [
             "@com_lihaoyi_sourcecode",
         ],
@@ -88,6 +98,7 @@ artifacts = {
     "com_lihaoyi_pprint": {
         "artifact": "com.lihaoyi:pprint_2.11:0.5.4",
         "sha256": "9b31150ee7f07212a825e02fca56e0999789d2b8ec720a84b75ce29ca7e195b5",
+        "srcjar_sha256": "48759a346b4e59f8d7086efbcdc2456b08da6a5da7f1b7881e9a8b6f97592298",
         "deps": [
             "@com_lihaoyi_fansi",
             "@com_lihaoyi_sourcecode",
@@ -97,6 +108,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.11:0.2.1",
         "sha256": "4b45e8b4efee81457b97439e250cd80a67f1ddbe896735cca0f05c88ebead58c",
+        "srcjar_sha256": "18aeb09f8427dd4f66a00d39f6412bc93fcff4ceb926f1b463a1893cd3f781b1",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -109,14 +121,17 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.2.1",
         "sha256": "c160fbd78f51a0c2375a794e435ce2112524a6871f64d0331895e9e26ee8b9ee",
+        "srcjar_sha256": "78a8a2728fd5236b24a9bed7c253729887848ff5d3af5f9ef02e85be5fc43bba",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -200,6 +215,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala-compiler:2.11.12",
         "sha256": "3e892546b72ab547cb77de4d840bcfd05c853e73390fed7370a8f19acb0735a0",
+        "srcjar_sha256": "d57797fe3982d69d56d432046459f5b72e87a422170d98cf295c3b1bbe93f456",
         "deps": [
             "@io_bazel_rules_scala_scala_parser_combinators",
             "@io_bazel_rules_scala_scala_xml",
@@ -210,14 +226,17 @@ artifacts = {
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala-library:2.11.12",
         "sha256": "0b3d6fd42958ee98715ba2ec5fe221f4ca1e694d7c981b0ae0cd68e97baf6dce",
+        "srcjar_sha256": "a32ccfac851adeb094a31134af1034d0ba026512931433cba86d5dd12d91f1ff",
     },
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.11:1.1.2",
         "sha256": "3e0889e95f5324da6420461f7147cb508241ed957ac5cfedc25eef19c5448f26",
+        "srcjar_sha256": "95086f3eebd756720e0fcb168f1b041e830896868803785fdd805c96fce7df50",
     },
     "io_bazel_rules_scala_scala_reflect": {
         "artifact": "org.scala-lang:scala-reflect:2.11.12",
         "sha256": "6ba385b450a6311a15c918cf8688b9af9327c6104f0ecbd35933cfcd3095fe04",
+        "srcjar_sha256": "4d4adbc4f5f6be87ec555635dd40926bf71c6d638a06d59d929de04386099063",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -225,6 +244,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.11:1.3.0",
         "sha256": "0f6dc9b10f2ed3b1cc461330c17e76a2cb7c9874289454407551d4bace712d66",
+        "srcjar_sha256": "cd1ca87baa94a562890d3949fa1a16040ce1939896d4a02c57659ceeb3e17289",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -232,6 +252,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_2.11:3.2.19",
         "sha256": "20708ca81baeed428eaf9453f038a37dadba376f5d05e85a3fb882e303040d3d",
+        "srcjar_sha256": "1e144d19da246a2401b4c7d1254be4e9b599f2f03a55bb44e2c23e9a3ddcbb50",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -240,6 +261,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_2.11:3.2.19",
         "sha256": "6f01d1f8cc8063e989900c954f3378c7cd18b7ccb5c3e54242e1dec7eea0472b",
+        "srcjar_sha256": "9e51badec41f488cebd1f74d25c8a3bdac4161b54649122c59e724fabc04e889",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -261,10 +283,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_2.11:3.2.19",
         "sha256": "763ba4408a4256a1a430b11f15b4d6f1c5f7fcf0be192a6ef4fd1124008330b7",
+        "srcjar_sha256": "5de8c0e06f704fd30430ba8467f86e1a9f20276ca2a24b4e06e3a1ba86022049",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -276,6 +300,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_2.11:3.2.19",
         "sha256": "07c86a616aaec57eb211a7cf7a47f7d3cc93f322042419c1f4daef687b5185c4",
+        "srcjar_sha256": "f1a7f1682adef04bd66d0c711e706327f1c6fb40f6c80599af5c9f0a6212b34c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -285,6 +310,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_2.11:3.2.19",
         "sha256": "acc41aa36c8c252a7e0332a3f03b66c09120ff8b7814eab39737ddc11cd9a4d0",
+        "srcjar_sha256": "71103b6f9e752770253b167ab8cfcb1adbd46f8ecae804e68c003f1348d683ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -294,6 +320,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_2.11:3.2.19",
         "sha256": "1eab3d1d54b8708869c493223db8deee2c0b3b40ce7ae3a79c82f7c2e0451d39",
+        "srcjar_sha256": "1f56dd506a12425a11e2b837a0416d7595160a57d042bed8e928ecc7ca13fce4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -303,6 +330,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_2.11:3.2.19",
         "sha256": "499508dad83c33f1347f9a7ef6590ebbdba5275c0dba47df1ce1f048a518d1a5",
+        "srcjar_sha256": "3f2922d60b0945c331826d99f0c225f74e3a40785d4d287e854145aff140ee6d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -312,6 +340,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_2.11:3.2.19",
         "sha256": "933d154f2f6fc7e86954760cd534e189ab5c8eab790fc66e41fabb9df4da3bb7",
+        "srcjar_sha256": "aee8f9050f855de8f6d23a0c7fd8307bd648cd2f8e08cba60183577f28060e56",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -321,6 +350,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_2.11:3.2.19",
         "sha256": "6f7d1679d8d375603b836fab1972d88601d26e1e1322856feb54947b4a534935",
+        "srcjar_sha256": "55a2d43256f955e108196097ffc2e5d2d7224723a0d68fd4f95ef3287d26aa1f",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -330,6 +360,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.11:3.2.19",
         "sha256": "509771ba2bc172882e0db9d4e8437a032753d4d5a66f9dc61e7f453ecc0057fb",
+        "srcjar_sha256": "e0c385ea2abcdd51384dbee66384ca97f0559c2ed25217b2d7fb30ac35f79635",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -339,6 +370,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_2.11:3.2.19",
         "sha256": "5cd41cc8607163df9d15d26e12985fa88803c98fefa19b77f8ce466e39062795",
+        "srcjar_sha256": "ac2a920f304e957a1feff3f449dc556be9bd74b85891a901322691a34be5c758",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -348,6 +380,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_2.11:3.2.19",
         "sha256": "f95779953fd8a5291f66348d999228464494dffbf97a5193583ace1adf9c1ad5",
+        "srcjar_sha256": "5c58e1ba8bc1f45d394fcab3ef6f9c62cb9531874ccd6b2dcbbb723473a22d8e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -357,6 +390,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_2.11:3.2.19",
         "sha256": "0b8f0945629d9ea8f0b0f4d9840d4f86df5abba53888b48e559971b887c42946",
+        "srcjar_sha256": "76b16ccd3ab49e4e0cf3dd242931ce3979c3c51ac048865e8648806e3470ec5e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -366,6 +400,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_2.11:3.2.19",
         "sha256": "6537c4948ff42cac2eaa7e3d88dd699bff891c574e252ba65372c7d5ed1cd1f9",
+        "srcjar_sha256": "6768f1c650b1fb3c5525c10f766c15bc177e855b0b31607c2d2afb92378725fb",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -375,6 +410,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_2.11:3.2.19",
         "sha256": "eacabc4e1b08cf704ad194b10b325590bc59173832af3e6d3109dd9b900f9fd6",
+        "srcjar_sha256": "bcb3e6a496e87891e79ec0fee6063e654f79bf3407d4294ecacf756a1550d850",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -422,14 +458,17 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.11:2.1.2",
         "sha256": "e9667b8b7276aeb42599f536fe4d7caab06eabc55e9995572267ad60c7a11c8b",
+        "srcjar_sha256": "41623a5b578c83ad9f1fe18ddfeb55aebf44ed0cc8621cba1979024b12e9bf30",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -437,6 +476,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.11.12",
         "sha256": "a6dd7203ce4af9d6185023d5dba9993eb8e80584ff4b1f6dec574a2aba4cd2b7",
+        "srcjar_sha256": "50df9e4b4c996cda761f35cbc603cf145a21157a72a82d023d44b0eeeb293e29",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],
@@ -444,10 +484,12 @@ artifacts = {
     "org_scala_sbt_test_interface": {
         "artifact": "org.scala-sbt:test-interface:1.0",
         "sha256": "15f70b38bb95f3002fec9aea54030f19bb4ecfbad64c67424b5e5fea09cd749e",
+        "srcjar_sha256": "c314491c9df4f0bd9dd125ef1d51228d70bd466ee57848df1cd1b96aea18a5ad",
     },
     "org_scalacheck_scalacheck": {
         "artifact": "org.scalacheck:scalacheck_2.11:1.14.3",
         "sha256": "3cbc95bb615f1a384b8c4406dfc42b225499f08adf7639de11566069e47d44cf",
+        "srcjar_sha256": "4bfdd6d84985c15021cf29f1d288c2844bd6827a6d6baae9b966a7c8f53f4118",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_sbt_test_interface",
@@ -456,6 +498,7 @@ artifacts = {
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.11:4.3.22",
         "sha256": "eaf3bc9c5168a52b4da0e1d39ea1ef2570a675b7de56cce7f64389835b20ac09",
+        "srcjar_sha256": "3cf958439868a9319e2636569cf68b543ab9390b7c425c4996f99f68cff79eaa",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -464,6 +507,7 @@ artifacts = {
     "org_scalameta_fastparse": {
         "artifact": "org.scalameta:fastparse_2.11:1.0.1",
         "sha256": "49ecc30a4b47efc0038099da0c97515cf8f754ea631ea9f9935b36ca7d41b733",
+        "srcjar_sha256": "9769781eeb2980be3379c2cf6aced31f60ad32fe903a830687185e9ffc223d84",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -473,6 +517,7 @@ artifacts = {
     "org_scalameta_fastparse_utils": {
         "artifact": "org.scalameta:fastparse-utils_2.11:1.0.1",
         "sha256": "93f58db540e53178a686621f7a9c401307a529b68e051e38804394a2a86cea94",
+        "srcjar_sha256": "f1c28e408d8309f6f96ea9ed0f2e0bc5661fb84d3730d1bde06207a93a3d091b",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -481,6 +526,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.11:4.3.22",
         "sha256": "c5d2d0e95c5e0fa49c0ad8e269a7e431cd74ec56b7c6bd080a39d102c36cc36d",
+        "srcjar_sha256": "415bc9da4221a9074c758cc3afcb1f27cca4ada4a7b78731418ea85bf11c9677",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_trees",
@@ -489,6 +535,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.11:2.7.5",
         "sha256": "25cd19d57e0d5e23574ba4a3a200c31432f7ebd0e55ca565cfd06ad71482d940",
+        "srcjar_sha256": "c9279e8d5e84037692173cf532644c76f67f19015f6bb3bc3784bd09840fd30c",
         "deps": [
             "@com_geirsson_metaconfig_core",
             "@com_geirsson_metaconfig_typesafe_config",
@@ -500,6 +547,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.11:4.3.22",
         "sha256": "c66ea80ff72fbb1a5cc0c11c6365106c9750ad05f8cf17adb88ac8b10925ef72",
+        "srcjar_sha256": "6ff4983ae9ba064900063f37013b7bd21cbaf5ac6f12c2b1b26a7926af4fb543",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_scalap",
@@ -509,6 +557,7 @@ artifacts = {
     "org_scalameta_semanticdb_scalac": {
         "artifact": "org.scalameta:semanticdb-scalac_2.11.12:4.13.10",
         "sha256": "39e2053bfcbae0d3bcd932557724d95dabbb28ff347a6aac308d288a67609be1",
+        "srcjar_sha256": "985a6eddd0f4909c780a0e4d5c0676964d16d95a574bc00c016b3331a324fd62",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -516,6 +565,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.11:4.3.22",
         "sha256": "59c3c27a579d893118e4e6b29db7b17fec010b3bb63cafe995be50fe907d4026",
+        "srcjar_sha256": "31414e54285748ad2df754f1c25cd6f2a409e862c9340f438625f7b99f9142d8",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_common",
@@ -525,6 +575,7 @@ artifacts = {
     "org_scalatestplus_scalacheck_1_14": {
         "artifact": "org.scalatestplus:scalacheck-1-14_2.11:3.1.1.1",
         "sha256": "1acd4045cc97e19bc0cdbdfba387be421dfe9406564834b509a1e3cf3c50cb43",
+        "srcjar_sha256": "5e911230e1651e3fe8c4bf79782cd455963abf26c01bc7a91e57b767d5b71f7d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest",
@@ -552,6 +603,7 @@ artifacts = {
     "org_typelevel_kind_projector": {
         "artifact": "org.typelevel:kind-projector_2.11.12:0.13.4",
         "sha256": "5afb39eb69c9f2b8a6f3642f1d4cf7ba3e99e1bd447f5109538f6a2fc59e0d57",
+        "srcjar_sha256": "09fde23a3709b3399903d4cdeb145a89083e91aa542508f3104bf2cc3e2d3c31",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
             "@io_bazel_rules_scala_scala_library",
@@ -560,6 +612,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.11:0.3.0",
         "sha256": "fa697cb6d1e03cb143183c45cc543734e7600dcb4dee63005738d28a722c202e",
+        "srcjar_sha256": "d678e290975f4e408592c7b80f4e5c375ce122a5526f9cf52daee7bc23387da4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -571,6 +624,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -580,6 +634,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -587,6 +642,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -601,6 +657,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -617,6 +674,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -629,6 +687,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -638,6 +697,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -648,6 +708,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -662,6 +723,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -669,6 +731,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -678,6 +741,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -689,6 +753,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -701,6 +766,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -711,10 +777,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -727,6 +795,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -739,6 +808,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -746,6 +816,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -755,6 +826,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -780,10 +852,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -791,6 +865,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_2.11:0.9.8",
         "sha256": "9fda69065da447cf91aa3c923a95b80c2bdb9f46f95b2c14af97f533b099b5a9",
+        "srcjar_sha256": "435799325da3246978c057eb3e1a7d44d98a7eb6da9f1068914f3fc19a1925fa",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -800,6 +875,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_2.11:0.9.8",
         "sha256": "20556c018aa55b196fef2e54d6f2a14d88821be8d1ba58e2c977fffb01d78972",
+        "srcjar_sha256": "f40cbac6a48d70843a80f755ebb0ddfe64434b2580040456fd72994229e0ae1f",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -807,10 +883,12 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.11:0.7.14",
         "sha256": "314e34bf331b10758ff7a780560c8b5a5b09e057695a643e33ab548e3d94aa03",
+        "srcjar_sha256": "d0cfca3398f8906b474e6b29ae0e4b493332c4dcce0be94420a020d4a3dd7e3e",
     },
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_2.11:0.9.8",
         "sha256": "c973046bff0e396dce25ce56e567a88b84e4b6cde0280964d23a2c1133f09a49",
+        "srcjar_sha256": "cb3667cd3fc6355c14b1c6ffd026c7d6bb14e9378bdbe90736cba43e18a801a5",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@com_lihaoyi_fastparse",
@@ -821,6 +899,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.11:0.9.8",
         "sha256": "6541e7f62c03dd6e63a77943c568b0719b3137e0ada135ad3ef045f7f99eb953",
+        "srcjar_sha256": "6faa6399ee52886b493ba0ec19558ef288cc2b8950697ffb96c3ff7251b0e0f5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@scala_proto_rules_grpc_protobuf",

--- a/third_party/repositories/scala_2_12.bzl
+++ b/third_party/repositories/scala_2_12.bzl
@@ -18,14 +18,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -33,6 +36,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -50,14 +54,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.12:0.5.1",
         "sha256": "57bd285ff4c4aa706fbe26e08e344881b0fc05a1a7ef8928385fab9b5208de81",
+        "srcjar_sha256": "125a6a437cb07ac97b7c71c71969978ac740e9c4154fbf60105e2d681f37b3a0",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -77,6 +84,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.12:0.4.4",
         "sha256": "b3be5e4f73dca4dfc8d2036198d5792163927318831258bdfbe9a786994a2ad1",
+        "srcjar_sha256": "3e9865263f3968b22ee5ca2ccc75ae4aaa73115357cc3cee938088689a1c17b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -89,18 +97,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -184,6 +196,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala-compiler:2.12.21",
         "sha256": "fb1bb6b0d7e8e922f03b5294ef0af23b9d2bd1cde6819ecb820c57210db4548e",
+        "srcjar_sha256": "4392a5faa59928b164e3f7548234a3b2804dcd407b16214d01176a7f1f63a5f1",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -193,10 +206,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala-library:2.12.21",
         "sha256": "e2f4040c95cc4dd1cfeaae38bdde596e4b36933632451efa7d8564c6a359510c",
+        "srcjar_sha256": "8c017a4ac49179a6d9c0e5300b38f20ec44b8f80d6b00018a5e3034c46365e10",
     },
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.12:2.4.0",
         "sha256": "23a8d4ddbb7d116dc7a4c41a33f362e5f908cb6b57210c6ed38e61a6c8e383ea",
+        "srcjar_sha256": "6e93bce718c90dc9bbf018dbdb571f03afe3f3b47e7c94c85894bbfe9ca15720",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -204,6 +219,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect": {
         "artifact": "org.scala-lang:scala-reflect:2.12.21",
         "sha256": "8b91a08ba69a0564689793e732f06768d0914ec9e90fa8c3d1b55c5bf4600c14",
+        "srcjar_sha256": "f690f8e748bd388a3a2535fb25990cae1c15fe15a98360dd4028905b7500f991",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -211,6 +227,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.12:2.3.0",
         "sha256": "4932c56a2d5aae77ae8d7ac6bed1f21d48268fdbac8b4e5f3ca5196ad10fd93e",
+        "srcjar_sha256": "bb93b2fdcd36ebd3e7e6e6de961cd2a4ead3815c9565c7be5cad860cf3d8c81c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -218,6 +235,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_2.12:3.2.19",
         "sha256": "a50a3248208b25e9797c447709fe4276026510beae01e82366f405a66d9a8d57",
+        "srcjar_sha256": "1e144d19da246a2401b4c7d1254be4e9b599f2f03a55bb44e2c23e9a3ddcbb50",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -226,6 +244,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_2.12:3.2.19",
         "sha256": "9f7dc750bbd6eeb52f0d8bc7c542ace46da9efdca0128a5a92769a448e065a62",
+        "srcjar_sha256": "9e51badec41f488cebd1f74d25c8a3bdac4161b54649122c59e724fabc04e889",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -247,10 +266,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_2.12:3.2.19",
         "sha256": "57b683ac16954fae147182bae9619a1d3070286bc2febc18c059600dd2885a99",
+        "srcjar_sha256": "5de8c0e06f704fd30430ba8467f86e1a9f20276ca2a24b4e06e3a1ba86022049",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -262,6 +283,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_2.12:3.2.19",
         "sha256": "4644e596643982591ab335adfecd55cd3ca773a859cd9a163bb14fed032b0c9f",
+        "srcjar_sha256": "f1a7f1682adef04bd66d0c711e706327f1c6fb40f6c80599af5c9f0a6212b34c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -271,6 +293,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_2.12:3.2.19",
         "sha256": "a7173e04338830b03cb366839bd03deb1765e06bacd3414c306548ba03280016",
+        "srcjar_sha256": "71103b6f9e752770253b167ab8cfcb1adbd46f8ecae804e68c003f1348d683ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -280,6 +303,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_2.12:3.2.19",
         "sha256": "b3974fa6f1f4b97b583ac94911adbb5b78a48a5c06101860d015f0e9df0e0131",
+        "srcjar_sha256": "1f56dd506a12425a11e2b837a0416d7595160a57d042bed8e928ecc7ca13fce4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -289,6 +313,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_2.12:3.2.19",
         "sha256": "008cad5f68215028f3120ce24cd8f40ee435260d14455143884da8f66496c7b2",
+        "srcjar_sha256": "3f2922d60b0945c331826d99f0c225f74e3a40785d4d287e854145aff140ee6d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -298,6 +323,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_2.12:3.2.19",
         "sha256": "24646029011aa0528cbba3d14320167f16604225eb72eaf95521134ac82944e6",
+        "srcjar_sha256": "aee8f9050f855de8f6d23a0c7fd8307bd648cd2f8e08cba60183577f28060e56",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -307,6 +333,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_2.12:3.2.19",
         "sha256": "4ccea10ecf3f1ecfd16d7cab4da2dbec965da1cebc5e956aeddc814e27845ba8",
+        "srcjar_sha256": "55a2d43256f955e108196097ffc2e5d2d7224723a0d68fd4f95ef3287d26aa1f",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -316,6 +343,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.12:3.2.19",
         "sha256": "1048196692ce8ad06fed0e6fb41ce87d6b205646be3c2a78d3654ce90a9d5bc5",
+        "srcjar_sha256": "e0c385ea2abcdd51384dbee66384ca97f0559c2ed25217b2d7fb30ac35f79635",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -325,6 +353,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_2.12:3.2.19",
         "sha256": "e879ad96f7c5ab558994b34d9a96cf50dc6b32f7c34e7df0586d72ba6c3cbddc",
+        "srcjar_sha256": "ac2a920f304e957a1feff3f449dc556be9bd74b85891a901322691a34be5c758",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -334,6 +363,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_2.12:3.2.19",
         "sha256": "7482f4b139e870f14b8d32f4ad57a11846d7d5e7ea6448aebd34416bee7c2749",
+        "srcjar_sha256": "5c58e1ba8bc1f45d394fcab3ef6f9c62cb9531874ccd6b2dcbbb723473a22d8e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -343,6 +373,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_2.12:3.2.19",
         "sha256": "3c0ae4964bd2f56fd71404480724bf2ee94d081187ddf2704b603f897f1faa16",
+        "srcjar_sha256": "76b16ccd3ab49e4e0cf3dd242931ce3979c3c51ac048865e8648806e3470ec5e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -352,6 +383,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_2.12:3.2.19",
         "sha256": "36e8fa4935945c913c6989e98050355814c2f6ee96b0b350da3cc76e471eb14f",
+        "srcjar_sha256": "6768f1c650b1fb3c5525c10f766c15bc177e855b0b31607c2d2afb92378725fb",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -361,6 +393,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_2.12:3.2.19",
         "sha256": "ff5c1ebe03dbf728f6d2a698b8757d940cbeae0102b4ba3301c4ef7447033e18",
+        "srcjar_sha256": "bcb3e6a496e87891e79ec0fee6063e654f79bf3407d4294ecacf756a1550d850",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -408,14 +441,17 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.12:2.14.0",
         "sha256": "40d7c1719db7940a7101509dff407f1ff67baf01abd1f40547b04077d94a92e5",
+        "srcjar_sha256": "3135ab55ffc54fa4f8dc69dd465d6484c18cdf5578ef1de722ccbc2de4094093",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -423,6 +459,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.12.21",
         "sha256": "e33e12ad739cd70db536b5e305a07d3b081490863f0db67a515d41585c087605",
+        "srcjar_sha256": "806fb8d5ee8ff8bed6a2ed60162986aa634b9f318261e0815c467817d9e5d143",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],
@@ -430,6 +467,7 @@ artifacts = {
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.12:4.15.0",
         "sha256": "c0aa97e75e76ea7b8b0b8b184e88c2026404fc1019cbb8654033b765242a8619",
+        "srcjar_sha256": "063f363bf298586d5b432b995c0d28e0980f8c92dc8cda08717dc0313d974829",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -454,6 +492,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.12:4.15.0",
         "sha256": "181790fcd968f66f1e3a14a456817f7af5586ed09348d19e91c54be2a19c91e9",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -461,6 +500,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.12:2.8.2",
         "sha256": "f90e3b1398b72f50dbb4bbc58dacf7775202e353379837db836258f7f21e6b30",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -468,6 +508,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.12:0.18.2",
         "sha256": "4fa925ea1cf2c5d1025650173dcbc5225e1ca6bc941f705b743060be59e51472",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -479,6 +520,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.12:0.18.2",
         "sha256": "f7f14cc9ed379e672954f0295bf52200ba275ac0e89a44fd75afe0e33e07d048",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler",
@@ -489,6 +531,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.12:0.18.2",
         "sha256": "81b23cce37e94fb0d76c5583195daf4194322c9ba6aed4bb6ce845c374bca615",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library",
@@ -498,6 +541,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.12:4.15.0",
         "sha256": "665afe0636a0de59a755d30823e8e423f31d705a5a84fa95693c993ae4aadb02",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_trees",
@@ -506,6 +550,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.12:3.10.7",
         "sha256": "d4392d112ef61b057d7225d3028f857673736c05e6e793534a17c6e50a9613e9",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_metaconfig_core",
@@ -515,6 +560,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.12:3.10.7",
         "sha256": "2b3501e228f445d21d2398de09f4b53229fa22b01a5ea8a0ee617c055ebb790e",
+        "srcjar_sha256": "e8be6c46aaa41a0dedb2608daf43f594bfd2ff142b7828f917e75d082e8f140b",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_mdoc_parser",
@@ -526,6 +572,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.12:3.10.7",
         "sha256": "18e31babafc871b8dc37c69b48acac9774a4601af2b549ece421ae1dd7b15897",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -535,6 +582,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.12:3.10.7",
         "sha256": "eea65b5e6a6da8c263016fdd31000f3e336a0ddeba502150f96f384ad9cc865d",
+        "srcjar_sha256": "2b3a5f034e5ea75af5e2e3965c88f93714d3a69a4f37f4553ee5d8ea80c3765d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -542,6 +590,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.12:4.15.0",
         "sha256": "449a86398ab168445dcdb238525c6cfa447ebfeaedd7f9639474f78de5a77277",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_parsers",
@@ -557,6 +606,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.12:4.15.0",
         "sha256": "ef7fdde32e874b69f34022e0685bba7d3d51a598e9adaf6457719a429c223753",
+        "srcjar_sha256": "e27586660bde1c0bee2a99eca5a4adf47c090813cda802afc53bd2d11f900efd",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_common",
@@ -592,6 +642,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.12:0.4.4",
         "sha256": "bffacf6bfc346d4822b2c18e62fb39f18418beeb41f849761ff9ac1c20a9aea9",
+        "srcjar_sha256": "15be9c8170818417331baf846d931d5daaab2699c6417af6feb56fbee66f07d8",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -603,6 +654,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -612,6 +664,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -619,6 +672,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -633,6 +687,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -649,6 +704,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -661,6 +717,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -670,6 +727,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -680,6 +738,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -694,6 +753,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -701,6 +761,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -710,6 +771,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -721,6 +783,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -733,6 +796,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -743,10 +807,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -759,6 +825,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -771,6 +838,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -778,6 +846,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -787,6 +856,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -812,10 +882,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -823,6 +895,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_2.12:1.0.0-alpha.3",
         "sha256": "f0a3dc37259776c0268c8e35a36419194d162ed1efb1eb065edb74caa3f6d77a",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -833,6 +906,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_2.12:1.0.0-alpha.3",
         "sha256": "8bde73d646d124927649e4a2ff0d087ea08395df62b20f7a368074dce59bc7d3",
+        "srcjar_sha256": "fd2cd8fe024f7dacfe736f549f70b81de0a0526c57502e8660775b837becf5e2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -841,6 +915,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.12:0.9.9",
         "sha256": "dcfb2c0ec742e1e2c89ed43d7ed9e3b105a0c48af0a6c1d381d1077ffe55aa08",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library",
@@ -849,6 +924,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.12:0.9.9",
         "sha256": "3e1e6305b4091e0579ca935ec7341770af34ed34c14e3f53b9485704fe15c7ad",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -857,6 +933,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_2.12:1.0.0-alpha.3",
         "sha256": "6196d9ed08e07830542971a48971cc2fba02186930d10c8623884115f0135fd4",
+        "srcjar_sha256": "e51dea15f87bcacd9c813ecffb78c6d813b19d8f7ce02c36940de8ce1be72118",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -867,6 +944,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.12:1.0.0-alpha.3",
         "sha256": "d6f1a71e7acdd47eb0b7367d32a5b2d930c3fe1b75e9b8b641b449c1ef0ebda2",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_2_13.bzl
+++ b/third_party/repositories/scala_2_13.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -188,6 +200,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -198,6 +211,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -209,6 +223,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -216,6 +231,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -223,6 +239,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_2.13:2.1.0",
         "sha256": "d122cbf93115ee714570de6a9c18e53001fedb474911d4cb5091758ee51f053a",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -230,6 +247,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_2.13:3.2.19",
         "sha256": "c27c33de17d450e29e66c16c5af4cfa33e8ffcf03c124f0a3d249d848cccd4af",
+        "srcjar_sha256": "1e144d19da246a2401b4c7d1254be4e9b599f2f03a55bb44e2c23e9a3ddcbb50",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -238,6 +256,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_2.13:3.2.19",
         "sha256": "c37d97f16172d45b2aef0cebbe59dd2174b7d1ff2c2f272516707cf923015a52",
+        "srcjar_sha256": "9e51badec41f488cebd1f74d25c8a3bdac4161b54649122c59e724fabc04e889",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -259,10 +278,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_2.13:3.2.19",
         "sha256": "30230081d029f6341b83fe7f157d336113e1c97497fe950169293d28a5bf2936",
+        "srcjar_sha256": "5de8c0e06f704fd30430ba8467f86e1a9f20276ca2a24b4e06e3a1ba86022049",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -274,6 +295,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_2.13:3.2.19",
         "sha256": "a77294d3d5a564e1d8cd6550d4ac795ac042fa90efa91d139da123d7ec5f3bec",
+        "srcjar_sha256": "f1a7f1682adef04bd66d0c711e706327f1c6fb40f6c80599af5c9f0a6212b34c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -283,6 +305,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_2.13:3.2.19",
         "sha256": "58a44e6be12409596feab4d4123900ef2af55d3fcb72033412059ce055e91dee",
+        "srcjar_sha256": "71103b6f9e752770253b167ab8cfcb1adbd46f8ecae804e68c003f1348d683ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -292,6 +315,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_2.13:3.2.19",
         "sha256": "de4d28423dc69e91fdc8f3a03a4fb6b443c5626b819c896e5fbe4a73a375654a",
+        "srcjar_sha256": "1f56dd506a12425a11e2b837a0416d7595160a57d042bed8e928ecc7ca13fce4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -301,6 +325,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_2.13:3.2.19",
         "sha256": "f3e463422cca38117bb48665602543474fbc2c37427b1133a9c34332f895b08a",
+        "srcjar_sha256": "3f2922d60b0945c331826d99f0c225f74e3a40785d4d287e854145aff140ee6d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -310,6 +335,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_2.13:3.2.19",
         "sha256": "4c682781b67c5daeeebb9e132a78929b824f88747b963b9aa8bd24a0a7d6893b",
+        "srcjar_sha256": "aee8f9050f855de8f6d23a0c7fd8307bd648cd2f8e08cba60183577f28060e56",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -319,6 +345,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_2.13:3.2.19",
         "sha256": "926aeb37193ad79d0b380160765c9ab61d4367b994c1ab715896fe4961241d5e",
+        "srcjar_sha256": "55a2d43256f955e108196097ffc2e5d2d7224723a0d68fd4f95ef3287d26aa1f",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -328,6 +355,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_2.13:3.2.19",
         "sha256": "033f16c1143fbe51675d080b13ac319d98581d0331ba3ccebb121e3904a774a3",
+        "srcjar_sha256": "e0c385ea2abcdd51384dbee66384ca97f0559c2ed25217b2d7fb30ac35f79635",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -337,6 +365,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_2.13:3.2.19",
         "sha256": "8ebbd5c12843d75f15283f31c35994b6e733ce737f666b05528fa8b6e67ad32e",
+        "srcjar_sha256": "ac2a920f304e957a1feff3f449dc556be9bd74b85891a901322691a34be5c758",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -346,6 +375,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_2.13:3.2.19",
         "sha256": "6c1c7d557485861d920b1c26748a871232b626e93d466a3d9bb8dbbc6e38485d",
+        "srcjar_sha256": "5c58e1ba8bc1f45d394fcab3ef6f9c62cb9531874ccd6b2dcbbb723473a22d8e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -355,6 +385,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_2.13:3.2.19",
         "sha256": "7a4c836cf66c99c1e12ca96e6d94c4f68b7dbb49144f9e13af73ada4df752652",
+        "srcjar_sha256": "76b16ccd3ab49e4e0cf3dd242931ce3979c3c51ac048865e8648806e3470ec5e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -364,6 +395,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_2.13:3.2.19",
         "sha256": "64658d736039267baae0108af620617e8ce88b2f4683112e2e31e4ad2a603c0f",
+        "srcjar_sha256": "6768f1c650b1fb3c5525c10f766c15bc177e855b0b31607c2d2afb92378725fb",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -373,6 +405,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_2.13:3.2.19",
         "sha256": "08050f3d05c72575cac29a1483185b443d5f9f34c1fcf80c683083330385ef93",
+        "srcjar_sha256": "bcb3e6a496e87891e79ec0fee6063e654f79bf3407d4294ecacf756a1550d850",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -407,6 +440,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -428,6 +462,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -436,10 +471,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -447,6 +484,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
         ],
@@ -454,6 +492,7 @@ artifacts = {
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library",
@@ -478,6 +517,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -485,6 +525,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -492,6 +533,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -503,6 +545,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler",
@@ -513,6 +556,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library",
@@ -522,6 +566,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_trees",
@@ -530,6 +575,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_metaconfig_core",
@@ -539,6 +585,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_mdoc_parser",
@@ -550,6 +597,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_reflect",
@@ -559,6 +607,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -566,6 +615,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_parsers",
@@ -574,6 +624,7 @@ artifacts = {
     "org_scalameta_semanticdb_scalac": {
         "artifact": "org.scalameta:semanticdb-scalac_2.13.18:4.13.10",
         "sha256": "d10285e2c958b75804a2a327e0e69eec3727ac883d37a6e1fa15d17ec2e44d39",
+        "srcjar_sha256": "985a6eddd0f4909c780a0e4d5c0676964d16d95a574bc00c016b3331a324fd62",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -581,6 +632,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scalameta_common",
@@ -608,6 +660,7 @@ artifacts = {
     "org_typelevel_kind_projector": {
         "artifact": "org.typelevel:kind-projector_2.13.18:0.13.4",
         "sha256": "e4bac237aae1a530cc5c7f0c98723a2f9e4890b8ef02a8d0aa2afa8c79dce6c0",
+        "srcjar_sha256": "8bbb2471ab188e56fd0e3c62b0f18d92ffd4ee4fadcd12b9190c9cc26659e5fa",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler",
             "@io_bazel_rules_scala_scala_library",
@@ -616,6 +669,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -627,6 +681,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -636,6 +691,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -643,6 +699,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -657,6 +714,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -673,6 +731,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -685,6 +744,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -694,6 +754,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -704,6 +765,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -718,6 +780,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -725,6 +788,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -734,6 +798,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -745,6 +810,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -757,6 +823,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -767,10 +834,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -783,6 +852,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -795,6 +865,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -802,6 +873,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -811,6 +883,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -836,10 +909,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -847,6 +922,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_2.13:1.0.0-alpha.3",
         "sha256": "0235bf7d1e8d4fca860543fb60abe84739cd73fae27610894deebe1cb63987d7",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -857,6 +933,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_2.13:1.0.0-alpha.3",
         "sha256": "2e98ceb862a97fa985ebc65f797fb6a0f519f25c7099a7529015cf4b5926671d",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -865,6 +942,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library",
@@ -873,6 +951,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -881,6 +960,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:1.0.0-alpha.3",
         "sha256": "f01ecf90701dfb043b9770a66e88f533ca7994c054971eb28280120d77bb7046",
+        "srcjar_sha256": "f454368acd15e230fa66b39b453c62042c148100367673d54fd85ad1fe11f739",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -891,6 +971,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:1.0.0-alpha.3",
         "sha256": "5ccb18f96f0456f8b8bb1df0a1af7b5934bbeea24fbd8d2ab433510d0fcf5d46",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_1.bzl
+++ b/third_party/repositories/scala_3_1.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.2.0-scala-1",
         "sha256": "8c34d8f56614901a1f3367b15b38adc8b13107ffd8e141e004f9de1e23db8ea4",
+        "srcjar_sha256": "990a242b482418d7d4b85f4257106768dc3540405cb921bf54ae29f20e686dd5",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.1.3",
         "sha256": "140c7bc825b9df3cb69a093adc4f11f7f0992f1fa87bae10d16e89020fe03e82",
+        "srcjar_sha256": "ed413714f27a52f2535298a74824eab8d6d99b32ced1a12730ba7a154c351f64",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
         ],
@@ -206,6 +220,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -216,10 +231,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.1.3",
         "sha256": "dca9bcd395deffca77c1d3919b4cc998234025059a892b10c3674c9a37d6dc9f",
+        "srcjar_sha256": "5101d6c425ea373e76f7def352a124d41c51f4ebeaaaa8f861e7f13e6b028275",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.1.3",
         "sha256": "1ac79970d94a1762ce6af4208820b4fa4c70093409decaad85c69d8b5f46e422",
+        "srcjar_sha256": "5e0639672da01681b117781b6325374d3a3dd3d6bb12de7782dc6c7b2115485d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -227,6 +244,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -238,6 +256,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -245,6 +264,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -252,10 +272,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.1.3",
         "sha256": "0a183e880575bcc97a2047761880241784734e7ee094dc6fafd6a8f2109ff1da",
+        "srcjar_sha256": "18d84fc1faa6b7d20ec480881f709332bdc17f9cbcb544a3b39723f62ac5ff7a",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -263,6 +285,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -270,6 +293,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -290,10 +314,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -304,6 +330,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -312,6 +339,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -320,6 +348,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -328,6 +357,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -336,6 +366,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -344,6 +375,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -352,6 +384,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -360,6 +393,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -368,6 +402,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -376,6 +411,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -384,6 +420,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -392,6 +429,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -425,6 +463,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -433,6 +472,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -446,6 +486,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -454,10 +495,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -465,6 +508,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -472,6 +516,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -480,6 +525,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -488,10 +534,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -499,6 +547,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -506,6 +555,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -513,10 +563,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -541,6 +593,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -548,6 +601,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -555,6 +609,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -566,6 +621,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -576,6 +632,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -585,6 +642,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -593,6 +651,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -602,6 +661,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -613,6 +673,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -622,6 +683,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -629,6 +691,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -637,6 +700,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -672,6 +736,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -683,6 +748,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -692,6 +758,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -699,6 +766,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -713,6 +781,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -729,6 +798,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -741,6 +811,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -750,6 +821,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -760,6 +832,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -774,6 +847,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -781,6 +855,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -790,6 +865,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -801,6 +877,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -813,6 +890,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -823,10 +901,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -839,6 +919,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -851,6 +932,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -858,6 +940,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -867,6 +950,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -892,10 +976,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -903,6 +989,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_2.13:1.0.0-alpha.3",
         "sha256": "0235bf7d1e8d4fca860543fb60abe84739cd73fae27610894deebe1cb63987d7",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library_2",
@@ -913,6 +1000,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_2.13:1.0.0-alpha.3",
         "sha256": "2e98ceb862a97fa985ebc65f797fb6a0f519f25c7099a7529015cf4b5926671d",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -921,6 +1009,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -929,6 +1018,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -937,6 +1027,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:1.0.0-alpha.3",
         "sha256": "f01ecf90701dfb043b9770a66e88f533ca7994c054971eb28280120d77bb7046",
+        "srcjar_sha256": "f454368acd15e230fa66b39b453c62042c148100367673d54fd85ad1fe11f739",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library_2",
@@ -947,6 +1038,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:1.0.0-alpha.3",
         "sha256": "5ccb18f96f0456f8b8bb1df0a1af7b5934bbeea24fbd8d2ab433510d0fcf5d46",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_2.bzl
+++ b/third_party/repositories/scala_3_2.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.3.0-scala-1",
         "sha256": "26bc3a72b537997e289b50b490d72c1b8827208241020d86de2cdf6a7df0f2f5",
+        "srcjar_sha256": "688ecd0669c1266979ab177b597d99c09b496774d44322e81d2b804c84b79a30",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.2.2",
         "sha256": "4b350ee6f6bc5b33f882f0ade788fac930e0f99285bb08d996f59946f8d3889a",
+        "srcjar_sha256": "669d580fc4a8d3c2e2d13d5735ae9be05d567613fe44482de5bcc5e2e2ee89ea",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
         ],
@@ -206,6 +220,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -216,10 +231,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.2.2",
         "sha256": "f07bab6250d718613f0f8250cc61cc23217c4fd84c410c3af43b8098fff31f69",
+        "srcjar_sha256": "bc66b5c458c367e88914175a67fcc30976af3a7f3e8ff66803acde53840be459",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.2.2",
         "sha256": "f96317c57a5beae2cb16607d2b99cba7b136a96416e736966e5955e6608d868b",
+        "srcjar_sha256": "b39cc0b46b95cfdb7774291cf25b66c708c9ecd1c0a1b5d98dcb30108a3755e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -227,6 +244,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -238,6 +256,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -245,6 +264,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -252,10 +272,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.2.2",
         "sha256": "df0690721532323a3c533385a06a4f532231d012d38f65bd75864718cfabace4",
+        "srcjar_sha256": "36ed2cc5641a7aecd1998a66fcf281c57e941d191fa2e9e682fb8d7721e57b31",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -263,6 +285,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -270,6 +293,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -290,10 +314,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -304,6 +330,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -312,6 +339,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -320,6 +348,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -328,6 +357,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -336,6 +366,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -344,6 +375,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -352,6 +384,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -360,6 +393,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -368,6 +402,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -376,6 +411,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -384,6 +420,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -392,6 +429,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -425,6 +463,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -433,6 +472,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -446,6 +486,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -454,10 +495,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -465,6 +508,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -472,6 +516,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -480,6 +525,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -488,10 +534,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -499,6 +547,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -506,6 +555,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -513,10 +563,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -541,6 +593,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -548,6 +601,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -555,6 +609,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -566,6 +621,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -576,6 +632,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -585,6 +642,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -593,6 +651,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -602,6 +661,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -613,6 +673,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -622,6 +683,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -629,6 +691,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -637,6 +700,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -672,6 +736,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -683,6 +748,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -692,6 +758,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -699,6 +766,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -713,6 +781,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -729,6 +798,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -741,6 +811,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -750,6 +821,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -760,6 +832,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -774,6 +847,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -781,6 +855,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -790,6 +865,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -801,6 +877,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -813,6 +890,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -823,10 +901,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -839,6 +919,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -851,6 +932,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -858,6 +940,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -867,6 +950,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -892,10 +976,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -903,6 +989,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_2.13:1.0.0-alpha.3",
         "sha256": "0235bf7d1e8d4fca860543fb60abe84739cd73fae27610894deebe1cb63987d7",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library_2",
@@ -913,6 +1000,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_2.13:1.0.0-alpha.3",
         "sha256": "2e98ceb862a97fa985ebc65f797fb6a0f519f25c7099a7529015cf4b5926671d",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -921,6 +1009,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -929,6 +1018,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -937,6 +1027,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_2.13:1.0.0-alpha.3",
         "sha256": "f01ecf90701dfb043b9770a66e88f533ca7994c054971eb28280120d77bb7046",
+        "srcjar_sha256": "f454368acd15e230fa66b39b453c62042c148100367673d54fd85ad1fe11f739",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library_2",
@@ -947,6 +1038,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_2.13:1.0.0-alpha.3",
         "sha256": "5ccb18f96f0456f8b8bb1df0a1af7b5934bbeea24fbd8d2ab433510d0fcf5d46",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_3.bzl
+++ b/third_party/repositories/scala_3_3.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.9.0-scala-1",
         "sha256": "75ac366e8ecb691e06a7e85041eed0f67919a646e5262fa0901225698c104375",
+        "srcjar_sha256": "c4a40287795a38e23d971ecd7287f9d14c3ed207081ce40afb4fbac2f18ba2cf",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.3.8",
         "sha256": "89de0156398ce8547656bb2324ff2fbcfd7a85d7da065df4e01a85d949d081b8",
+        "srcjar_sha256": "194058f5aa33bbf7c8b6312edb446cc9eeb984004f7c528d92e9875c0b30f034",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@io_bazel_rules_scala_scala_interfaces",
@@ -213,6 +227,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -223,10 +238,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.3.8",
         "sha256": "a7734cf3b9ccb6ab2597b279421bb29471da7c6d7bacfc947600883de4eeb3eb",
+        "srcjar_sha256": "ec904b4a9946c4b34b6b2309f8864fd5643904c9d533ccbcb8b2c2bc84bbaec4",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.3.8",
         "sha256": "2c6eace9158df8ee4485a06128a479d968c1ebfc83ae9b1a394b58429f0d1492",
+        "srcjar_sha256": "3ee0545cd93486a5b950f578c90a74a1d2934b5e9c002db405c75eea7aa24e65",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -234,6 +251,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -245,6 +263,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -252,6 +271,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -259,6 +279,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.3.8",
         "sha256": "e3a0ba5b0eed0ec5e0b5c29234abce911577d5571366ab75f11c52924874a945",
+        "srcjar_sha256": "559a2c25880618414bd713e02b45a7e1eb53bc9d0b3d98b0425d3bc70dd53eb1",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -266,6 +287,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -273,6 +295,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -280,6 +303,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -300,10 +324,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -314,6 +340,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -322,6 +349,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -330,6 +358,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -338,6 +367,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -346,6 +376,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -354,6 +385,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -362,6 +394,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -370,6 +403,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -378,6 +412,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -386,6 +421,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -394,6 +430,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -402,6 +439,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -435,6 +473,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -443,6 +482,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -456,6 +496,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -464,10 +505,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -475,6 +518,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -482,6 +526,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -490,6 +535,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -498,10 +544,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -509,6 +557,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -516,6 +565,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -523,10 +573,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -551,6 +603,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -558,6 +611,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -565,6 +619,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -576,6 +631,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -586,6 +642,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -595,6 +652,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -603,6 +661,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -612,6 +671,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -623,6 +683,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -632,6 +693,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -639,6 +701,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -647,6 +710,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -682,6 +746,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -693,6 +758,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -702,6 +768,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -709,6 +776,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -723,6 +791,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -739,6 +808,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -751,6 +821,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -760,6 +831,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -770,6 +842,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -784,6 +857,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -791,6 +865,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -800,6 +875,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -811,6 +887,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -823,6 +900,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -833,10 +911,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -849,6 +929,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -861,6 +942,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -868,6 +950,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -877,6 +960,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -902,10 +986,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -913,6 +999,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_3:1.0.0-alpha.3",
         "sha256": "f61d76a09a6d8ccc25d0f98ab9f9172ad42659dd76a694c3b7294ba3e5a26a06",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -923,6 +1010,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_3:1.0.0-alpha.3",
         "sha256": "ddf29b2aee3e88bd8f58948470965c296ef6e07f6e09f4e02ed7b19bafb78499",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -931,6 +1019,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -939,6 +1028,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -947,6 +1037,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_3:1.0.0-alpha.3",
         "sha256": "8b128634d64bf0a29c52001eabc12458e15c958843894a4020d181c7fc1d21fc",
+        "srcjar_sha256": "dbddbe90f391ec7d950b644deeb32797e4835659cd1f90689c8b27ec98a39af8",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -957,6 +1048,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_3:1.0.0-alpha.3",
         "sha256": "87400fb72734b26f058b35e6c13518f5e7a54d4dce3714452ce0df24cdb9d0c6",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_4.bzl
+++ b/third_party/repositories/scala_3_4.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.6.0-scala-1",
         "sha256": "bf16f8b69e89cadab550bce266a052780af7f1eb29dd1c04c3bd014113752c12",
+        "srcjar_sha256": "6a58718b53a6bd8f1b1e22b2bf7ef9b88eccbbe5e0fc223847b0343100d4a45a",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.4.3",
         "sha256": "ad071cf0cfff64dce675344c34667d0812dbcb6016c6be10c4e5ebdc6903e060",
+        "srcjar_sha256": "3c413efa9a2921ef59da7f065c445ae1b6b97057cbbc6b16957ad052a575a3ce",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@org_scala_sbt_compiler_interface",
@@ -207,6 +221,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -217,10 +232,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.4.3",
         "sha256": "f340a643dbb9e7864fc32135ac0620adc51bc16daeb646b66046c27d5d500df4",
+        "srcjar_sha256": "e63ac77deebacf0a32280fcd4435b6d1525f98fd43c2c7ba701215699c130566",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.4.3",
         "sha256": "7d1cfac8091c82a6d09c111f08f61ed96b635c4527a5db59e5255c71b1f3ca6c",
+        "srcjar_sha256": "b19540fb394959571cd21f9e59bc7c642a2705473a73a73752b4b4bad712ac8e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -228,6 +245,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -239,6 +257,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -246,6 +265,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -253,10 +273,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.4.3",
         "sha256": "e3b5bdb3bbb3038e290d85e6e4f528c9d7fe1c7b1274695e3140ec6b86a84097",
+        "srcjar_sha256": "431758e81148d968509f8afb2d8dfea25503e2b74aebbd7658e23ab13d30ec3e",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -264,6 +286,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -271,6 +294,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -291,10 +315,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -305,6 +331,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -313,6 +340,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -321,6 +349,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -329,6 +358,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -337,6 +367,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -345,6 +376,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -353,6 +385,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -361,6 +394,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -369,6 +403,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -377,6 +412,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -385,6 +421,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -393,6 +430,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -426,6 +464,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -434,6 +473,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -447,6 +487,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -455,10 +496,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -466,6 +509,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -473,6 +517,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -481,6 +526,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -489,10 +535,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -500,6 +548,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -507,6 +556,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -514,10 +564,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -542,6 +594,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -549,6 +602,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -556,6 +610,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -567,6 +622,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -577,6 +633,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -586,6 +643,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -594,6 +652,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -603,6 +662,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -614,6 +674,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -623,6 +684,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -630,6 +692,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -638,6 +701,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -673,6 +737,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -684,6 +749,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -693,6 +759,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -700,6 +767,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -714,6 +782,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -730,6 +799,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -742,6 +812,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -751,6 +822,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -761,6 +833,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -775,6 +848,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -782,6 +856,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -791,6 +866,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -802,6 +878,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -814,6 +891,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -824,10 +902,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -840,6 +920,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -852,6 +933,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -859,6 +941,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -868,6 +951,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -893,10 +977,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -904,6 +990,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_3:1.0.0-alpha.3",
         "sha256": "f61d76a09a6d8ccc25d0f98ab9f9172ad42659dd76a694c3b7294ba3e5a26a06",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -914,6 +1001,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_3:1.0.0-alpha.3",
         "sha256": "ddf29b2aee3e88bd8f58948470965c296ef6e07f6e09f4e02ed7b19bafb78499",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -922,6 +1010,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -930,6 +1019,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -938,6 +1028,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_3:1.0.0-alpha.3",
         "sha256": "8b128634d64bf0a29c52001eabc12458e15c958843894a4020d181c7fc1d21fc",
+        "srcjar_sha256": "dbddbe90f391ec7d950b644deeb32797e4835659cd1f90689c8b27ec98a39af8",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -948,6 +1039,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_3:1.0.0-alpha.3",
         "sha256": "87400fb72734b26f058b35e6c13518f5e7a54d4dce3714452ce0df24cdb9d0c6",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_5.bzl
+++ b/third_party/repositories/scala_3_5.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.7.0-scala-2",
         "sha256": "823cd3a46e289c69e37994e03aee3864e1e059aacb3e0bf34f536b3669b61772",
+        "srcjar_sha256": "e3821837de754207fbf0dc71d0f81bb32dd56b92558ef26932185544ad1b295a",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.5.2",
         "sha256": "ba6b31f2d63048d5e4bac45facf42811da2093ae60e90932ab72778e439243b2",
+        "srcjar_sha256": "a750f6b93aa4d8b73ad9e6f92e287724c6fa6007900c2ff49321e20a08478d57",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@org_scala_sbt_compiler_interface",
@@ -207,6 +221,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -217,10 +232,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.5.2",
         "sha256": "36bb7c369bfd245dce403c886e1f004a574d0b7935d50cf5a9bf6ddefd1d2b0e",
+        "srcjar_sha256": "bf37d365699eeec5524835cd4aed4efc630242da7d650457176e909f053389d2",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.5.2",
         "sha256": "3d1117bb660d3721d2a01345e064d96fd6eca5e7a4e574eecaa409c064432cba",
+        "srcjar_sha256": "4cec3c27de50db020fcc273908c95376429ebb6a15b1300e6103dd4aaca66c10",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -228,6 +245,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -239,6 +257,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -246,6 +265,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -253,10 +273,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.5.2",
         "sha256": "b380158748e147f4e44654ad16003c89599ddd456eac29f9686cb6d5515067f3",
+        "srcjar_sha256": "70029e732b5fcf974d9ff5e872d891c0bbab2dd8514742f4cdd6487edd012186",
     },
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -264,6 +286,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -271,6 +294,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -291,10 +315,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -305,6 +331,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -313,6 +340,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -321,6 +349,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -329,6 +358,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -337,6 +367,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -345,6 +376,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -353,6 +385,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -361,6 +394,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -369,6 +403,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -377,6 +412,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -385,6 +421,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -393,6 +430,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -426,6 +464,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -434,6 +473,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -447,6 +487,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -455,10 +496,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -466,6 +509,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -473,6 +517,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -481,6 +526,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -489,10 +535,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -500,6 +548,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -507,6 +556,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -514,10 +564,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -542,6 +594,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -549,6 +602,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -556,6 +610,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -567,6 +622,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -577,6 +633,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -586,6 +643,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -594,6 +652,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -603,6 +662,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -614,6 +674,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -623,6 +684,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -630,6 +692,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -638,6 +701,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -673,6 +737,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -684,6 +749,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -693,6 +759,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -700,6 +767,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -714,6 +782,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -730,6 +799,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -742,6 +812,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -751,6 +822,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -761,6 +833,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -775,6 +848,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -782,6 +856,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -791,6 +866,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -802,6 +878,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -814,6 +891,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -824,10 +902,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -840,6 +920,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -852,6 +933,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -859,6 +941,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -868,6 +951,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -893,10 +977,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -904,6 +990,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_3:1.0.0-alpha.3",
         "sha256": "f61d76a09a6d8ccc25d0f98ab9f9172ad42659dd76a694c3b7294ba3e5a26a06",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -914,6 +1001,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_3:1.0.0-alpha.3",
         "sha256": "ddf29b2aee3e88bd8f58948470965c296ef6e07f6e09f4e02ed7b19bafb78499",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -922,6 +1010,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -930,6 +1019,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -938,6 +1028,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_3:1.0.0-alpha.3",
         "sha256": "8b128634d64bf0a29c52001eabc12458e15c958843894a4020d181c7fc1d21fc",
+        "srcjar_sha256": "dbddbe90f391ec7d950b644deeb32797e4835659cd1f90689c8b27ec98a39af8",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -948,6 +1039,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_3:1.0.0-alpha.3",
         "sha256": "87400fb72734b26f058b35e6c13518f5e7a54d4dce3714452ce0df24cdb9d0c6",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_6.bzl
+++ b/third_party/repositories/scala_3_6.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.7.1-scala-1",
         "sha256": "3b764f500ee290ad44ff03db92c0de2b3ed920a1df531eab35a793f79b786379",
+        "srcjar_sha256": "a1832f2d7b282d24fce82ca0b2d313d709ee74b82a1133dfa3e98d9b94e8705b",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.6.4",
         "sha256": "d0a38984801db97fd3d41c381a6807d6aabf517775de0d90e3bea0636e69ae2e",
+        "srcjar_sha256": "6debf939ad54880010d7a742732041f5ee90d262eb45c9fb93e6f68b657ffe4e",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@io_bazel_rules_scala_scala_interfaces",
@@ -213,6 +227,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -223,10 +238,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.6.4",
         "sha256": "d18678e1dbb080cf39666c629371a0d6df93177982d030607528a2d2da70e034",
+        "srcjar_sha256": "6eb9c0871f5445548ad3389840f2dc8e48ed8af5203ae5839999ed18ea589a1c",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.6.4",
         "sha256": "a8c962526908331e077f70f391a7493e0cdbfd14edba8c1a780daee501ca06e6",
+        "srcjar_sha256": "d355756b26c0085af072744ea8f659671077843c3c7b86ba2c486e093eb2390a",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -234,6 +251,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -245,6 +263,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -252,6 +271,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -259,6 +279,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.6.4",
         "sha256": "6801af0a9dc297474e7b8ce81f2caa6b8b57a54e783d290a8728fa19d34f11da",
+        "srcjar_sha256": "cc15418592a75ddd081e32a4c8c43027c678897027c4656283461e5c80f4e84b",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -266,6 +287,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -273,6 +295,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -280,6 +303,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -300,10 +324,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -314,6 +340,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -322,6 +349,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -330,6 +358,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -338,6 +367,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -346,6 +376,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -354,6 +385,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -362,6 +394,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -370,6 +403,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -378,6 +412,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -386,6 +421,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -394,6 +430,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -402,6 +439,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -435,6 +473,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -443,6 +482,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -456,6 +496,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -464,10 +505,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -475,6 +518,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -482,6 +526,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -490,6 +535,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -498,10 +544,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -509,6 +557,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -516,6 +565,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -523,10 +573,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -551,6 +603,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -558,6 +611,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -565,6 +619,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -576,6 +631,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -586,6 +642,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -595,6 +652,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -603,6 +661,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -612,6 +671,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -623,6 +683,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -632,6 +693,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -639,6 +701,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -647,6 +710,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -682,6 +746,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -693,6 +758,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -702,6 +768,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -709,6 +776,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -723,6 +791,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -739,6 +808,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -751,6 +821,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -760,6 +831,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -770,6 +842,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -784,6 +857,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -791,6 +865,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -800,6 +875,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -811,6 +887,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -823,6 +900,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -833,10 +911,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -849,6 +929,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -861,6 +942,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -868,6 +950,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -877,6 +960,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -902,10 +986,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -913,6 +999,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_3:1.0.0-alpha.3",
         "sha256": "f61d76a09a6d8ccc25d0f98ab9f9172ad42659dd76a694c3b7294ba3e5a26a06",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -923,6 +1010,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_3:1.0.0-alpha.3",
         "sha256": "ddf29b2aee3e88bd8f58948470965c296ef6e07f6e09f4e02ed7b19bafb78499",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -931,6 +1019,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -939,6 +1028,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -947,6 +1037,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_3:1.0.0-alpha.3",
         "sha256": "8b128634d64bf0a29c52001eabc12458e15c958843894a4020d181c7fc1d21fc",
+        "srcjar_sha256": "dbddbe90f391ec7d950b644deeb32797e4835659cd1f90689c8b27ec98a39af8",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -957,6 +1048,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_3:1.0.0-alpha.3",
         "sha256": "87400fb72734b26f058b35e6c13518f5e7a54d4dce3714452ce0df24cdb9d0c6",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_7.bzl
+++ b/third_party/repositories/scala_3_7.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.8.0-scala-1",
         "sha256": "86af037580bdf9ce9c05f8b2afd734daf1a8564c38cd10ca5d08bf81508ad2e4",
+        "srcjar_sha256": "78543ab8bafec0e7d09227872db06f4c725f5e0743f1f3eab1f60ef6876588e9",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.7.4",
         "sha256": "1a60682b898fb04753dec78f2904078d48670079b7ad5106d442a0f431d346e0",
+        "srcjar_sha256": "9be3d36dfb771f76e1030b4d012a6dfd62dab5d0fac7661991ae1f765b901a9d",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@io_bazel_rules_scala_scala_interfaces",
@@ -213,6 +227,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -223,10 +238,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.7.4",
         "sha256": "c19ba8ea1a13c7fcdef675353c8ddd671156cf220879dcb28b27e986aae31ea9",
+        "srcjar_sha256": "0c2667c1fa6053ddc26a456d8dc3c6c5587078eb4768d8389c86f878fc27c1ea",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.7.4",
         "sha256": "73089d33f763b94758170e0a66be978f9397c14b7795e343898aa89b3d7b6639",
+        "srcjar_sha256": "8fa31d20f0ee9a66d1ef5fd3d406561473a66ae2639f7bed6f44f94e628635de",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -234,6 +251,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:2.13.18",
         "sha256": "4e85d96ff7bc7dc627985523c3541b9917aaa08e956391380c42db21a2c4e5a0",
+        "srcjar_sha256": "bac5952705c53dce8a1a0ade4b6ca40900ac3421cd84dd6458ac683d768c3d18",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -245,6 +263,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -252,6 +271,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -259,6 +279,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.7.4",
         "sha256": "24dfe7089232a42d28d5bee1209f462e4b4ca90622e0b13752399c12585e3069",
+        "srcjar_sha256": "5abd3c1fa1bc3c973410dcc10087da8bd89fff86ffa1280649a4a4cb30abedcc",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -266,6 +287,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -273,6 +295,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -280,6 +303,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -300,10 +324,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -314,6 +340,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -322,6 +349,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -330,6 +358,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -338,6 +367,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -346,6 +376,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -354,6 +385,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -362,6 +394,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -370,6 +403,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -378,6 +412,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -386,6 +421,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -394,6 +430,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -402,6 +439,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -435,6 +473,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -443,6 +482,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -456,6 +496,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -464,10 +505,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -475,6 +518,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -482,6 +526,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -490,6 +535,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -498,10 +544,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -509,6 +557,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -516,6 +565,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -523,10 +573,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -551,6 +603,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -558,6 +611,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -565,6 +619,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -576,6 +631,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -586,6 +642,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -595,6 +652,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -603,6 +661,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -612,6 +671,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -623,6 +683,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -632,6 +693,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -639,6 +701,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -647,6 +710,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -682,6 +746,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -693,6 +758,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -702,6 +768,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -709,6 +776,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -723,6 +791,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -739,6 +808,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -751,6 +821,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -760,6 +831,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -770,6 +842,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -784,6 +857,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -791,6 +865,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -800,6 +875,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -811,6 +887,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -823,6 +900,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -833,10 +911,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -849,6 +929,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -861,6 +942,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -868,6 +950,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -877,6 +960,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -902,10 +986,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -913,6 +999,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_3:1.0.0-alpha.3",
         "sha256": "f61d76a09a6d8ccc25d0f98ab9f9172ad42659dd76a694c3b7294ba3e5a26a06",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -923,6 +1010,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_3:1.0.0-alpha.3",
         "sha256": "ddf29b2aee3e88bd8f58948470965c296ef6e07f6e09f4e02ed7b19bafb78499",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -931,6 +1019,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -939,6 +1028,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -947,6 +1037,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_3:1.0.0-alpha.3",
         "sha256": "8b128634d64bf0a29c52001eabc12458e15c958843894a4020d181c7fc1d21fc",
+        "srcjar_sha256": "dbddbe90f391ec7d950b644deeb32797e4835659cd1f90689c8b27ec98a39af8",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -957,6 +1048,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_3:1.0.0-alpha.3",
         "sha256": "87400fb72734b26f058b35e6c13518f5e7a54d4dce3714452ce0df24cdb9d0c6",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",

--- a/third_party/repositories/scala_3_8.bzl
+++ b/third_party/repositories/scala_3_8.bzl
@@ -14,14 +14,17 @@ artifacts = {
     "com_google_android_annotations": {
         "artifact": "com.google.android:annotations:4.1.1.4",
         "sha256": "ba734e1e84c09d615af6a09d33034b4f0442f8772dec120efb376d86a565ae15",
+        "srcjar_sha256": "e9b667aa958df78ea1ad115f7bbac18a5869c3128b1d5043feb360b0cfce9d40",
     },
     "com_google_code_findbugs_jsr305": {
         "artifact": "com.google.code.findbugs:jsr305:3.0.2",
         "sha256": "766ad2a0783f2687962c8ad74ceecc38a28b9f72a2d085ee438b7813e928d0c7",
+        "srcjar_sha256": "1c9e85e272d0708c6a591dc74828c71603053b48cc75ae83cce56912a2aa063b",
     },
     "com_google_code_gson_gson": {
         "artifact": "com.google.code.gson:gson:2.12.1",
         "sha256": "ebee13d5fb7477cd7f1cc010e0c356df8ca80709715248da97f79e35ccb4fbec",
+        "srcjar_sha256": "c5ab4ceb195f2a9278058d6a396c4872a1a07ed8b53fe80230dfd3f173d7cf56",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
         ],
@@ -29,6 +32,7 @@ artifacts = {
     "com_google_errorprone_error_prone_annotations": {
         "artifact": "com.google.errorprone:error_prone_annotations:2.45.0",
         "sha256": "6ba61510e22944e8aec3fe970972d088d8da132a24f2bc817a43c7b70665cc2b",
+        "srcjar_sha256": "f8def362960be28236286f1c9ee9ba0112be25447c2a7c42efb13f8fc95a3016",
     },
     "com_google_guava_guava_21_0": {
         "testonly": True,
@@ -46,14 +50,17 @@ artifacts = {
     "com_google_j2objc_j2objc_annotations": {
         "artifact": "com.google.j2objc:j2objc-annotations:3.1",
         "sha256": "84d3a150518485f8140ea99b8a985656749629f6433c92b80c75b36aba3b099b",
+        "srcjar_sha256": "295938307f4016b3f128f7347101b236ada1394808104519c9e93cd61b64602b",
     },
     "com_google_protobuf_protobuf_java": {
         "artifact": "com.google.protobuf:protobuf-java:4.33.5",
         "sha256": "cb9e00d6e3d4b1305f3fdc147490ce347bfe8c05dc821a433b23b2ff28749bb1",
+        "srcjar_sha256": "efd3ceba03a47dbc38a8f95049d6885ad679d98514b0809ab4632884c4e97657",
     },
     "com_lihaoyi_fansi": {
         "artifact": "com.lihaoyi:fansi_2.13:0.5.1",
         "sha256": "e50796c69261fac857469122ab75f5aab4aeef855ca414f184cb132b318c2d9d",
+        "srcjar_sha256": "b28dc640b3b412023f605d29320adc89f50b0511d7e1376f9bbf9b1032a1de5d",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -81,6 +88,7 @@ artifacts = {
     "com_lihaoyi_sourcecode": {
         "artifact": "com.lihaoyi:sourcecode_2.13:0.4.4",
         "sha256": "bd4e99aef8267a410b6ed716c487cf5256f801425f158a8c9cbd056eb032d80d",
+        "srcjar_sha256": "854238ec90912d0621ec068cddd8854a81f67242785b5e6fbe42f87c255641e9",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -93,18 +101,22 @@ artifacts = {
     "com_typesafe_config": {
         "artifact": "com.typesafe:config:1.4.5",
         "sha256": "4a4b0affb22a9572409d3a6bde99ce3f2045c551cadc1ca7fe09690892c526c3",
+        "srcjar_sha256": "4e17ad7d6a83922a9f1f7b65a33a2d33052a85314303d6f6e318ca3caf9c5d75",
     },
     "dev_dirs_directories": {
         "artifact": "dev.dirs:directories:26",
         "sha256": "6d18fe25aa30b7e08b908cd21151d8f96e22965c640acd7751add9bbfe6137d4",
+        "srcjar_sha256": "192050e3a2a0eba7f22745765aaaf567ce6d515fe6a992688b4e262e9f14947b",
     },
     "io_bazel_rules_scala_failureaccess": {
         "artifact": "com.google.guava:failureaccess:1.0.3",
         "sha256": "cbfc3906b19b8f55dd7cfd6dfe0aa4532e834250d7f080bd8d211a3e246b59cb",
+        "srcjar_sha256": "6fef4dfd2eb9f961655f2a3c4ea87c023618d9fcbfb6b104c17862e5afe66b97",
     },
     "io_bazel_rules_scala_guava": {
         "artifact": "com.google.guava:guava:33.5.0-jre",
         "sha256": "1e301f0c52ac248b0b14fdc3d12283c77252d4d6f48521d572e7d8c4c2cc4ac7",
+        "srcjar_sha256": "79423ae87a2203950e0e3ce2a00682b3b8d8557e631bbf662dba5494fe3b55cb",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@com_google_j2objc_j2objc_annotations",
@@ -195,10 +207,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_asm": {
         "artifact": "org.scala-lang.modules:scala-asm:9.9.0-scala-1",
         "sha256": "75ac366e8ecb691e06a7e85041eed0f67919a646e5262fa0901225698c104375",
+        "srcjar_sha256": "c4a40287795a38e23d971ecd7287f9d14c3ed207081ce40afb4fbac2f18ba2cf",
     },
     "io_bazel_rules_scala_scala_compiler": {
         "artifact": "org.scala-lang:scala3-compiler_3:3.8.4",
         "sha256": "740be02b51e815ef2a927a422d61fd851e25403655fb9ee2e076b4f9ce1fb34e",
+        "srcjar_sha256": "73f28370c489c4b1afedc90fde7e4eb14fd9e528fd3af56a51e4d561b61dcd17",
         "deps": [
             "@io_bazel_rules_scala_scala_asm",
             "@io_bazel_rules_scala_scala_interfaces",
@@ -210,6 +224,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_compiler_2": {
         "artifact": "org.scala-lang:scala-compiler:2.13.18",
         "sha256": "2f15891fcae7aad30a3892194fb2abb6224cf7ce5d2bd90fba7f1c48682fca21",
+        "srcjar_sha256": "08d9984b0e8c553bdfd7b5fa6aa8c1d2f2f1cd6904399b9a0ab8eba345ded335",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -220,10 +235,12 @@ artifacts = {
     "io_bazel_rules_scala_scala_interfaces": {
         "artifact": "org.scala-lang:scala3-interfaces:3.8.4",
         "sha256": "eac968f8ff5f7aed55fb9ffb535bb6effaef4c9d3d8593a45b6dd98b7ce0b9d9",
+        "srcjar_sha256": "019d30a3641c7385e158667135554babf8618e17b169e964cc005a69d53fb54b",
     },
     "io_bazel_rules_scala_scala_library": {
         "artifact": "org.scala-lang:scala3-library_3:3.8.4",
         "sha256": "8f82e1c8974a868f3beeb475fa9c32239d2e082e9f803ebfc3eeb91211b887d1",
+        "srcjar_sha256": "894345294cb995fa32092bf8144c59276c3891581a32daa9a559daf69b8f0203",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -231,6 +248,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_library_2": {
         "artifact": "org.scala-lang:scala-library:3.8.4",
         "sha256": "1b8330de5774c15874173f168b674255caa00c5ef3648ab0b6cb763bb7fd2de7",
+        "srcjar_sha256": "1005197fb7a69f0bdfcdd6551c4f01f8955f043d515fc9320faaaa79f0e3616a",
     },
     "io_bazel_rules_scala_scala_parallel_collections": {
         "artifact": "org.scala-lang.modules:scala-parallel-collections_2.13:1.2.0",
@@ -242,6 +260,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_parser_combinators": {
         "artifact": "org.scala-lang.modules:scala-parser-combinators_2.13:2.4.0",
         "sha256": "e36dccdc21fd4bc770907a9e126d7e3901e71a191eb9ea8e93a0227774e0945d",
+        "srcjar_sha256": "d400578b2eae8bcd251ff2fe3236fe7cf091cb38ec013982fc101ff102d6d8ee",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -249,6 +268,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_reflect_2": {
         "artifact": "org.scala-lang:scala-reflect:2.13.18",
         "sha256": "6935ff1982b2ac93d695f15aa66921be2f602921277afe002f018fd8c7d6e29b",
+        "srcjar_sha256": "22c70ff11e4e38b9cc1bc3eb0131f3d4c3e46869f468c91829b97dc125d31fa1",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -256,6 +276,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_tasty_core": {
         "artifact": "org.scala-lang:tasty-core_3:3.8.4",
         "sha256": "eaea300a6fa4ccd24c979f76e1356b10b27151b395ad3249f9ad8afb4ba8ae20",
+        "srcjar_sha256": "e3407a6f107a984ce53d43e14f0e33d57d0baa912026e87ec32e92f52685016a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -263,6 +284,7 @@ artifacts = {
     "io_bazel_rules_scala_scala_xml": {
         "artifact": "org.scala-lang.modules:scala-xml_3:2.1.0",
         "sha256": "48f22343575f4b1d6550eecc42d4b7f0a0d30223c72f015d8d893feab4cbeecd",
+        "srcjar_sha256": "b2f5f01c669f29dc03a8127f7a8ca2cdb40dff3e29ba416e3de4f6bef0480aca",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -270,6 +292,7 @@ artifacts = {
     "io_bazel_rules_scala_scalactic": {
         "artifact": "org.scalactic:scalactic_3:3.2.19",
         "sha256": "26ef71a6d0993301d28d9693bada18ff81b373336b70368fcff01ed4eb4b958e",
+        "srcjar_sha256": "bbfa9bf00870adf3587cc98dd374a32394e817c0a22a0285deed3fa20ef3e82c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
         ],
@@ -277,6 +300,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest": {
         "artifact": "org.scalatest:scalatest_3:3.2.19",
         "sha256": "cd886ba42615fe0d730dd57197e6ee53eeb062cfd0b4d8c5d9757c977c0fdcf8",
+        "srcjar_sha256": "abbe71617ec5902d762fde00a9525262e5b3d9c1ed19dc2d58765eeb64eee373",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -297,10 +321,12 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_compatible": {
         "artifact": "org.scalatest:scalatest-compatible:3.2.19",
         "sha256": "5dc6b8fa5396fe9e1a7c2b72df174a8eb3e92770cdc3e70636d3eba673cd0da3",
+        "srcjar_sha256": "3e4471354f33698d9eeef51813f45747a9657ccc0dc615e284890936366f70a7",
     },
     "io_bazel_rules_scala_scalatest_core": {
         "artifact": "org.scalatest:scalatest-core_3:3.2.19",
         "sha256": "f6e3d38c2034a9cab7313f644d8a933bf1b5241ff35002cc76916a427a826223",
+        "srcjar_sha256": "35d5214b0a97b1ca60d45244abd2c7d7b812edef856d8dbe1395fb10d14d2a8a",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scala_xml",
@@ -311,6 +337,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_diagrams": {
         "artifact": "org.scalatest:scalatest-diagrams_3:3.2.19",
         "sha256": "835acf8ec2cb0d39beb1052ee2139029fdac28d172fc867db89ff49d640b255e",
+        "srcjar_sha256": "c2d5f3735cc8d2f1b02e894378cb609c6104b106c6a64cd7cc3b67b4473d701e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -319,6 +346,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_featurespec": {
         "artifact": "org.scalatest:scalatest-featurespec_3:3.2.19",
         "sha256": "3d49deeede2cd01578e037065862d7734afd3a6330c35dc3c4906f53f57302db",
+        "srcjar_sha256": "d195c96360999c4bf21de34157e5d5859d58072df671adb9abd78047d11056ab",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -327,6 +355,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_flatspec": {
         "artifact": "org.scalatest:scalatest-flatspec_3:3.2.19",
         "sha256": "85a6fb2285f20445615c6780a498c3bca99e4c2aad32fab6f74202bdc61e56a9",
+        "srcjar_sha256": "3ce482355e5041f7011416b7f3263df41a366dc5de532f76d22519aec37694a5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -335,6 +364,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_freespec": {
         "artifact": "org.scalatest:scalatest-freespec_3:3.2.19",
         "sha256": "ebc8573874766368316366495dcdfe0cca6d8082dc9cc08b5a2fd0834cdaecc0",
+        "srcjar_sha256": "0e502172cf787b3d7f589bfdd73c51f5aa9196e3ab31b245f7f490a957c30db3",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -343,6 +373,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funspec": {
         "artifact": "org.scalatest:scalatest-funspec_3:3.2.19",
         "sha256": "872b6889fac777aa813d21fb5f1e89710407785a61eb18a570142b6be10389a7",
+        "srcjar_sha256": "50f3212eb85e590e15a425e9bb59031e84d034d91d339672b7c2b38b3f464a4e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -351,6 +382,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_funsuite": {
         "artifact": "org.scalatest:scalatest-funsuite_3:3.2.19",
         "sha256": "42129cc156bd8978d9a438abd57001fc42ababf18f6178cbee91d0a9489334e0",
+        "srcjar_sha256": "4c7491e0ec87e5cef5952986294caa04bd261d823d31390abbed42baa3fe461e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -359,6 +391,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_matchers_core": {
         "artifact": "org.scalatest:scalatest-matchers-core_3:3.2.19",
         "sha256": "723fecdf0ea4542947ef5174068c4e05cd2145a3dcb6ffc797079368c94a187e",
+        "srcjar_sha256": "58dedc4aa2fc18c024245f0f780a5cd6f20769c63a2c15ccf8a93917a7fe1fd2",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -367,6 +400,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_mustmatchers": {
         "artifact": "org.scalatest:scalatest-mustmatchers_3:3.2.19",
         "sha256": "837f76b73ff299fb6748ba0aff4eb7c9d9c00252741ad2bc15af3998d2e0558c",
+        "srcjar_sha256": "699bbffcafb430285f72aec43d700b92a076ea6a322cf59d12d132381dcdbf6e",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -375,6 +409,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_propspec": {
         "artifact": "org.scalatest:scalatest-propspec_3:3.2.19",
         "sha256": "6b033e73f3a53717a32a0d4d35ae2021a0afe8a028c42da62fb937932934bce3",
+        "srcjar_sha256": "304fb62b45deb001c8bfd8cf26603fb7362e585980bc2b806219674bce97ecd5",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -383,6 +418,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_refspec": {
         "artifact": "org.scalatest:scalatest-refspec_3:3.2.19",
         "sha256": "827b78a65c25a1dc4af747a7711e24c785fae92c39600fd357a7d486fcce2e7a",
+        "srcjar_sha256": "c1886564cfd390cadf8b0dff85bef4c14a71c54a77fde660cebfa5c36fcbd80c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -391,6 +427,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_shouldmatchers": {
         "artifact": "org.scalatest:scalatest-shouldmatchers_3:3.2.19",
         "sha256": "76ddce37f710ea96bdb3eebcb4bb0a0125fc70fb2ebaa7cc74c9bd28284b6a23",
+        "srcjar_sha256": "04e7e9601964516aa2d896574dac12b55fe96385e38f6fe80cb3514fcd9c82ba",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_matchers_core",
@@ -399,6 +436,7 @@ artifacts = {
     "io_bazel_rules_scala_scalatest_wordspec": {
         "artifact": "org.scalatest:scalatest-wordspec_3:3.2.19",
         "sha256": "c6acce0958b086cb857c4da6107f903b6166a46dfa251f54d3a0869212e229c7",
+        "srcjar_sha256": "7276bb382a85b38d8870da1dad80a98384c7da2a5ecc149d21101151e2e5ed2c",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@io_bazel_rules_scala_scalatest_core",
@@ -432,6 +470,7 @@ artifacts = {
     "io_github_java_diff_utils_java_diff_utils": {
         "artifact": "io.github.java-diff-utils:java-diff-utils:4.16",
         "sha256": "620403030d676a4a27f780a3acec7438dee1b1651a1c804fa6bb11bb07399a6f",
+        "srcjar_sha256": "1307a36819f8dac34187402947e2a9e850b9e7ce95dd5044524e4860c3378ab0",
     },
     "libthrift": {
         "artifact": "org.apache.thrift:libthrift:0.8.0",
@@ -440,6 +479,7 @@ artifacts = {
     "net_java_dev_jna_jna": {
         "artifact": "net.java.dev.jna:jna:5.17.0",
         "sha256": "b3a9408e7c51e08ef0e3bfcc08f443f6ec0f6191ba8cd7c18d53d2b22e5bdbc0",
+        "srcjar_sha256": "1e8dd4205deab6eb9d6045ad9e69a8754fc21029d56ede1dcd9f22a5e06571a7",
     },
     "org_apache_commons_commons_lang_3_5": {
         "testonly": True,
@@ -453,6 +493,7 @@ artifacts = {
     "org_codehaus_mojo_animal_sniffer_annotations": {
         "artifact": "org.codehaus.mojo:animal-sniffer-annotations:1.26",
         "sha256": "342f4d815eae69bb980620d0a622862709be37d38f47577675b42c739a962da9",
+        "srcjar_sha256": "56d2844b620f4742f4b1c47d83357745b39cb26c45423d1249066c15eca31a86",
     },
     "org_jline_jline": {
         "artifact": "org.jline:jline:jar:jdk8:3.30.6",
@@ -461,10 +502,12 @@ artifacts = {
     "org_jline_jline_native": {
         "artifact": "org.jline:jline-native:3.30.6",
         "sha256": "43c36f0934545a9549fb3c8ff3afa361c320efe1c94759ecd09b340648397c80",
+        "srcjar_sha256": "a0bcb1cc9bb3a9902ee4a6b1f7a16cac06734e7b44b6d7b85ba6b92693b67008",
     },
     "org_jline_jline_reader": {
         "artifact": "org.jline:jline-reader:3.30.6",
         "sha256": "065ca5599713a8bf80fb11b24401ebe5be92816cda0fa9b73450d767a86dd07f",
+        "srcjar_sha256": "8c923f814f3fdffd432d42c4e2aa320c353d5fdfc39e0b0dd4754587e592fad2",
         "deps": [
             "@org_jline_jline_terminal",
         ],
@@ -472,6 +515,7 @@ artifacts = {
     "org_jline_jline_terminal": {
         "artifact": "org.jline:jline-terminal:3.30.6",
         "sha256": "9a8dfde8a25b0a9687cf11e0dd4a128665e831f14f9ced85ffc284d3adbad374",
+        "srcjar_sha256": "5d52ad88f8b83c7e82f72c6d66795cbd9f605aa48b40c2d475e597af2c5d73ef",
         "deps": [
             "@org_jline_jline_native",
         ],
@@ -479,6 +523,7 @@ artifacts = {
     "org_jline_jline_terminal_jna": {
         "artifact": "org.jline:jline-terminal-jna:3.30.6",
         "sha256": "0104b9ae3fc3ac12b6810c31587a9c3c2a6a384cd42d4fcfed166e65c21f59f9",
+        "srcjar_sha256": "e179977744b8b84c9d5812bbdbc40e1f27fd781171c7b6d6e7fadc0c3f356904",
         "deps": [
             "@net_java_dev_jna_jna",
             "@org_jline_jline_terminal",
@@ -487,6 +532,7 @@ artifacts = {
     "org_jline_jline_terminal_jni": {
         "artifact": "org.jline:jline-terminal-jni:3.30.6",
         "sha256": "f42a21ac1121e253673a377aafec24330d8b646d831e1e02ac856c16a92de95e",
+        "srcjar_sha256": "c778016c9fb60e726eb50c28530195db222f25983c4c369d7de15eaa0a704e73",
         "deps": [
             "@org_jline_jline_native",
             "@org_jline_jline_terminal",
@@ -495,10 +541,12 @@ artifacts = {
     "org_jspecify_jspecify": {
         "artifact": "org.jspecify:jspecify:1.0.0",
         "sha256": "1fad6e6be7557781e4d33729d49ae1cdc8fdda6fe477bb0cc68ce351eafdfbab",
+        "srcjar_sha256": "adf0898191d55937fb3192ba971826f4f294292c4a960740f3c27310e7b70296",
     },
     "org_scala_lang_modules_scala_collection_compat": {
         "artifact": "org.scala-lang.modules:scala-collection-compat_2.13:2.14.0",
         "sha256": "95986ac32df70c9ebdd96edfb276cdc038deedbe600177a45f6584022f34a13f",
+        "srcjar_sha256": "56672b16b5573d4c91e66ae6682ab3ef6d0ff4335ebffc4fdfe408bb4117b409",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -506,6 +554,7 @@ artifacts = {
     "org_scala_lang_scalap": {
         "artifact": "org.scala-lang:scalap:2.13.18",
         "sha256": "278216a595f34d0cfb78ae710cb487f31d468fa5e883ffae8af0947b6f67c517",
+        "srcjar_sha256": "c166028ba4a31b8ca9423389e1c5b2ca7d870695e217e7f1299507e3a4bb02c9",
         "deps": [
             "@io_bazel_rules_scala_scala_compiler_2",
         ],
@@ -513,6 +562,7 @@ artifacts = {
     "org_scala_sbt_compiler_interface": {
         "artifact": "org.scala-sbt:compiler-interface:1.12.0",
         "sha256": "92f487a505eafdd0a033e4ff4f38a81509a655c76257c64e6808dd873cc145c3",
+        "srcjar_sha256": "6e59d8fd35f900e2f96c2e3defe0c55c0a3577dde712a0912ffd1e7eae2fbaf0",
         "deps": [
             "@org_scala_sbt_util_interface",
         ],
@@ -520,10 +570,12 @@ artifacts = {
     "org_scala_sbt_util_interface": {
         "artifact": "org.scala-sbt:util-interface:1.12.4",
         "sha256": "cd6916d1e622c3e662bf58d739babae022a582ec48107f5fb84b25cc56b0c3dc",
+        "srcjar_sha256": "293a0e9dd418801e9dfa90d1f65d88fe0063fa2d8dc477b50aa9e5b3b68a70f4",
     },
     "org_scalameta_common": {
         "artifact": "org.scalameta:common_2.13:4.15.0",
         "sha256": "530eaeeeebf8caf0183526fac90ca6691384840c02b390c373f685c9cf6a3a1c",
+        "srcjar_sha256": "7fb15ab14147774bad75f8e044ff757655737e32e76f16658fa4b9b32ab65418",
         "deps": [
             "@com_lihaoyi_sourcecode",
             "@io_bazel_rules_scala_scala_library_2",
@@ -548,6 +600,7 @@ artifacts = {
     "org_scalameta_io": {
         "artifact": "org.scalameta:io_2.13:4.15.0",
         "sha256": "b218f83d291d7860789dbc19998a70ff51ab8519d077c7dea66a3bb369cde8f3",
+        "srcjar_sha256": "9078cf60f01f8f226d6f098f59354f7e118e4aba15e78e7f45a4fa90177bc468",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -555,6 +608,7 @@ artifacts = {
     "org_scalameta_mdoc_parser": {
         "artifact": "org.scalameta:mdoc-parser_2.13:2.8.2",
         "sha256": "d4123f01f875810f43379819527d1dc310a33b91fdcb48a423a760f21cd8aa05",
+        "srcjar_sha256": "62bcd8509f7e0fc9e148c7668f86765c02e27c87acedf077306e1ff86789c32b",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -562,6 +616,7 @@ artifacts = {
     "org_scalameta_metaconfig_core": {
         "artifact": "org.scalameta:metaconfig-core_2.13:0.18.2",
         "sha256": "a7c38a68fb2d215e68842828255359b4ab36ca3a9c4b0652a736cee094ee500d",
+        "srcjar_sha256": "b968cd04a80098a6e308e522733b984e7529c0b5d107a89e9641236f469a5630",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -573,6 +628,7 @@ artifacts = {
     "org_scalameta_metaconfig_pprint": {
         "artifact": "org.scalameta:metaconfig-pprint_2.13:0.18.2",
         "sha256": "2d8b1615d92684e5bb8b3bece69dfe6ed81508403b025ee8bcb43b856ad83674",
+        "srcjar_sha256": "498254a90b97ff04a4d23a17486194ab3d49fb378ecb3d2eefa9a7691951035f",
         "deps": [
             "@com_lihaoyi_fansi",
             "@io_bazel_rules_scala_scala_compiler_2",
@@ -583,6 +639,7 @@ artifacts = {
     "org_scalameta_metaconfig_typesafe_config": {
         "artifact": "org.scalameta:metaconfig-typesafe-config_2.13:0.18.2",
         "sha256": "66279b219190fbe52899c120c231a63a562e2ca7b67e69cc78a79ce58da57cd0",
+        "srcjar_sha256": "f769fafc6a7158a2dda3d3c69742f4a0b209affc278c011872a95230295ee485",
         "deps": [
             "@com_typesafe_config",
             "@io_bazel_rules_scala_scala_library_2",
@@ -592,6 +649,7 @@ artifacts = {
     "org_scalameta_parsers": {
         "artifact": "org.scalameta:parsers_2.13:4.15.0",
         "sha256": "f6a295241a5aea7412f41d8fb4f28e40d88b7748bcf91684ec36827c0ccce84e",
+        "srcjar_sha256": "b2053e1f57aced06d167be5e2de71695c2bd9c2b0337293b7aa27731f3d829e3",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_trees",
@@ -600,6 +658,7 @@ artifacts = {
     "org_scalameta_scalafmt_config": {
         "artifact": "org.scalameta:scalafmt-config_2.13:3.10.7",
         "sha256": "77ffba85d2a674bb1cd8574a6433407aa63ba045ef5c3b07904f110d3e269a2c",
+        "srcjar_sha256": "78e1cc11f7d9557d526151219f33c3f7042f207ce30bd4bf8122cbe574663dc4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_metaconfig_core",
@@ -609,6 +668,7 @@ artifacts = {
     "org_scalameta_scalafmt_core": {
         "artifact": "org.scalameta:scalafmt-core_2.13:3.10.7",
         "sha256": "0be2991c2e0cbb454404eee062fa32c356b48361b0541b2cd3e5fbeed57a9d8f",
+        "srcjar_sha256": "ca79bccf0b22578b0790d23de49c9e5ea242a386cc93e33509b2abf29d2767b4",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_mdoc_parser",
@@ -620,6 +680,7 @@ artifacts = {
     "org_scalameta_scalafmt_macros": {
         "artifact": "org.scalameta:scalafmt-macros_2.13:3.10.7",
         "sha256": "54cee00115b7d9e17706f839a68e3cc3530a31326bb189e82f17e62fa964d862",
+        "srcjar_sha256": "e27cbf49845418c9f4d1dd94902ab23b6d58dbe9955ec6c3865b8bb631bf5f81",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@io_bazel_rules_scala_scala_reflect_2",
@@ -629,6 +690,7 @@ artifacts = {
     "org_scalameta_scalafmt_sysops": {
         "artifact": "org.scalameta:scalafmt-sysops_2.13:3.10.7",
         "sha256": "eb82049ecf849da04e7296669b4a8c2cdde82288b2e16b3973be5a346015264a",
+        "srcjar_sha256": "b26086902e63fb49e89fedd38c15605bbe75ac60f0d26541b7719563bc35c80e",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -636,6 +698,7 @@ artifacts = {
     "org_scalameta_scalameta": {
         "artifact": "org.scalameta:scalameta_2.13:4.15.0",
         "sha256": "b3e3d85d87a3ccae0136ce056c9f3ab3bab35c350f70a4227c8f382df5cb5957",
+        "srcjar_sha256": "6fc8c041be1923dc147d103d32b627d5e02dbc89580447c0c129912406b8855d",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_parsers",
@@ -644,6 +707,7 @@ artifacts = {
     "org_scalameta_trees": {
         "artifact": "org.scalameta:trees_2.13:4.15.0",
         "sha256": "a5374fc65313e5e6bf3abef2d6ed7365ef205e088ac52fd3a02451a030e3719d",
+        "srcjar_sha256": "0516430e32571fc374818ec005e0c4f40dae46ed41e54b95345c636ae7f5a8cd",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@org_scalameta_common",
@@ -679,6 +743,7 @@ artifacts = {
     "org_typelevel_paiges_core": {
         "artifact": "org.typelevel:paiges-core_2.13:0.4.4",
         "sha256": "ffbd59d3648e71c5b8f4474a54121fb3512707e7901245831669aa9e85f3bbf0",
+        "srcjar_sha256": "6eb5088d030c407040531668fe32ff87d0ec3313751228fdb261da8554c12784",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
         ],
@@ -690,6 +755,7 @@ artifacts = {
     "scala_proto_rules_grpc_api": {
         "artifact": "io.grpc:grpc-api:1.79.0",
         "sha256": "f09410380ddb66cfe52a5c865624be8af750433f0b550efdfab3dff9df2b97ac",
+        "srcjar_sha256": "da30eec62596e05390e4ea28fa34d110e5d3e2596c8cecdedf98537f8054165d",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_errorprone_error_prone_annotations",
@@ -699,6 +765,7 @@ artifacts = {
     "scala_proto_rules_grpc_context": {
         "artifact": "io.grpc:grpc-context:1.79.0",
         "sha256": "d911eb41290d3d6dd7ff521b77e80b455d58459e939fe8dbf21c4795d951655c",
+        "srcjar_sha256": "65a958201c9c9a34c4ecfc98d3ac33a498e52940ed43bfb1eeee9f551f41a288",
         "deps": [
             "@scala_proto_rules_grpc_api",
         ],
@@ -706,6 +773,7 @@ artifacts = {
     "scala_proto_rules_grpc_core": {
         "artifact": "io.grpc:grpc-core:1.79.0",
         "sha256": "3905dcc7d56288fa4b102f0af94f941c393167ec5fce1fc2a9662f2a9c53821b",
+        "srcjar_sha256": "482ec98d4412d906cbba4b4bc3c51e61e41f94bcd153227b527c4221b6962627",
         "deps": [
             "@com_google_android_annotations",
             "@com_google_code_gson_gson",
@@ -720,6 +788,7 @@ artifacts = {
     "scala_proto_rules_grpc_netty": {
         "artifact": "io.grpc:grpc-netty:1.79.0",
         "sha256": "7cb02da891d6409459bb602be68e63be2419af12e96c97ff64ef758f6a150acd",
+        "srcjar_sha256": "118af93f35064a48b86bdbc8480314265632141569299024bf748305140b6710",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -736,6 +805,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf": {
         "artifact": "io.grpc:grpc-protobuf:1.79.0",
         "sha256": "3985a84170198c1a50d36011285ed43d78477c8e9a4b5e4a8ae038a03a8b8241",
+        "srcjar_sha256": "4d919d895039f603bbbaa501bf0ee01de2adc5b43b36b2b2ed7cf0ab3fdde46a",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@com_google_protobuf_protobuf_java",
@@ -748,6 +818,7 @@ artifacts = {
     "scala_proto_rules_grpc_protobuf_lite": {
         "artifact": "io.grpc:grpc-protobuf-lite:1.79.0",
         "sha256": "27a1bc17bdd0a9f1432bd299d51773f5cf1f20e14a6fc943754a34be4029a596",
+        "srcjar_sha256": "ffe979c8f74cb8f6b92b3566922b1d3893112321b564b57189cefc9e603efd34",
         "deps": [
             "@com_google_code_findbugs_jsr305",
             "@io_bazel_rules_scala_guava",
@@ -757,6 +828,7 @@ artifacts = {
     "scala_proto_rules_grpc_stub": {
         "artifact": "io.grpc:grpc-stub:1.79.0",
         "sha256": "6ac28427db750e24dc89421230e63927fb49e9ec0bee8cecb0634c90785c8ac3",
+        "srcjar_sha256": "b3b85e6756c699ddb66a6a685924b757875c97d506982b211f2dc70518af049d",
         "deps": [
             "@com_google_errorprone_error_prone_annotations",
             "@io_bazel_rules_scala_guava",
@@ -767,6 +839,7 @@ artifacts = {
     "scala_proto_rules_grpc_util": {
         "artifact": "io.grpc:grpc-util:1.79.0",
         "sha256": "3ed8871e5f740f4d3254b6fc0011612d7e8be97b684dce36a763a9c599a95329",
+        "srcjar_sha256": "f391cce848ffd7383469b8c205233f2450c995cea5b5b440c9cf3e84f23d2395",
         "deps": [
             "@io_bazel_rules_scala_guava",
             "@org_codehaus_mojo_animal_sniffer_annotations",
@@ -781,6 +854,7 @@ artifacts = {
     "scala_proto_rules_netty_buffer": {
         "artifact": "io.netty:netty-buffer:4.1.130.Final",
         "sha256": "00a522b67ea35cb7b4dd9cf27f85c6c58f5e306785aa045302e5f6b2d4944a87",
+        "srcjar_sha256": "c30cbe8f4c131d6a99ddb84557a7b781923a2d3d980e11c8a7ca2934a39b88d0",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -788,6 +862,7 @@ artifacts = {
     "scala_proto_rules_netty_codec": {
         "artifact": "io.netty:netty-codec:4.1.130.Final",
         "sha256": "52636bc29bd62120b97bbe5d1d21eab9b1cb2bef8efbb54d2221c5f3fa08d8cd",
+        "srcjar_sha256": "7865db4844cc11bc0530bef0b26b232a9c4fed52e2c59a4f70f1eabd51fb667b",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -797,6 +872,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http": {
         "artifact": "io.netty:netty-codec-http:4.1.130.Final",
         "sha256": "5b6addc1df7b3397a193bd6544a8bfdb18ecac99fd13bee4ec75b1781a664e5e",
+        "srcjar_sha256": "ae30ea9700c45d53227a9dfcc3f229ea48c9f2066062183aacaf9ca675a99c95",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -808,6 +884,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_http2": {
         "artifact": "io.netty:netty-codec-http2:4.1.130.Final",
         "sha256": "f8ffdb550368fd5dee7c7f1393fa49552522f280ed8de96aebf4269cab0dc8f3",
+        "srcjar_sha256": "882b21352c8301655d4df8b45c9975fc5519f76260f7ce3d5e37aeb76bdea049",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -820,6 +897,7 @@ artifacts = {
     "scala_proto_rules_netty_codec_socks": {
         "artifact": "io.netty:netty-codec-socks:4.1.130.Final",
         "sha256": "9b8f8b2fab256411936ddf5358c3eb6b184c49ea7b8b01f40d473fa94ed7b92c",
+        "srcjar_sha256": "7657bd88e4d65c85d255047c2d5a942210f66f9a85cd6acbb4fdd2ff0a1f4aa0",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -830,10 +908,12 @@ artifacts = {
     "scala_proto_rules_netty_common": {
         "artifact": "io.netty:netty-common:4.1.130.Final",
         "sha256": "53921f28dd5a352b1bed0e1cbcc54d013dc60ffebeae9b2b1e53eabef317e581",
+        "srcjar_sha256": "9c986998ea0ed5416f15f93fa097d39c83e84ee7d64c954fae332b407a04f4ce",
     },
     "scala_proto_rules_netty_handler": {
         "artifact": "io.netty:netty-handler:4.1.130.Final",
         "sha256": "98c78ec187ca30a4b9775bf6f632f5c9929db6bf06a60e6971f945813880ca0f",
+        "srcjar_sha256": "4fd9ed997c051fdf45f9a9283a0c461b09a5d5001b80f495508871ff048a7b4a",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -846,6 +926,7 @@ artifacts = {
     "scala_proto_rules_netty_handler_proxy": {
         "artifact": "io.netty:netty-handler-proxy:4.1.130.Final",
         "sha256": "33656875d0001587eea4a9778cf2242b418bc887ed03b2d37ef3969e0b7d3b5e",
+        "srcjar_sha256": "8f6b51692e0d2f8f228f8ff22eefa155a774194972bd814cbe34fbd052da7e21",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_codec",
@@ -858,6 +939,7 @@ artifacts = {
     "scala_proto_rules_netty_resolver": {
         "artifact": "io.netty:netty-resolver:4.1.130.Final",
         "sha256": "48c5b218a89d184e1b601d46433957f515fcefdb4464182b1348bce4f5a18f35",
+        "srcjar_sha256": "d74be8e1306c4e17b783622cda547c33031b7f1957c77f07d1a29575ddb746e3",
         "deps": [
             "@scala_proto_rules_netty_common",
         ],
@@ -865,6 +947,7 @@ artifacts = {
     "scala_proto_rules_netty_transport": {
         "artifact": "io.netty:netty-transport:4.1.130.Final",
         "sha256": "1bf573266d271f856705a9984d25449c56a1d73c02a16af12033ceccfe555dbb",
+        "srcjar_sha256": "ab3776dda65078cb019a8c6c5c10dfb66c72115a13f2d3248b52c2fc7c6f7414",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -874,6 +957,7 @@ artifacts = {
     "scala_proto_rules_netty_transport_native_unix_common": {
         "artifact": "io.netty:netty-transport-native-unix-common:4.1.130.Final",
         "sha256": "cf5efc4168597d7cd14695b469418cac2a1134533f9a0c82ef0538d796fd39e1",
+        "srcjar_sha256": "12f5691191952f07da3715fcbb29bea851ce6514cd69f4d88796d8da12a09526",
         "deps": [
             "@scala_proto_rules_netty_buffer",
             "@scala_proto_rules_netty_common",
@@ -899,10 +983,12 @@ artifacts = {
     "scala_proto_rules_perfmark_api": {
         "artifact": "io.perfmark:perfmark-api:0.27.0",
         "sha256": "c7b478503ec524e55df19b424d46d27c8a68aeb801664fadd4f069b71f52d0f6",
+        "srcjar_sha256": "311551ab29cf51e5a8abee6a019e88dee47d1ea71deb9fcd3649db9c51b237bc",
     },
     "scala_proto_rules_proto_google_common_protos": {
         "artifact": "com.google.api.grpc:proto-google-common-protos:2.66.0",
         "sha256": "e50c79240ba7391bf860fb2661fe6354d25a42cba69ca4a30bcf4e3117368588",
+        "srcjar_sha256": "2a54e6a470bf07d66b0774fff57ac5c91f080c8e300eae78a8294b298bceb08f",
         "deps": [
             "@com_google_protobuf_protobuf_java",
         ],
@@ -910,6 +996,7 @@ artifacts = {
     "scala_proto_rules_scalapb_compilerplugin": {
         "artifact": "com.thesamet.scalapb:compilerplugin_3:1.0.0-alpha.3",
         "sha256": "f61d76a09a6d8ccc25d0f98ab9f9172ad42659dd76a694c3b7294ba3e5a26a06",
+        "srcjar_sha256": "052b989fe8dc5d49a9df3f7aa813fe2e6e5f02ea3b5e629d4d478c11236cfc20",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -920,6 +1007,7 @@ artifacts = {
     "scala_proto_rules_scalapb_lenses": {
         "artifact": "com.thesamet.scalapb:lenses_3:1.0.0-alpha.3",
         "sha256": "ddf29b2aee3e88bd8f58948470965c296ef6e07f6e09f4e02ed7b19bafb78499",
+        "srcjar_sha256": "6a349905cd24fdc22d7f30527e21b54679e58ea5cd5c4966f0b96f3bf111fa61",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",
@@ -928,6 +1016,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_bridge": {
         "artifact": "com.thesamet.scalapb:protoc-bridge_2.13:0.9.9",
         "sha256": "d3b70d7ef67e9186d25b10898b115d27bf2ccf53e9f3d136404420d2ec52ed66",
+        "srcjar_sha256": "c24b3ec355846168fce61b2d1ce0d7cee49079d799a1411b1cdea0d364c6794c",
         "deps": [
             "@dev_dirs_directories",
             "@io_bazel_rules_scala_scala_library_2",
@@ -936,6 +1025,7 @@ artifacts = {
     "scala_proto_rules_scalapb_protoc_gen": {
         "artifact": "com.thesamet.scalapb:protoc-gen_2.13:0.9.9",
         "sha256": "0adb3cedd175aa703d06aa58c914e3876a6e88613a63eb83d3e2a74592f1ba1b",
+        "srcjar_sha256": "6c4d621291ee88946049fc730c4ee8910d9ef6d7a1545297a50e8879c08b47b6",
         "deps": [
             "@io_bazel_rules_scala_scala_library_2",
             "@scala_proto_rules_scalapb_protoc_bridge",
@@ -944,6 +1034,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime_3:1.0.0-alpha.3",
         "sha256": "8b128634d64bf0a29c52001eabc12458e15c958843894a4020d181c7fc1d21fc",
+        "srcjar_sha256": "dbddbe90f391ec7d950b644deeb32797e4835659cd1f90689c8b27ec98a39af8",
         "deps": [
             "@com_google_protobuf_protobuf_java",
             "@io_bazel_rules_scala_scala_library",
@@ -954,6 +1045,7 @@ artifacts = {
     "scala_proto_rules_scalapb_runtime_grpc": {
         "artifact": "com.thesamet.scalapb:scalapb-runtime-grpc_3:1.0.0-alpha.3",
         "sha256": "87400fb72734b26f058b35e6c13518f5e7a54d4dce3714452ce0df24cdb9d0c6",
+        "srcjar_sha256": "9d4cca2fb1a3a3e623dacb87d8687b79120284507391081b4e157b5f151ad684",
         "deps": [
             "@io_bazel_rules_scala_scala_library",
             "@org_scala_lang_modules_scala_collection_compat",


### PR DESCRIPTION
## Summary

The generated `third_party/repositories/scala_*.bzl` files recorded only a `sha256` for each artifact's main jar, never for its `-sources.jar`. Without an integrity hash, Bazel cannot serve source jars from its repository cache (which is keyed by content hash), so any fresh output base re-downloads every source jar from Maven. This is especially painful for nested `bazel build` invocations (e.g. from within a test) that run in an isolated output base with an empty `external/`.

This PR records `srcjar_sha256` for every resolvable artifact so source jars are served from the repository cache instead of being re-fetched.

- **`scripts/create_repository.py`**: resolve the `sources` classifier via a second `coursier fetch` and backfill `srcjar_sha256` onto every artifact entry (not just those whose version changed). Emits metadata keys in a canonical order (`srcjar_sha256` right after `sha256`). Artifacts that publish no sources jar are simply skipped.
- **`third_party/repositories/repositories.bzl`**: thread `srcjar_sha256` (already a supported attribute on the underlying rule) through to `scala_maven_import_external`.
- Regenerated all 11 `scala_*.bzl` files — **974 `srcjar_sha256` entries added**, with no version churn, reordering, or removals.

## Test plan

- [x] `python3 scripts/create_repository.py` regenerates cleanly; the diff for the artifact files is purely added `srcjar_sha256` lines.
- [x] End-to-end cache reuse verified: fetched a source-fetching repo (`scalatest_core`) into a fresh `--repository_cache`, confirmed the pinned sources hash landed in the cache's content-addressable store, then re-fetched with a fresh `--output_base` and **no network access** (Maven unreachable) — the source jar was served entirely from the cache (`All requested repos fetched successfully`, zero downloads).
- [ ] CI green across supported Scala versions / Bazel versions.