### PR TITLE
refactor: Add nested test-run macros and generalize the nested-bazel helper

### DIFF
--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -50,7 +50,13 @@ def _nested_bazel_test(
     if expect_success:
         args += ["--expect-success"]
     for key in env:
-        args += ["--env", "%s=%s" % (key, env[key])]
+        value = env[key]
+        # Same Bourne-tokenization guard as bazel_args below: an env value with a
+        # space would otherwise be split into two `sh_test` args, and the helper
+        # would reject the stray token.
+        if " " in value:
+            value = "'%s'" % value
+        args += ["--env", "%s=%s" % (key, value)]
     for bazel_arg in bazel_args:
         # Bazel applies Bourne tokenization to `sh_test` `args`, which would split
         # a flag containing spaces (e.g. `--test_arg=test 1`) into two tokens.

--- a/test/expect_build_failure/expect_build_failure.bzl
+++ b/test/expect_build_failure/expect_build_failure.bzl
@@ -1,10 +1,18 @@
-"""Macro for asserting that `bazel build` of a target fails.
+"""Macros for asserting the outcome of a nested `bazel <command>` of a target.
 
-Bazel has no native "expect this target to fail to build" rule, so we wrap an
-`sh_test` around `expect_build_failure.sh` (which runs a nested `bazel build`).
-This macro lets callers declare intent -- the target and the messages the build
-output must/mustn't contain -- instead of hand-assembling the script's raw args,
-`$(rootpath ...)` expansions, runfiles, and boilerplate tags on every call.
+Bazel has no native "run bazel and assert on the outcome" rule, so we wrap an
+`sh_test` around `expect_build_failure.sh` (which runs a nested `bazel build`,
+`bazel test` or `bazel coverage`). These macros let callers declare intent --
+the target, the subcommand, and the messages the output must/mustn't contain --
+instead of hand-assembling the script's raw args, `$(rootpath ...)` expansions,
+runfiles, and boilerplate tags on every call.
+
+- `expect_build_failure_test` asserts a `bazel build` fails.
+- `expect_test_failure_test` asserts a `bazel test` (or `bazel coverage`) fails.
+- `expect_test_success_test` asserts a `bazel test` succeeds (e.g. a fixture that
+  only passes under a specific `--test_filter` or inherited env var).
+
+All three share the same script and nested-Bazel plumbing.
 """
 
 load("@rules_shell//shell:sh_test.bzl", "sh_test")
@@ -14,54 +22,42 @@ _HELPER = "//test/expect_build_failure:expect_build_failure.sh"
 # Sourced at runtime by _HELPER, so it must be present in the test's runfiles.
 _NESTED_BAZEL_LIB = "//test/expect_build_failure:nested_bazel.sh"
 
-def expect_build_failure_test(
-        name,
-        target,
-        build_args = [],
-        worker_sandboxing = False,
-        expect = [],
-        reject = [],
-        size = "large",
-        tags = ["local", "requires-network"],
-        **kwargs):
-    """Declares an `sh_test` asserting that building `target` fails.
-
-    Args:
-        name: test target name.
-        target: label whose `bazel build` must fail. A package-relative label
-            (`":foo"` or `"foo"`) is resolved against this package.
-        build_args: extra flags forwarded verbatim to the nested `bazel build`
-            (e.g. `"--repo_env=SCALA_VERSION=2.13.18"`).
-        worker_sandboxing: if True, pass `--worker_sandboxing` to the nested
-            `bazel build` -- but only on non-Windows, since Bazel worker
-            sandboxing is not implemented on Windows (mirrors the historical
-            guard in test/shell/test_persistent_worker.sh; without it the nested
-            scalac worker fails to start with a missing-JVM error instead of
-            producing the compile failure under test).
-        expect: file labels whose (newline-stripped) contents must appear in the
-            build output. Automatically added to the test's `data`.
-        reject: file labels whose (newline-stripped) contents must NOT appear in
-            the build output. Automatically added to the test's `data`.
-        size: test size; defaults to `"large"` (the nested Bazel invocation is
-            slow and, on a cold cache, serializes on the shared output base).
-        tags: test tags; defaults to `["local", "requires-network"]` because the
-            nested `bazel build` fetches external repos and must run outside the
-            sandbox.
-        **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
-    """
-    # The nested `bazel build` runs from the workspace root, so a package-relative
-    # label must be absolutized against this package first -- otherwise it would
-    # resolve against the root package.
+def _absolutize(target):
+    # The nested `bazel <command>` runs from the workspace root, so a
+    # package-relative label must be absolutized against this package first --
+    # otherwise it would resolve against the root package.
     if target.startswith("//") or target.startswith("@"):
-        absolute_target = target
+        return target
     elif target.startswith(":"):
-        absolute_target = "//%s%s" % (native.package_name(), target)
+        return "//%s%s" % (native.package_name(), target)
     else:
-        absolute_target = "//%s:%s" % (native.package_name(), target)
+        return "//%s:%s" % (native.package_name(), target)
 
-    args = ["--target", absolute_target]
-    for build_arg in build_args:
-        args += ["--build-arg", build_arg]
+def _nested_bazel_test(
+        name,
+        command,
+        target,
+        bazel_args,
+        expect_success,
+        env,
+        worker_sandboxing,
+        expect,
+        reject,
+        size,
+        tags,
+        **kwargs):
+    args = ["--command", command, "--target", _absolutize(target)]
+    if expect_success:
+        args += ["--expect-success"]
+    for key in env:
+        args += ["--env", "%s=%s" % (key, env[key])]
+    for bazel_arg in bazel_args:
+        # Bazel applies Bourne tokenization to `sh_test` `args`, which would split
+        # a flag containing spaces (e.g. `--test_arg=test 1`) into two tokens.
+        # Single-quote such values so tokenization keeps them whole.
+        if " " in bazel_arg:
+            bazel_arg = "'%s'" % bazel_arg
+        args += ["--bazel-arg", bazel_arg]
     for expect_file in expect:
         args += ["--expect-file", "$(rootpath %s)" % expect_file]
     for reject_file in reject:
@@ -69,19 +65,21 @@ def expect_build_failure_test(
     if worker_sandboxing:
         args = args + select({
             "@platforms//os:windows": [],
-            "//conditions:default": ["--build-arg", "--worker_sandboxing"],
+            "//conditions:default": ["--bazel-arg", "--worker_sandboxing"],
         })
 
-    # The nested `bazel build` reads the *real* source tree, not the runfiles, so
-    # `target` and its sources are not otherwise inputs of this `sh_test`: without
-    # help Bazel would serve a cached PASS even after the code under test changed
-    # (a false green). We can't just add `target` to `data` -- it is expected to
-    # fail to build, which would break this test's own build -- and a macro can't
-    # introspect a target's `srcs`. So glob every source file in this package and
-    # declare it as runfiles: editing any of them changes the test's cache key and
-    # forces a re-run. This covers the common case of a fixture whose sources live
-    # alongside its BUILD file; a `target` in another package is not tracked (pass
-    # its sources via `data` if you need that).
+    # The nested `bazel <command>` reads the *real* source tree, not the runfiles,
+    # so `target` and its sources are not otherwise inputs of this `sh_test`:
+    # without help Bazel would serve a cached result even after the code under
+    # test changed (a false green -- a negative test that silently stops
+    # re-running). We can't just add `target` to `data`: the failure-asserting
+    # macros expect it to *fail* to build, which would break this test's own
+    # build, and a macro can't introspect a target's `srcs` anyway. So glob every
+    # source file in this package and declare it as runfiles: editing any of them
+    # changes the test's cache key and forces a re-run. This covers the common
+    # case of a fixture whose sources live alongside its BUILD file; a `target` in
+    # another package is not tracked (pass its sources via `data` if you need
+    # that).
     code_under_test = native.glob(["**/*"], allow_empty = True)
 
     # Both entries must be in the test's runfiles (a file reaches runfiles only if
@@ -90,7 +88,7 @@ def expect_build_failure_test(
     #     workspace under `bazel test` (BUILD_WORKSPACE_DIRECTORY is `bazel run`
     #     only; TEST_SRCDIR points at the runfiles copy). It reads this root
     #     marker -- a symlink back into the source tree -- and resolves it to the
-    #     directory the nested `bazel build` must run in. See
+    #     directory the nested `bazel <command>` must run in. See
     #     _nested_bazel_find_workspace in nested_bazel.sh.
     #   - nested_bazel.sh: sourced at runtime by the helper script.
     data = [
@@ -121,6 +119,161 @@ def expect_build_failure_test(
         srcs = [_HELPER],
         args = args,
         data = deduped_data,
+        tags = tags,
+        **kwargs
+    )
+
+def expect_build_failure_test(
+        name,
+        target,
+        build_args = [],
+        worker_sandboxing = False,
+        expect = [],
+        reject = [],
+        size = "large",
+        tags = ["local", "requires-network"],
+        **kwargs):
+    """Declares an `sh_test` asserting that `bazel build` of `target` fails.
+
+    Args:
+        name: test target name.
+        target: label whose `bazel build` must fail. A package-relative label
+            (`":foo"` or `"foo"`) is resolved against this package. The caller
+            must tag this fixture `"manual"`: it is expected to fail to build and
+            would otherwise break a plain wildcard `bazel build //...`.
+        build_args: extra flags forwarded verbatim to the nested `bazel build`
+            (e.g. `"--repo_env=SCALA_VERSION=2.13.18"`).
+        worker_sandboxing: if True, pass `--worker_sandboxing` to the nested
+            `bazel build` -- but only on non-Windows, since Bazel worker
+            sandboxing is not implemented on Windows (mirrors the historical
+            guard in test/shell/test_persistent_worker.sh; without it the nested
+            scalac worker fails to start with a missing-JVM error instead of
+            producing the compile failure under test).
+        expect: file labels whose (newline-stripped) contents must appear in the
+            build output. Automatically added to the test's `data`.
+        reject: file labels whose (newline-stripped) contents must NOT appear in
+            the build output. Automatically added to the test's `data`.
+        size: test size; defaults to `"large"` (the nested Bazel invocation is
+            slow and, on a cold cache, serializes on the shared output base).
+        tags: test tags; defaults to `["local", "requires-network"]` because the
+            nested `bazel build` fetches external repos and must run outside the
+            sandbox.
+        **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
+    """
+    _nested_bazel_test(
+        name = name,
+        command = "build",
+        target = target,
+        bazel_args = build_args,
+        expect_success = False,
+        env = {},
+        worker_sandboxing = worker_sandboxing,
+        expect = expect,
+        reject = reject,
+        size = size,
+        tags = tags,
+        **kwargs
+    )
+
+def expect_test_failure_test(
+        name,
+        target,
+        command = "test",
+        bazel_args = [],
+        worker_sandboxing = False,
+        expect = [],
+        reject = [],
+        size = "large",
+        tags = ["local", "requires-network"],
+        **kwargs):
+    """Declares an `sh_test` asserting that `bazel test`/`coverage` of `target` fails.
+
+    Same plumbing as `expect_build_failure_test`, but the nested invocation is
+    `bazel test` (or `bazel coverage`), so the failure being asserted is a test
+    run / coverage failure rather than a build failure.
+
+    Args:
+        name: test target name.
+        target: label whose nested run must fail. A package-relative label
+            (`":foo"` or `"foo"`) is resolved against this package. The caller
+            must tag this fixture `"manual"`: it is expected to fail and would
+            otherwise break a plain wildcard `bazel test //...`.
+        command: the bazel subcommand to run; `"test"` (default) or `"coverage"`.
+        bazel_args: extra flags forwarded verbatim to the nested `bazel <command>`
+            (e.g. `"--extra_toolchains=//some:failing_toolchain"`).
+        worker_sandboxing: see `expect_build_failure_test`.
+        expect: file labels whose (newline-stripped) contents must appear in the
+            output. Automatically added to the test's `data`.
+        reject: file labels whose (newline-stripped) contents must NOT appear in
+            the output. Automatically added to the test's `data`.
+        size: test size; defaults to `"large"`.
+        tags: test tags; defaults to `["local", "requires-network"]`.
+        **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
+    """
+    _nested_bazel_test(
+        name = name,
+        command = command,
+        target = target,
+        bazel_args = bazel_args,
+        expect_success = False,
+        env = {},
+        worker_sandboxing = worker_sandboxing,
+        expect = expect,
+        reject = reject,
+        size = size,
+        tags = tags,
+        **kwargs
+    )
+
+def expect_test_success_test(
+        name,
+        target,
+        bazel_args = [],
+        env = {},
+        worker_sandboxing = False,
+        expect = [],
+        reject = [],
+        size = "large",
+        tags = ["local", "requires-network"],
+        **kwargs):
+    """Declares an `sh_test` asserting that `bazel test` of `target` succeeds.
+
+    Same plumbing as `expect_test_failure_test`, but the nested `bazel test` is
+    expected to pass. Useful for a fixture that only passes under a specific
+    `--test_filter` or with an inherited env var, which this wrapper supplies via
+    `bazel_args`/`env`.
+
+    Args:
+        name: test target name.
+        target: label whose nested `bazel test` must succeed. A package-relative
+            label (`":foo"` or `"foo"`) is resolved against this package. The
+            caller must tag this fixture `"manual"`: it only passes with the
+            flags this wrapper supplies, so a plain wildcard `bazel test //...`
+            would run it without them and fail.
+        bazel_args: extra flags forwarded verbatim to the nested `bazel test`
+            (e.g. `"--test_filter=A"`).
+        env: dict of KEY: VALUE exported into the nested `bazel` client env before
+            the run (e.g. to feed the target's `env_inherit`).
+        worker_sandboxing: see `expect_build_failure_test`.
+        expect: file labels whose (newline-stripped) contents must appear in the
+            output. Automatically added to the test's `data`.
+        reject: file labels whose (newline-stripped) contents must NOT appear in
+            the output. Automatically added to the test's `data`.
+        size: test size; defaults to `"large"`.
+        tags: test tags; defaults to `["local", "requires-network"]`.
+        **kwargs: forwarded to the underlying `sh_test` (e.g. extra `data`).
+    """
+    _nested_bazel_test(
+        name = name,
+        command = "test",
+        target = target,
+        bazel_args = bazel_args,
+        expect_success = True,
+        env = env,
+        worker_sandboxing = worker_sandboxing,
+        expect = expect,
+        reject = reject,
+        size = size,
         tags = tags,
         **kwargs
     )

--- a/test/expect_build_failure/expect_build_failure.sh
+++ b/test/expect_build_failure/expect_build_failure.sh
@@ -1,24 +1,34 @@
 #!/usr/bin/env bash
 #
-# Verifies that `bazel build` of a target fails, and that the combined build
-# output contains every expected message and none of the rejected messages.
+# Runs a nested `bazel <command>` (build/test/coverage) of a target, asserts it
+# fails (or, with --expect-success, succeeds), and that the combined output
+# contains every expected message and none of the rejected messages.
 #
-# The nested `bazel build` (and the rationale for it) lives in the shared
+# The nested `bazel` invocation (and the rationale for it) lives in the shared
 # nested_bazel.sh helper this script sources.
 #
 # Usage:
 #   expect_build_failure.sh --target <label> \
-#       [--build-arg <flag>]... \
+#       [--command <build|test|coverage>] \
+#       [--expect-success] \
+#       [--env <KEY=VALUE>]... \
+#       [--bazel-arg <flag>]... \
 #       [--expect-file <path>]... \
 #       [--reject-file <path>]...
 #
-#   --target       the label to build; the build is expected to fail.
-#   --build-arg    extra option forwarded to the nested `bazel build` (e.g.
-#                  `--repo_env=SCALA_VERSION=2.13.18`); repeatable.
-#   --expect-file  file whose (newline-stripped) contents must appear in the
-#                  build output; repeatable.
-#   --reject-file  file whose (newline-stripped) contents must NOT appear in the
-#                  build output; repeatable.
+#   --target          the label to act on.
+#   --command         the bazel subcommand to run; defaults to `build`.
+#   --expect-success  assert the invocation succeeds; by default it must fail.
+#   --env             KEY=VALUE exported into the nested `bazel` client env before
+#                     the invocation (e.g. to feed a target's `env_inherit`);
+#                     repeatable.
+#   --bazel-arg       extra option forwarded to the nested `bazel <command>` (e.g.
+#                     `--repo_env=SCALA_VERSION=2.13.18` or `--extra_toolchains=...`);
+#                     repeatable.
+#   --expect-file     file whose (newline-stripped) contents must appear in the
+#                     output; repeatable.
+#   --reject-file     file whose (newline-stripped) contents must NOT appear in the
+#                     output; repeatable.
 #
 # Messages are passed as files rather than inline strings because Bazel subjects
 # `sh_test` `args` to Bourne tokenization, which would split messages that
@@ -34,7 +44,9 @@ orig_pwd="${PWD}"
 source "${TEST_SRCDIR:-${RUNFILES_DIR:-$0.runfiles}}/${TEST_WORKSPACE:-_main}/test/expect_build_failure/nested_bazel.sh"
 
 target=""
-build_args=()
+command="build"
+expect_success="false"
+bazel_args=()
 expect_files=()
 reject_files=()
 
@@ -44,8 +56,22 @@ while [[ "$#" -gt 0 ]]; do
       target="$2"
       shift 2
       ;;
-    --build-arg)
-      build_args+=("$2")
+    --command)
+      command="$2"
+      shift 2
+      ;;
+    --expect-success)
+      expect_success="true"
+      shift
+      ;;
+    --env)
+      # Exported here so it reaches the nested `bazel` client (nested_bazel_run
+      # only prepends HOME, preserving the rest of the environment).
+      export "${2?--env requires KEY=VALUE}"
+      shift 2
+      ;;
+    --bazel-arg)
+      bazel_args+=("$2")
       shift 2
       ;;
     --expect-file)
@@ -90,17 +116,27 @@ _resolve_message_file() {
 
 nested_bazel_setup "rules_scala_expect_build_failure_output_base"
 
-output="$(nested_bazel_run build ${build_args[@]+"${build_args[@]}"} "${target}" 2>&1)" && {
-  echo "Expected build of \"${target}\" to fail, but it succeeded." >&2
+set +e
+output="$(nested_bazel_run "${command}" ${bazel_args[@]+"${bazel_args[@]}"} "${target}" 2>&1)"
+status=$?
+set -e
+
+if [[ "${expect_success}" == "true" && "${status}" -ne 0 ]]; then
+  echo "Expected \`bazel ${command}\` of \"${target}\" to succeed, but it failed (exit ${status})." >&2
   echo "${output}" >&2
   exit 1
-}
+fi
+if [[ "${expect_success}" != "true" && "${status}" -eq 0 ]]; then
+  echo "Expected \`bazel ${command}\` of \"${target}\" to fail, but it succeeded." >&2
+  echo "${output}" >&2
+  exit 1
+fi
 
 for expect_file in ${expect_files[@]+"${expect_files[@]}"}; do
   resolved="$(_resolve_message_file "${expect_file}")"
   expected_message="$(tr -d '\n' <"${resolved}")"
   if ! grep --quiet --fixed-strings -- "${expected_message}" <<<"${output}"; then
-    echo "Build failed as expected, but output did not contain the expected message." >&2
+    echo "Nested \`bazel ${command}\` finished as expected, but output did not contain the expected message." >&2
     echo "Expected (from ${expect_file}): ${expected_message}" >&2
     echo "Output:" >&2
     echo "${output}" >&2
@@ -112,7 +148,7 @@ for reject_file in ${reject_files[@]+"${reject_files[@]}"}; do
   resolved="$(_resolve_message_file "${reject_file}")"
   rejected_message="$(tr -d '\n' <"${resolved}")"
   if grep --quiet --fixed-strings -- "${rejected_message}" <<<"${output}"; then
-    echo "Build failed as expected, but output contained a message that should be absent." >&2
+    echo "Nested \`bazel ${command}\` finished as expected, but output contained a message that should be absent." >&2
     echo "Rejected (from ${reject_file}): ${rejected_message}" >&2
     echo "Output:" >&2
     echo "${output}" >&2


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-17

* **PR #1863 (THIS ONE)**:
  `master` ← `refactor/nested-bazel-test-macros`

    * PR #1856:
      `refactor/nested-bazel-test-macros` ← `refactor/test-run-toolchain-failures-as-bazel-test`

      * PR #1857:
        `refactor/test-run-toolchain-failures-as-bazel-test` ← `refactor/junit-rule-failures-as-bazel-test`

        * PR #1858:
          `refactor/junit-rule-failures-as-bazel-test` ← `refactor/specs2-failure-messages-as-bazel-test`

          * PR #1859:
            `refactor/specs2-failure-messages-as-bazel-test` ← `refactor/positive-nested-test-runs-as-bazel-test`

    * PR #1864:
      `refactor/nested-bazel-test-macros` ← `refactor/analysis-build-failures-as-bazel-test`

<!-- end git-machete generated -->

### Description

Pure test-infra change under `test/expect_build_failure/`, with no callers: factors the shared `sh_test` plumbing into a private `_nested_bazel_test` helper, adds the `expect_test_failure_test` and `expect_test_success_test` sibling macros, and generalizes `expect_build_failure.sh` to run any subcommand (`--command`, `--expect-success`, `--env`, `--bazel-arg`). `expect_build_failure_test` keeps its signature, and #1860's code-under-test glob now lives in the shared helper so all three macros inherit sound caching.

### Motivation

These helper additions were previously piggybacked into unrelated test-migration PRs, mixing mechanism with usage. Extracting them here on top of #1860 lets the migration stack rebase onto this branch and shrink to just fixtures + callers.