### PR TITLE
Track code under test so `expect_build_failure_test` caching is sound

### DIFF
--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -72,6 +72,18 @@ def expect_build_failure_test(
             "//conditions:default": ["--build-arg", "--worker_sandboxing"],
         })
 
+    # The nested `bazel build` reads the *real* source tree, not the runfiles, so
+    # `target` and its sources are not otherwise inputs of this `sh_test`: without
+    # help Bazel would serve a cached PASS even after the code under test changed
+    # (a false green). We can't just add `target` to `data` -- it is expected to
+    # fail to build, which would break this test's own build -- and a macro can't
+    # introspect a target's `srcs`. So glob every source file in this package and
+    # declare it as runfiles: editing any of them changes the test's cache key and
+    # forces a re-run. This covers the common case of a fixture whose sources live
+    # alongside its BUILD file; a `target` in another package is not tracked (pass
+    # its sources via `data` if you need that).
+    code_under_test = native.glob(["**/*"], allow_empty = True)
+
     # Both entries must be in the test's runfiles (a file reaches runfiles only if
     # it is a declared dependency):
     #   - MODULE.bazel: the helper has no other way to find the *real* source
@@ -84,10 +96,23 @@ def expect_build_failure_test(
     data = [
         "//:MODULE.bazel",
         _NESTED_BAZEL_LIB,
-    ] + expect + reject + kwargs.pop("data", [])
+    ] + expect + reject + code_under_test + kwargs.pop("data", [])
+
+    # De-duplicate by canonical label: `code_under_test` re-lists files that are
+    # also named explicitly (e.g. the expect/reject `.txt`s, passed as `:foo.txt`),
+    # and Bazel rejects a label that resolves to the same target twice in `data`.
+    # Compare canonical labels so `foo`, `:foo` and `//pkg:foo` collapse to one.
     deduped_data = []
+    seen = {}
     for entry in data:
-        if entry not in deduped_data:
+        if entry.startswith("//") or entry.startswith("@"):
+            key = entry
+        elif entry.startswith(":"):
+            key = "//%s%s" % (native.package_name(), entry)
+        else:
+            key = "//%s:%s" % (native.package_name(), entry)
+        if key not in seen:
+            seen[key] = True
             deduped_data.append(entry)
 
     sh_test(


### PR DESCRIPTION
## Problem

`expect_build_failure_test` (in `test/expect_build_failure/expect_build_failure.bzl`) has no native Bazel equivalent — there is no "assert this target fails to build" rule — so it wraps an `sh_test` around `expect_build_failure.sh`, which runs a **nested** `bazel build` of the target under test.

That nested build deliberately operates on the **real source tree**, not the test's runfiles (it resolves the workspace root via `//:MODULE.bazel` and `cd`s into it — see `nested_bazel.sh`). The upshot is that **the target under test and its sources were never inputs of the `sh_test`**. Its only declared inputs were:

- `expect_build_failure.sh` (the helper)
- `nested_bazel.sh`
- `//:MODULE.bazel`
- the `expect` / `reject` fixture `.txt`s

Because Bazel keys a test's result cache on the test executable + its runfiles, and the code under test was in neither, the cache key **did not depend on the thing being tested**. Concretely:

- **False green (the real danger):** edit a fixture's `.scala`/`.java` so it would now *build successfully* (or fail differently), and Bazel serves a cached `PASS` — the negative test silently never re-runs.
- **Over-invalidation (the flip side):** every one of these tests data-deps on `//:MODULE.bazel`, so *any* `MODULE.bazel` change re-runs **all** of them at once — exactly when the shared-output-base serialization hurts most.

## Why not just add `target` to `data`?

Two dead ends:

1. `target` is **expected to fail to build**. Putting it in `data` would make it a dependency of the `sh_test`, so the test's *own* build would fail before the test ever runs.
2. A macro runs at loading time and **can't introspect a target's `srcs`** (that's analysis-time provider info), so it can't enumerate the exact sources either.

## Fix

Glob every source file in the calling package and declare it as the test's runfiles:

```starlark
code_under_test = native.glob(["**/*"], allow_empty = True)
```

Editing any of those files now changes the `sh_test`'s cache key and forces a re-run. This is done entirely **in the macro**, so all callers get it with zero per-`BUILD` changes.

Dedup is also made **label-canonical** (`foo`, `:foo`, and `//pkg:foo` collapse to one): the glob re-lists the `expect`/`reject` `.txt`s that callers pass as `:foo.txt`, and Bazel rejects a target that appears twice in `data`.

## Verification

On `//test/scalacopts/scalacopts_from_toolchain:scalacopts_from_toolchain_fails_build_test`:

| Step | Result |
|------|--------|
| Run 1 (populate) | `PASSED in 12.2s` |
| Run 2 (no change) | `(cached) PASSED` |
| Edit `ClassWithUnused.scala`, Run 3 | `PASSED in 8.5s` — **no `(cached)`**, re-executed |

Before this change, Run 3 would have stayed `(cached)`. All 8 caller packages on `master` continue to analyze cleanly.

## Scope / limitations

- **Same-package fixtures only.** The glob tracks the caller package's own sources — the common case. A `target` in *another* package (e.g. `test/scalacopts_invalid`, whose target still points at `//test_expect_failure/scalacopts_invalid:empty`) is not tracked; those should pass the relevant sources via `data`, or move the fixture into the package.
- **Conservative by design.** Any change in the fixture package (incl. its `BUILD`) re-runs the test — this errs toward correctness over minimal reruns.
- Only `expect_build_failure_test` exists on `master`. As the sibling macros (`expect_test_failure_test`, `expect_test_success_test`) and the shared `_nested_bazel_test` helper land, this same glob + dedup should move into that helper so all three inherit it in one place.