### PR TITLE
ci: Skip downstream consumer tests on the last_green Bazel step

### DIFF
--- a/.bazelci/presubmit.yml
+++ b/.bazelci/presubmit.yml
@@ -80,6 +80,10 @@ tasks:
       # (`env: 'bazel': No such file`). Forward the client PATH into test actions
       # so the nested calls find last_green, as released-Bazel steps already do.
       - echo "test --test_env=PATH" >>.bazelrc
+      # Downstream consumer tests aren't expected to build against an
+      # unreleased Bazel; skip them so a green here means an actual
+      # last_green regression, not third-party noise.
+      - echo "test --test_tag_filters=-no-last-green" >>.bazelrc
       - "./test_rules_scala.sh"
     soft_fail:
       - exit_status: "*"

--- a/test/community_build/downstream_test.bzl
+++ b/test/community_build/downstream_test.bzl
@@ -15,7 +15,7 @@ def downstream_test(
         targets,
         extra_bazel_flags = "",
         size = "large",
-        tags = ["external", "local", "requires-network"],
+        tags = ["external", "local", "requires-network", "no-last-green"],
         **kwargs):
     """Declares an `sh_test` testing `targets` in the `repo_name` external repo.
 
@@ -29,9 +29,9 @@ def downstream_test(
         size: test size; defaults to "large" (nested Bazel invocation, cold
             Maven/git fetch on first run).
         tags: test tags; defaults to
-            `["external", "local", "requires-network"]`. `external`
-            disables test-result caching: the nested build reads this
-            checkout's *live* source tree via `local_path_override`, so
+            `["external", "local", "requires-network", "no-last-green"]`.
+            `external` disables test-result caching: the nested build reads
+            this checkout's *live* source tree via `local_path_override`, so
             rules_scala's sources are code under test without being declared
             inputs of this `sh_test` -- a cached PASS would survive edits to
             them and go stale (the same unsound-caching trap
@@ -40,6 +40,10 @@ def downstream_test(
             a BUILD-file glob's reach). `local` and `requires-network` match
             `expect_build_failure_test`'s rationale -- the nested build
             fetches external repos and must run outside the sandbox.
+            `no-last-green` excludes these from the last_green Bazel CI step
+            (via `--test_tag_filters`): a third-party consumer isn't expected
+            to build against an unreleased Bazel, so failures there are noise,
+            not a rules_scala regression.
         **kwargs: forwarded to the underlying `sh_test`.
     """
     sh_test(


### PR DESCRIPTION
### Description

The `joern_test` and `dicer_test` downstream tests run against last_green Bazel in the `test_rules_scala_linux_last_green` step, via `./test_rules_scala.sh` (which runs `bazel test test/...`). Third-party consumers don't build against an unreleased Bazel, so this step keeps soft-failing on those two. That failing status is just noise, and it also hides a real last_green breakage in anything else.

The fix tags both tests `no-last-green` and drops that tag in the last_green step only, with `--test_tag_filters=-no-last-green` added to `.bazelrc` right after the existing `--test_env=PATH` line (#1861). The released-Bazel steps (`bazel test //...` and the plain `test_rules_scala`) still run them.

The tag is a default inside the `downstream_test` macro, not set on each target. This is true for every downstream consumer, not just these two, so any consumer added later is skipped automatically.

### Motivation

Fixes #1883. After this, a green last_green step means a real last_green regression, not the expected third-party noise.
