### PR TITLE
Worker: echo WorkRequest.request_id on WorkResponse

### DIFF
--- a/src/java/io/bazel/rulesscala/worker/Worker.java
+++ b/src/java/io/bazel/rulesscala/worker/Worker.java
@@ -91,6 +91,7 @@ public final class Worker {
           WorkerProtocol.WorkResponse.newBuilder()
               .setExitCode(code)
               .setOutput(outStream.toString())
+              .setRequestId(request.getRequestId())
               .build()
               .writeDelimitedTo(stdout);
 

--- a/src/java/io/bazel/rulesscala/worker/WorkerTest.java
+++ b/src/java/io/bazel/rulesscala/worker/WorkerTest.java
@@ -65,6 +65,7 @@ public class WorkerTest {
       Files.write(tmpFile, contents.getBytes(StandardCharsets.UTF_8));
 
       WorkerProtocol.WorkRequest.newBuilder()
+          .setRequestId(42)
           .addArguments("@" + tmpFile)
           .build()
           .writeDelimitedTo(helper.requestOut);
@@ -76,6 +77,7 @@ public class WorkerTest {
 
       assertEquals(0, response.getExitCode());
       assertEquals(contents, response.getOutput());
+      assertEquals(42, response.getRequestId());
     } finally {
       Files.deleteIfExists(tmpFile);
     }


### PR DESCRIPTION
The persistent worker loop built WorkResponse without setting request_id, so proto's default (0) was written regardless of the incoming id. This breaks the Bazel worker protocol's correlation contract, which multiplex- capable clients (and executors that detect double-emit) rely on.

Match Bazel's own WorkRequestHandler by echoing request.getRequestId() verbatim. No wire-level change for non-multiplex clients that already send request_id=0.
