### PR TITLE
fix: Propagate `tags` from `scala_library_suite` to its aggregate target

### DIFF
--- a/scala/private/rules/scala_library.bzl
+++ b/scala/private/rules/scala_library.bzl
@@ -145,6 +145,10 @@ def scala_library_suite(
         visibility = visibility,
         exports = exports + ts,
         deps = ts,
+        # Forward tags to the aggregate target too (children already get them via
+        # **kwargs), so e.g. `tags = ["manual"]` can keep the whole suite -- which
+        # depends on every child -- out of wildcard builds.
+        tags = kwargs.get("tags", []),
     )
 
 ##


### PR DESCRIPTION
<!-- start git-machete generated -->

## Tree of downstream PRs as of 2026-07-17

* **PR #1865 (THIS ONE)**:
  `master` ← `fix/scala-library-suite-aggregate-tags`

    * PR #1864:
      `fix/scala-library-suite-aggregate-tags` ← `refactor/analysis-build-failures-as-bazel-test`

<!-- end git-machete generated -->

### Description

`scala_library_suite` compiles each source into its own child `scala_library` and defines an aggregate target (of the same `name`) that `deps`/`exports` all the children. The caller's `tags` reached the children (via `**kwargs`) but not the aggregate. This forwards them to the aggregate too.

It's a no-op for callers that pass no `tags` (the aggregate keeps its previous empty tag set); the only observable change is for callers that do pass `tags`.

### Motivation

`manual` only removes a target from wildcard *expansion*, not from being built as a dependency. So an untagged aggregate stayed in `//...` and pulled in every child, which made `tags = ["manual"]` on a suite effectively a no-op — the suite and all its children built under a wildcard anyway. The same applied to `--build_tag_filters` and other tags, which never reached the aggregate. Propagating `tags` makes them behave as a user would expect (and lets a suite be excluded from wildcard builds).