### PR TITLE
refactor: Use package-relative targets in expect_build_failure tests

### DIFF
--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -28,7 +28,8 @@ def expect_build_failure_test(
 
     Args:
         name: test target name.
-        target: label whose `bazel build` must fail.
+        target: label whose `bazel build` must fail. A package-relative label
+            (`":foo"` or `"foo"`) is resolved against this package.
         build_args: extra flags forwarded verbatim to the nested `bazel build`
             (e.g. `"--repo_env=SCALA_VERSION=2.13.18"`).
         worker_sandboxing: if True, pass `--worker_sandboxing` to the nested
@@ -48,7 +49,17 @@ def expect_build_failure_test(
             sandbox.
         **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
     """
-    args = ["--target", target]
+    # The nested `bazel build` runs from the workspace root, so a package-relative
+    # label must be absolutized against this package first -- otherwise it would
+    # resolve against the root package.
+    if target.startswith("//") or target.startswith("@"):
+        absolute_target = target
+    elif target.startswith(":"):
+        absolute_target = "//%s%s" % (native.package_name(), target)
+    else:
+        absolute_target = "//%s:%s" % (native.package_name(), target)
+
+    args = ["--target", absolute_target]
     for build_arg in build_args:
         args += ["--build-arg", build_arg]
     for expect_file in expect:

--- a/test/java_in_src_jar/BUILD
+++ b/test/java_in_src_jar/BUILD
@@ -1,9 +1,6 @@
 load("//scala:scala.bzl", "scala_library")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
-# Migrated from test/shell/test_scala_library.sh
-# (test_scala_library_expect_failure_on_java_in_src_jar_when_disabled).
-
 # Pack the Java source into a source jar so scala_library sees a `.srcjar` input
 # (rather than committing a binary jar into the repo).
 genrule(
@@ -27,5 +24,5 @@ scala_library(
 expect_build_failure_test(
     name = "java_in_src_jar_when_disabled_build_test",
     expect = ["expected_java_in_srcjar.txt"],
-    target = "//test/java_in_src_jar:java_source_jar",
+    target = ":java_source_jar",
 )

--- a/test/jmh/reports_failure/BUILD
+++ b/test/jmh/reports_failure/BUILD
@@ -1,8 +1,6 @@
 load("//jmh:jmh.bzl", "scala_benchmark_jmh")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
-# Migrated from test/shell/test_misc.sh (test_benchmark_jmh_failure).
-#
 # A JMH benchmark class may not be `final`, so this target is expected to fail to
 # build. It is tagged "manual" so wildcard `bazel build //...` skips it; the
 # expect_build_failure_test drives a nested `bazel build` and asserts the failure.
@@ -19,5 +17,5 @@ scala_benchmark_jmh(
 
 expect_build_failure_test(
     name = "jmh_reports_failure_build_test",
-    target = "//test/jmh/reports_failure:jmh_reports_failure",
+    target = ":jmh_reports_failure",
 )

--- a/test/macros/BUILD
+++ b/test/macros/BUILD
@@ -90,7 +90,7 @@ build_test(
 expect_build_failure_test(
     name = "incorrect_macro_user_build_test",
     expect = [":incorrect_macro_user_expected_error.txt"],
-    target = "//test/macros:incorrect-macro-user",
+    target = ":incorrect-macro-user",
 )
 
 # Regression test for https://github.com/bazel-contrib/rules_scala/issues/1819:
@@ -117,10 +117,6 @@ sh_test(
     ],
 )
 
-# Migrated from test/shell/test_persistent_worker.sh
-# (test_persistent_worker_handles_exception_in_macro_invocation and
-# test_persistent_worker_handles_stack_overflow_exception).
-#
 # These macros throw during expansion (a plain exception, and a StackOverflowError).
 # The Scalac persistent worker must surface a clean build failure rather than
 # crashing, so the sh_tests assert the build fails with the expected message and
@@ -151,7 +147,7 @@ expect_build_failure_test(
     build_args = ["--strategy=Scalac=worker"],
     expect = ["expected_macro_expansion_failure.txt"],
     reject = ["rejected_worker_crash.txt"],
-    target = "//test/macros:bad_macro_invocation",
+    target = ":bad_macro_invocation",
     worker_sandboxing = True,
 )
 
@@ -160,6 +156,6 @@ expect_build_failure_test(
     build_args = ["--strategy=Scalac=worker"],
     expect = ["expected_stack_overflow_failure.txt"],
     reject = ["rejected_worker_crash.txt"],
-    target = "//test/macros:stack_overflow_macro_invocation",
+    target = ":stack_overflow_macro_invocation",
     worker_sandboxing = True,
 )

--- a/test/scalacopts/scalacopts_from_toolchain/BUILD
+++ b/test/scalacopts/scalacopts_from_toolchain/BUILD
@@ -2,8 +2,6 @@ load("//scala:scala.bzl", "scala_library")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
-# Migrated from test/shell/test_toolchain.sh (test_scalaopts_from_scala_toolchain).
-#
 # `failing_scala_toolchain` adds scalacopts = ["-Ywarn-unused"]; combined with
 # the target's own -Xfatal-warnings, the unused val in ClassWithUnused.scala
 # becomes a fatal warning, so `failing_build` fails to compile when that
@@ -34,5 +32,5 @@ scala_library(
 expect_build_failure_test(
     name = "scalacopts_from_toolchain_fails_build_test",
     build_args = ["--extra_toolchains=//test/scalacopts/scalacopts_from_toolchain:failing_scala_toolchain"],
-    target = "//test/scalacopts/scalacopts_from_toolchain:failing_build",
+    target = ":failing_build",
 )

--- a/test/scalacopts_invalid/BUILD
+++ b/test/scalacopts_invalid/BUILD
@@ -1,5 +1,3 @@
-# Migrated from test/shell/test_invalid_scalacopts.sh.
-#
 # `//test_expect_failure/scalacopts_invalid:empty` is a `scala_library` with an
 # invalid `-source:not-existing` scalacopt, so it is expected to fail to build.
 # Bazel has no native "expect build failure" rule, so each test drives a nested

--- a/test/toolchains/compilers_javac_opts/BUILD
+++ b/test/toolchains/compilers_javac_opts/BUILD
@@ -1,9 +1,6 @@
 load("//scala:scala.bzl", "scala_library")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
-# Migrated from test/shell/test_toolchain.sh
-# (java_toolchain_javacopts_are_used / java_toolchain_javacopts_can_be_overridden).
-#
 # The fixtures fail to compile once an invalid javac flag reaches the compiler
 # (either via `--javacopt` on the command line, or a bad target `javacopts`).
 # They are tagged "manual" so wildcard builds skip them; the sh_tests drive a
@@ -29,12 +26,12 @@ expect_build_failure_test(
         "--verbose_failures",
     ],
     expect = ["expected_invalid_flag.txt"],
-    target = "//test/toolchains/compilers_javac_opts:can_configure_jvm_flags_for_javac_via_javacopts",
+    target = ":can_configure_jvm_flags_for_javac_via_javacopts",
 )
 
 expect_build_failure_test(
     name = "javac_javacopts_can_be_overridden_build_test",
     build_args = ["--verbose_failures"],
     expect = ["expected_invalid_target.txt"],
-    target = "//test/toolchains/compilers_javac_opts:can_override_default_toolchain_flags_for_javac_via_javacopts",
+    target = ":can_override_default_toolchain_flags_for_javac_via_javacopts",
 )

--- a/test/toolchains/compilers_jvm_flags/BUILD
+++ b/test/toolchains/compilers_jvm_flags/BUILD
@@ -1,9 +1,6 @@
 load("//scala:scala.bzl", "scala_library")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
-# Migrated from test/shell/test_javac_jvm_flags.sh and
-# test/shell/test_scalac_jvm_flags.sh.
-#
 # Each library sets an intentionally broken JVM flag (-Xmx1M, or an args-file
 # flag that must be `$(location ...)`-expanded) so compilation fails. The
 # fixtures are tagged "manual" so wildcard `bazel build //...` skips them; the
@@ -60,7 +57,7 @@ scala_library(
 [
     expect_build_failure_test(
         name = name + "_build_test",
-        target = "//test/toolchains/compilers_jvm_flags:" + name,
+        target = ":" + name,
     )
     for name in [
         "can_configure_jvm_flags_for_scalac",
@@ -74,7 +71,7 @@ scala_library(
         name = name + "_build_test",
         build_args = ["--verbose_failures"],
         expect = [message],
-        target = "//test/toolchains/compilers_jvm_flags:" + name,
+        target = ":" + name,
     )
     for name, message in [
         ("can_expand_jvm_flags_for_scalac", "expected_scalac_expand.txt"),

--- a/test/toolchains/scalac_jvm_opts/BUILD
+++ b/test/toolchains/scalac_jvm_opts/BUILD
@@ -2,9 +2,6 @@ load("//scala:scala.bzl", "scala_library")
 load("//scala:scala_toolchain.bzl", "scala_toolchain")
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
-# Migrated from test/shell/test_scalac_jvm_flags.sh
-# (test_scalac_jvm_flags_from_scala_toolchain_fails).
-#
 # `failing_scala_toolchain` sets scalac_jvm_flags = ["-Xmx1M"], which is not
 # enough heap for scalac, so `empty_build` fails to compile when that toolchain
 # is registered. `empty_build` compiles fine under the default toolchain, so it
@@ -33,5 +30,5 @@ scala_library(
 expect_build_failure_test(
     name = "scalac_jvm_flags_from_toolchain_fails_build_test",
     build_args = ["--extra_toolchains=//test/toolchains/scalac_jvm_opts:failing_scala_toolchain"],
-    target = "//test/toolchains/scalac_jvm_opts:empty_build",
+    target = ":empty_build",
 )


### PR DESCRIPTION
<!-- start git-machete generated -->

# Based on PR #1852

## Chain of upstream PRs & tree of downstream PRs as of 2026-07-08

* PR #1851:
  `master` ← `refactor/java-in-src-jar-as-bazel-test`

  * PR #1852:
    `refactor/java-in-src-jar-as-bazel-test` ← `refactor/toolchain-config-failures-as-bazel-test`

    * **PR #1853 (THIS ONE)**:
      `refactor/toolchain-config-failures-as-bazel-test` ← `refactor/expect-build-failure-relative-targets`

        * PR #1854:
          `refactor/expect-build-failure-relative-targets` ← `refactor/transitive-dep-failures-as-bazel-test`

          * PR #1855:
            `refactor/transitive-dep-failures-as-bazel-test` ← `refactor/analysis-build-failures-as-bazel-test`

            * PR #1856:
              `refactor/analysis-build-failures-as-bazel-test` ← `refactor/test-run-toolchain-failures-as-bazel-test`

              * PR #1857:
                `refactor/test-run-toolchain-failures-as-bazel-test` ← `refactor/junit-rule-failures-as-bazel-test`

                * PR #1858:
                  `refactor/junit-rule-failures-as-bazel-test` ← `refactor/specs2-failure-messages-as-bazel-test`

                  * PR #1859:
                    `refactor/specs2-failure-messages-as-bazel-test` ← `refactor/positive-nested-test-runs-as-bazel-test`

<!-- end git-machete generated -->

## Summary

Follow-up tidy-up of the `expect_build_failure_test` call sites:

- Drops the `# Migrated from test/shell/...` provenance comments (the remaining comment text keeps the actual rationale for each fixture).
- Switches every `expect_build_failure_test` `target` to a package-relative label (`:foo`). The macro now absolutizes a package-relative label against its own package before forwarding it to the nested `bazel build` (which runs from the workspace root, where a bare `:foo` would otherwise resolve against the root package).

## Test plan

- [x] `bazel test //test/java_in_src_jar:java_in_src_jar_when_disabled_build_test //test/toolchains/scalac_jvm_opts:scalac_jvm_flags_from_toolchain_fails_build_test` (relative-target resolution works)