### PR TITLE
fix: Fail string_in_filename_in_jar.sh when `jar` cannot read the jar

### DIFF
--- a/test/src/main/scala/scalarules/test/twitter_scrooge/strings/string_in_filename_in_jar.sh
+++ b/test/src/main/scala/scalarules/test/twitter_scrooge/strings/string_in_filename_in_jar.sh
@@ -22,7 +22,15 @@ fi
 
 dir="$(dirname $4)"
 jar_file="$dir/$2"
-jar tf ${jar_file} | grep -q $3
+
+# A jar that could not be read prints an empty listing, which is what a jar
+# missing the name looks like, so a "false" expectation would pass for free.
+if ! jar_listing="$(jar tf "${jar_file}")" ; then
+  echo "ERROR: Could not list ${jar_file}."
+  exit 1
+fi
+
+printf '%s\n' "${jar_listing}" | grep -q $3
 file_is_in_jar=$?
 
 if [ $file_is_in_jar -eq 0 ] ; then


### PR DESCRIPTION
### Description

`string_in_filename_in_jar.sh` piped `jar tf <jar>` into `grep -q` and looked only at the grep exit code. When `jar` itself fails (missing from `PATH`, or the jar file cannot be read) the listing comes out empty, which is indistinguishable from a jar that has no matching name, so `thrift5_not_in_namespace_in_java_jar` passed for the wrong reason and `thrift999_in_namespace_in_java_jar` failed with a misleading "Not found file" message.

The script now captures the listing and exits 1 if `jar` did not succeed. On a machine with no JDK both tests fail with `ERROR: Could not list <jar>`, and with a JDK on `PATH` all 5 tests in `strings/` pass, same as before.

### Motivation

Found while debugging a local failure in this package: a test that stays quiet when its tool never ran reports success it never checked. CI images ship a JDK, so CI behaviour stays the same.
