### PR TITLE
ci: Forward PATH to test actions on the last_green Bazel step

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -72,6 +72,14 @@ tasks:
       # Install xmllint
       - sudo apt update && sudo apt install --reinstall libxml2-utils -y
       - echo "common --lockfile_mode=update" >>.bazelrc
+      # The nested-Bazel tests (expect_build_failure_test etc.) shell out to
+      # `bazel` from inside a test action. bazelisk prepends the dir holding the
+      # resolved binary (here the downloaded last_green build) to PATH so nested
+      # invocations reuse it -- but last_green's Bazel uses a static action PATH
+      # by default, which drops that dir and makes the nested `bazel` unresolvable
+      # (`env: 'bazel': No such file`). Forward the client PATH into test actions
+      # so the nested calls find last_green, as released-Bazel steps already do.
+      - echo "test --test_env=PATH" >>.bazelrc
       - "./test_rules_scala.sh"
     soft_fail:
       - exit_status: "*"


### PR DESCRIPTION
### Description

Add `test --test_env=PATH` to the `./test_rules_scala (last_green Bazel)` step in `.bazelci/presubmit.yml`, so the client `PATH` is forwarded into `bazel test` actions on that step.

### Motivation

The nested-Bazel tests (`expect_build_failure_test`, `expect_no_ijar`, etc.) shell out to `bazel` from **inside** a `bazel test` action. bazelisk deliberately prepends the directory holding the resolved binary to `PATH` so that "Bazel targets that invoke `bazel` will use the same Bazel binary as the outer invocation" ([bazelisk README](https://github.com/bazelbuild/bazelisk/blob/master/README.md)).

That works on the released Bazel the other steps use, but the `last_green` binary (currently `10.0.0-pre-…`) uses a **static action `PATH`** by default, which drops bazelisk's prepended directory from the test-action environment. The nested call then can't find `bazel`:

```
Build failed as expected, but output did not contain the expected message.
env: 'bazel': No such file or directory
```

So all ~13 nested-Bazel tests fail and the step goes amber. It's currently `soft_fail: exit_status: "*"`, so it doesn't block PRs — but it also means the step never actually exercised last_green for these tests.

Forwarding `PATH` re-exposes bazelisk's directory to the test actions. Per bazelisk's design this makes the nested `bazel` resolve to the **same last_green binary**, so the step finally does what it's meant to for these tests instead of erroring out at launch.

Scoped to the last_green step only; the mild reduction in test-action hermeticity is acceptable for an advisory, soft-fail early-warning task. This was a pre-existing artifact of running nested-Bazel tests under last_green (not introduced by any recent test-migration commit).