### PR TITLE
refactor: Migrate scala-proto failing-generator test to Bazel

### DIFF
--- a/test/scala_proto_failing_generator/BUILD
+++ b/test/scala_proto_failing_generator/BUILD
@@ -1,0 +1,15 @@
+# Migrated from test/shell/test_scala_proto_library.sh.
+
+load("//test/expect_build_failure:expect_build_failure.bzl", "expect_build_failure_test")
+
+package(default_testonly = 1)
+
+expect_build_failure_test(
+    name = "scala_proto_failing_generator",
+    build_args = [
+        "--extra_toolchains=//test/proto/custom_generator:failing_scala_proto_deps_toolchain",
+        "--extra_toolchains=//test/proto/custom_generator:failing_scala_proto_toolchain",
+    ],
+    expect = ["expected_generator_failure.txt"],
+    target = "//test/proto/custom_generator:any_proto_scala",
+)

--- a/test/scala_proto_failing_generator/expected_generator_failure.txt
+++ b/test/scala_proto_failing_generator/expected_generator_failure.txt
@@ -1,0 +1,1 @@
+java.lang.RuntimeException: expected generator failure

--- a/test/shell/test_scala_proto_library.sh
+++ b/test/shell/test_scala_proto_library.sh
@@ -1,7 +1,6 @@
 # shellcheck source=./test_runner.sh
 dir=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 . "${dir}"/test_runner.sh
-. "${dir}"/test_helper.sh
 runner=$(get_test_runner "${1:-local}")
 
 test_scala_proto_library_action_label() {
@@ -20,14 +19,5 @@ test_scala_proto_custom_generator() {
   --extra_toolchains=//test/proto/custom_generator:scala_proto_toolchain
 }
 
-test_scala_proto_show_generator_exception() {
-  action_should_fail_with_message \
-    "java.lang.RuntimeException: expected generator failure" \
-    build //test/proto/custom_generator:any_proto_scala \
-    --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_deps_toolchain \
-    --extra_toolchains=//test/proto/custom_generator:failing_scala_proto_toolchain
-}
-
 $runner test_scala_proto_library_action_label
 $runner test_scala_proto_custom_generator
-$runner test_scala_proto_show_generator_exception


### PR DESCRIPTION
Replaces the `action_should_fail_with_message` case in test_scala_proto_library.sh
with an expect_build_failure_test that drives the same nested build (with the failing
custom-generator toolchains) and asserts the RuntimeException is surfaced.
