### PR TITLE
refactor: Migrate mismatching-resource-strip-prefix shell test to Bazel

### DIFF
--- a/test/mismatching_resource_strip_prefix/BUILD
+++ b/test/mismatching_resource_strip_prefix/BUILD
@@ -1,0 +1,11 @@
+# Migrated from test/shell/test_scala_library_jar.sh.
+
+load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
+
+package(default_testonly = 1)
+
+expect_build_failure_test(
+    name = "mismatching_resource_strip_prefix",
+    expect = ["expected_mismatching_prefix.txt"],
+    target = "//test_expect_failure/mismatching_resource_strip_prefix:noSrcsJarWithWrongStripPrefix",
+)

--- a/test/mismatching_resource_strip_prefix/BUILD
+++ b/test/mismatching_resource_strip_prefix/BUILD
@@ -1,5 +1,3 @@
-# Migrated from test/shell/test_scala_library_jar.sh.
-
 load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
 
 package(default_testonly = 1)

--- a/test/mismatching_resource_strip_prefix/expected_mismatching_prefix.txt
+++ b/test/mismatching_resource_strip_prefix/expected_mismatching_prefix.txt
@@ -1,0 +1,1 @@
+is not under the specified prefix wrong_prefix to strip

--- a/test/shell/test_scala_library_jar.sh
+++ b/test/shell/test_scala_library_jar.sh
@@ -1,7 +1,6 @@
 # shellcheck source=./test_runner.sh
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_runner.sh
-. "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
 test_resources() {
@@ -21,10 +20,5 @@ scala_library_jar_without_srcs_must_include_filegroup_resources(){
   test_resources "noSrcsWithFilegroupResources"
 }
 
-scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix() {
-  action_should_fail build test_expect_failure/mismatching_resource_strip_prefix:noSrcsJarWithWrongStripPrefix
-}
-
-$runner scala_library_jar_without_srcs_must_fail_on_mismatching_resource_strip_prefix
 $runner scala_library_jar_without_srcs_must_include_direct_file_resources
 $runner scala_library_jar_without_srcs_must_include_filegroup_resources


### PR DESCRIPTION
Replaces the one-line `action_should_fail build` case in test_scala_library_jar.sh
with an expect_build_failure_test, and additionally asserts the strip-prefix error
message (the shell test only checked the build failed at all).